### PR TITLE
Implement power flow-specific (re)active power limits proxies

### DIFF
--- a/src/psse_export.jl
+++ b/src/psse_export.jl
@@ -714,7 +714,7 @@ function write_to_buffers!(
         # TODO approximate a QT for generators that don't have it set
         # (this is needed to run power flows also)
         reactive_power_limits = with_units_base(
-            () -> PSY.get_reactive_power_limits(generator),
+            () -> get_reactive_power_limits_for_power_flow(generator),
             exporter.system,
             PSY.UnitSystem.NATURAL_UNITS,
         )
@@ -733,12 +733,14 @@ function write_to_buffers!(
         # TODO maybe have a better default here
         active_power_limits =
             with_units_base(
-                () -> PSY.get_active_power_limits(generator),
+                () -> get_active_power_limits_for_power_flow(generator),
                 exporter.system,
                 PSY.UnitSystem.NATURAL_UNITS,
             )
         PT = active_power_limits.max
+        isfinite(PT) || (PT = PSSE_DEFAULT)
         PB = active_power_limits.min
+        isfinite(PB) || (PB = PSSE_DEFAULT)
         WMOD = get(PSY.get_ext(generator), "WMOD", PSSE_DEFAULT)
         WPF = get(PSY.get_ext(generator), "WPF", PSSE_DEFAULT)
 

--- a/test/test_utils/common.jl
+++ b/test/test_utils/common.jl
@@ -8,12 +8,6 @@ powerflow_match_fn(
     isapprox(a, b; atol = POWERFLOW_COMPARISON_TOLERANCE) || IS.isequivalent(a, b)
 powerflow_match_fn(a, b) = IS.isequivalent(a, b)
 
-# TODO temporary hacks, see https://github.com/NREL-Sienna/PowerFlows.jl/issues/39
-PowerSystems.get_reactive_power_limits(::RenewableNonDispatch) = (min = 0.0, max = 0.0)
-PowerSystems.get_active_power_limits(
-    ::Union{RenewableDispatch, RenewableNonDispatch, Source},
-) = (min = 0.0, max = 0.0)
-
 # TODO another temporary hack
 "Create a version of the RTS_GMLC system that plays nice with the current implementation of AC power flow"
 function create_pf_friendly_rts_gmlc()


### PR DESCRIPTION
Fixes https://github.com/NREL-Sienna/PowerFlows.jl/issues/39 by implementing the functions `get_reactive_power_limits_for_power_flow` and `get_active_power_limits_for_power_flow`. In all normal cases, these just redirect to PSY's `get_reactive_power_limits` and `get_active_power_limits`. In a few special cases, each either detailed at https://github.com/NREL-Sienna/PowerFlows.jl/issues/39#issuecomment-2594101291 or already implemented elsewhere in the codebase, they instead return a proxy value to effect the behavior we want.