### PR TITLE
Export Trust Region and Combine Simple/Refinement NR

### DIFF
--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -5,6 +5,7 @@ export solve_powerflow!
 export PowerFlowData
 export DCPowerFlow
 export NewtonRaphsonACPowerFlow
+export TrustRegionACPowerFlow
 export ACPowerFlow
 export ACPowerFlowSolverType
 export PTDFDCPowerFlow

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -9,6 +9,7 @@ const ISAPPROX_ZERO_TOLERANCE = 1e-6
 
 const DEFAULT_NR_MAX_ITER::Int64 = 30   # default maxIterations for the NR power flow
 const DEFAULT_NR_TOL::Float64 = 1e-9 # default tolerance for the NR power flow
+const DEFAULT_REFINEMENT_THRESHOLD = 5e-2 # do refinement if relative error > 5%.
 const DEFAULT_REFINEMENT_MAX_ITER = 10 # how many times to try iterative refinement
 const DEFAULT_REFINEMENT_EPS::Float64 = 1e-6 # when to stop iterative refinement.
 const NR_SINGULAR_SCALING = 1e-6 # scaling factor in fallback method for singular Jacobian

--- a/src/powerflow_method.jl
+++ b/src/powerflow_method.jl
@@ -149,7 +149,7 @@ function _simple_step(time_step::Int,
     J::ACPowerFlowJacobian,
     refinement_threshold::Float64 = DEFAULT_REFINEMENT_THRESHOLD,
     refinement_eps::Float64 = DEFAULT_REFINEMENT_EPS,
-    )
+)
     copyto!(stateVector.r, residual.Rv)
     try
         # factorize the numeric object of KLU inplace, while reusing the symbolic object
@@ -159,9 +159,9 @@ function _simple_step(time_step::Int,
         # use one of the other fields of stateVector as a temporary buffer
         # to work out error on solution: if error is large, try doing refinement.
         δ_temp = stateVector.r_predict
-        copyto!(δ_temp, J.Jv*stateVector.r)
+        copyto!(δ_temp, J.Jv * stateVector.r)
         δ_temp .-= residual.Rv
-        delta = norm(δ_temp, 1)/norm(residual.Rv, 1)
+        delta = norm(δ_temp, 1) / norm(residual.Rv, 1)
         if delta > refinement_threshold
             stateVector.r .= solve_w_refinement(linSolveCache,
                 J.Jv,
@@ -216,8 +216,8 @@ function _run_powerflow_method(time_step::Int,
     maxIterations::Int = get(kwargs, :maxIterations, DEFAULT_NR_MAX_ITER)
     tol::Float64 = get(kwargs, :tol, DEFAULT_NR_TOL)
     refinement_threshold::Float64 = get(kwargs,
-            :refinement_eps,
-            DEFAULT_REFINEMENT_THRESHOLD)
+        :refinement_eps,
+        DEFAULT_REFINEMENT_THRESHOLD)
     refinement_eps::Float64 = get(kwargs, :refinement_eps, DEFAULT_REFINEMENT_EPS)
     i, converged = 0, false
     while i < maxIterations && !converged
@@ -280,7 +280,7 @@ function _newton_powerflow(
     pf::ACPowerFlow{T},
     data::ACPowerFlowData,
     time_step::Int64;
-    kwargs...) where T<:Union{TrustRegionACPowerFlow, NewtonRaphsonACPowerFlow}
+    kwargs...) where {T <: Union{TrustRegionACPowerFlow, NewtonRaphsonACPowerFlow}}
     residual = ACPowerFlowResidual(data, time_step)
     x0 = calculate_x0(data, time_step)
     residual(x0, time_step)
@@ -299,7 +299,15 @@ function _newton_powerflow(
     symbolic_factor!(linSolveCache, J.Jv)
     stateVector = StateVectorCache(x0, residual.Rv)
 
-    converged, i = _run_powerflow_method(time_step, stateVector, linSolveCache, residual, J, T; kwargs...)
+    converged, i = _run_powerflow_method(
+        time_step,
+        stateVector,
+        linSolveCache,
+        residual,
+        J,
+        T;
+        kwargs...,
+    )
     if converged
         @info("The $T solver converged after $i iterations.")
         if data.calculate_loss_factors

--- a/src/powerflow_method.jl
+++ b/src/powerflow_method.jl
@@ -1,19 +1,10 @@
-"""Abstract supertype for all variations of Newton-Raphson."""
-abstract type AbstractNewtonRaphsonMethod end
-"""Basic, no-frills Newton-Raphson."""
-struct SimpleNRMethod <: AbstractNewtonRaphsonMethod end
-"""Use iterative refinement to get better accuracy when solving J(x)*Δx = -f(x)."""
-struct RefinementNRMethod <: AbstractNewtonRaphsonMethod end
-"""Trust region method with a dog leg step."""
-struct TrustRegionNRMethod <: AbstractNewtonRaphsonMethod end
-
 """Cache for non-linear methods
 # Fields
 -`x::Vector{Float64}`: the current state vector. Used for all methods.
 -`r::Vector{Float64}`: the current residual. Used for all methods.
-    For `SimpleNRMethod` and `RefinementNRMethod`, we solve `J_x Δx = r` in-place,
+    For `NewtonRaphsonACPowerFlow`, we solve `J_x Δx = r` in-place,
     so this also stores the step `Δx` at times in those methods.
-The remainder of the fields are only used in the `TrustRegionNRMethod`:
+The remainder of the fields are only used in the `TrustRegionACPowerFlow`:
 -`r_predict::Vector{Float64}`: the predicted residual at `x+Δx_proposed`,
     under a linear approximation: i.e `J_x⋅(x+Δx_proposed)`.
 -`Δx_proposed::Vector{Float64}`: the suggested step `Δx`, selected among `Δx_nr`, 
@@ -42,22 +33,6 @@ function StateVectorCache(x0::Vector{Float64}, f0::Vector{Float64})
     Δx_cauchy = copy(x0)
     Δx_nr = copy(x0)
     return StateVectorCache(x, r, r_predict, Δx_proposed, Δx_cauchy, Δx_nr)
-end
-
-"""Reset all entries in a StateVectorCache to `x0` and `f0`, in preparation
-for re-using the cache for the next iterative method."""
-function resetCache!(
-    stateVector::StateVectorCache,
-    x0::Vector{Float64},
-    f0::Vector{Float64},
-)
-    copyto!(stateVector.x, x0)
-    copyto!(stateVector.r, f0)
-    copyto!(stateVector.r_predict, x0)
-    copyto!(stateVector.Δx_proposed, x0)
-    copyto!(stateVector.Δx_cauchy, x0)
-    copyto!(stateVector.Δx_nr, x0)
-    return
 end
 
 """Sets `Δx_proposed` equal to the `Δx` by which we should update `x`. Decides
@@ -165,27 +140,33 @@ function _trust_region_step(time_step::Int,
     return delta
 end
 
-"""Does a single iteration of either `SimpleNRMethod` or `RefinementNRMethod`,
-based on the value of `refinement::Bool`. Updates the `r` and `x`
+"""Does a single iteration of `NewtonRaphsonACPowerFlow`. Updates the `r` and `x`
  fields of the `stateVector`, and computes the Jacobian at the new `x`."""
 function _simple_step(time_step::Int,
     stateVector::StateVectorCache,
     linSolveCache::KLULinSolveCache{Int32},
     residual::ACPowerFlowResidual,
     J::ACPowerFlowJacobian,
-    refinement::Bool = false,
-    refinement_eps::Float64 = 1e-6)
-    # Note: before solve, the R.Rv has the residuals. After solve, R.Rv has the solution (dx). This is
-    # because the solve! function modifies the input vector in-place.
+    refinement_threshold::Float64 = DEFAULT_REFINEMENT_THRESHOLD,
+    refinement_eps::Float64 = DEFAULT_REFINEMENT_EPS,
+    )
+    copyto!(stateVector.r, residual.Rv)
     try
         # factorize the numeric object of KLU inplace, while reusing the symbolic object
         numeric_refactor!(linSolveCache, J.Jv)
         # solve for Δx in-place
-        if !refinement
-            solve!(linSolveCache, residual.Rv)
-        else
-            residual.Rv .=
-                solve_w_refinement(linSolveCache, J.Jv, residual.Rv, refinement_eps)
+        solve!(linSolveCache, stateVector.r)
+        # use one of the other fields of stateVector as a temporary buffer
+        # to work out error on solution: if error is large, try doing refinement.
+        δ_temp = stateVector.r_predict
+        copyto!(δ_temp, J.Jv*stateVector.r)
+        δ_temp .-= residual.Rv
+        delta = norm(δ_temp, 1)/norm(residual.Rv, 1)
+        if delta > refinement_threshold
+            stateVector.r .= solve_w_refinement(linSolveCache,
+                J.Jv,
+                residual.Rv,
+                refinement_eps)
         end
     catch e
         # TODO cook up a test case where Jacobian is singular.
@@ -198,14 +179,14 @@ function _simple_step(time_step::Int,
             tempCache = KLULinSolveCache(M) # not reused: just want a minimally-allocating
             # KLU factorization. TODO check if this is faster than Julia's default ldiv.
             full_factor!(tempCache, M)
-            solve!(tempCache, residual.Rv)
+            solve!(tempCache, stateVector.r)
         else
             @error("KLU factorization failed: $e")
             return
         end
     end
     # update x
-    stateVector.x .-= residual.Rv
+    stateVector.x .-= stateVector.r
     # update data's fields (the bus angles/voltages) to match x, and update the residual.
     # do this BEFORE updating the Jacobian. The Jacobian computation uses data's fields, not x.
     residual(stateVector.x, time_step)
@@ -214,52 +195,29 @@ function _simple_step(time_step::Int,
     return
 end
 
-"""Runs the full `SimpleNRMethod`.
+"""Runs the full `NewtonRaphsonACPowerFlow`.
 # Keyword arguments:
 - `maxIterations::Int`: maximum iterations. Default: $DEFAULT_NR_MAX_ITER.
-- `tol::Float64`: tolerance. The iterative search ends when `maximum(abs.(residual)) < tol`.
-    Default: $DEFAULT_NR_TOL."""
-function _nr_method(time_step::Int,
-    stateVector::StateVectorCache,
-    linSolveCache::KLULinSolveCache{Int32},
-    residual::ACPowerFlowResidual,
-    J::ACPowerFlowJacobian,
-    ::SimpleNRMethod;
-    kwargs...)
-    maxIterations::Int = get(kwargs, :maxIterations, DEFAULT_NR_MAX_ITER)
-    tol::Float64 = get(kwargs, :tol, DEFAULT_NR_TOL)
-    i, converged = 0, false
-    while i < maxIterations && !converged
-        _simple_step(
-            time_step,
-            stateVector,
-            linSolveCache,
-            residual,
-            J,
-        )
-        converged = norm(residual.Rv, Inf) < tol
-        i += 1
-    end
-    return converged, i
-end
-
-"""Runs the full `RefinementNRMethod`.
-# Keyword arguments:
-- `maxIterations::Int`: maximum iterations. Default: $DEFAULT_NR_MAX_ITER.
-- `tol::Float64`: tolerance. The iterative search ends when `maximum(abs.(residual)) < tol`.
+- `tol::Float64`: tolerance. The iterative search ends when `norm(abs.(residual)) < tol`.
     Default: $DEFAULT_NR_TOL.
+- `refinement_threshold::Float64`: If the solution to `J_x Δx = r` satisfies
+    `norm(J_x Δx - r, 1)/norm(r, 1) > refinement_threshold`, do iterative refinement to
+    improve the accuracy. Default: $DEFAULT_REFINEMENT_THRESHOLD.
 - `refinement_eps::Float64`: run iterative refinement on `J_x Δx = r` until
     `norm(Δx_{i}-Δx_{i+1}, 1)/norm(r,1) < refinement_eps`. Default: 
     $DEFAULT_REFINEMENT_EPS """
-function _nr_method(time_step::Int,
+function _run_powerflow_method(time_step::Int,
     stateVector::StateVectorCache,
     linSolveCache::KLULinSolveCache{Int32},
     residual::ACPowerFlowResidual,
     J::ACPowerFlowJacobian,
-    ::RefinementNRMethod;
+    ::Type{NewtonRaphsonACPowerFlow};
     kwargs...)
     maxIterations::Int = get(kwargs, :maxIterations, DEFAULT_NR_MAX_ITER)
     tol::Float64 = get(kwargs, :tol, DEFAULT_NR_TOL)
+    refinement_threshold::Float64 = get(kwargs,
+            :refinement_eps,
+            DEFAULT_REFINEMENT_THRESHOLD)
     refinement_eps::Float64 = get(kwargs, :refinement_eps, DEFAULT_REFINEMENT_EPS)
     i, converged = 0, false
     while i < maxIterations && !converged
@@ -269,7 +227,7 @@ function _nr_method(time_step::Int,
             linSolveCache,
             residual,
             J,
-            true,
+            refinement_threshold,
             refinement_eps,
         )
         converged = norm(residual.Rv, Inf) < tol
@@ -288,12 +246,12 @@ end
 - `eta::Float64`: improvement threshold. If the observed improvement in our residual
     exceeds `eta` times the predicted improvement, we accept the new `x_i`.
     Default: $DEFAULT_TRUST_REGION_ETA."""
-function _nr_method(time_step::Int,
+function _run_powerflow_method(time_step::Int,
     stateVector::StateVectorCache,
     linSolveCache::KLULinSolveCache{Int32},
     residual::ACPowerFlowResidual,
     J::ACPowerFlowJacobian,
-    ::TrustRegionNRMethod;
+    ::Type{TrustRegionACPowerFlow};
     kwargs...)
     maxIterations::Int = get(kwargs, :maxIterations, DEFAULT_NR_MAX_ITER)
     tol::Float64 = get(kwargs, :tol, DEFAULT_NR_TOL)
@@ -319,10 +277,10 @@ function _nr_method(time_step::Int,
 end
 
 function _newton_powerflow(
-    pf::ACPowerFlow{<:ACPowerFlowSolverType},
+    pf::ACPowerFlow{T},
     data::ACPowerFlowData,
     time_step::Int64;
-    kwargs...)
+    kwargs...) where T<:Union{TrustRegionACPowerFlow, NewtonRaphsonACPowerFlow}
     residual = ACPowerFlowResidual(data, time_step)
     x0 = calculate_x0(data, time_step)
     residual(x0, time_step)
@@ -341,42 +299,15 @@ function _newton_powerflow(
     symbolic_factor!(linSolveCache, J.Jv)
     stateVector = StateVectorCache(x0, residual.Rv)
 
-    for method in [SimpleNRMethod(), RefinementNRMethod(), TrustRegionNRMethod()]
-        converged, i =
-            _nr_method(
-                time_step,
-                stateVector,
-                linSolveCache,
-                residual,
-                J,
-                method;
-                kwargs...,
-            )
-        if converged
-            @info(
-                "The NewtonRaphsonACPowerFlow solver converged after $i iterations with method $method"
-            )
-            if data.calculate_loss_factors
-                calculate_loss_factors(data, J.Jv, time_step)
-            end
-
-            return true
+    converged, i = _run_powerflow_method(time_step, stateVector, linSolveCache, residual, J, T; kwargs...)
+    if converged
+        @info("The $T solver converged after $i iterations.")
+        if data.calculate_loss_factors
+            calculate_loss_factors(data, J.Jv, time_step)
         end
-        @warn("Failed with method $method")
-        # reset back to starting point before trying next method.
-        # Order here (R then J) is important.
-        residual(x0, time_step)
-        J(time_step)
-        resetCache!(stateVector, x0, residual.Rv)
+        return true
     end
-
-    if data.calculate_loss_factors
-        data.loss_factors[:, time_step] .= NaN
-    end
-
-    @error(
-        "Solver NewtonRaphsonACPowerFlow did not converge with any method."
-    )
+    @error("The $T solver failed to converge.")
     return false
 end
 

--- a/src/powerflow_types.jl
+++ b/src/powerflow_types.jl
@@ -2,6 +2,7 @@ abstract type PowerFlowEvaluationModel end
 abstract type ACPowerFlowSolverType end
 
 struct NewtonRaphsonACPowerFlow <: ACPowerFlowSolverType end
+struct TrustRegionACPowerFlow <: ACPowerFlowSolverType end
 
 struct ACPowerFlow{ACSolver <: ACPowerFlowSolverType} <: PowerFlowEvaluationModel
     check_reactive_power_limits::Bool

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,8 +39,9 @@ include("test_utils/penalty_factors_brute_force.jl")
 include("test_utils/legacy_pf.jl")
 
 const AC_SOLVERS_TO_TEST = (
-    LUACPowerFlow,
-    NewtonRaphsonACPowerFlow)
+    # LUACPowerFlow,
+    NewtonRaphsonACPowerFlow,
+    TrustRegionACPowerFlow)
 
 LOG_FILE = "power-flows.log"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,7 @@ include("test_utils/penalty_factors_brute_force.jl")
 include("test_utils/legacy_pf.jl")
 
 const AC_SOLVERS_TO_TEST = (
-    # LUACPowerFlow,
+    LUACPowerFlow,
     NewtonRaphsonACPowerFlow,
     TrustRegionACPowerFlow)
 

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -7,24 +7,21 @@ function run_pf(loads::Vector{Float64}; kwargs...)
         set_active_power!(comp, loads[i])
     end
     return PF.solve_powerflow(
-        ACPowerFlow{PF.NewtonRaphsonACPowerFlow}(),
+        ACPowerFlow{TrustRegionACPowerFlow}(),
         sys2;
-        kwargs,
+        kwargs...
     )
 end
 
 @testset "trust region" begin
-    # found by hand: all methods fail to converge => decrease loads, newton converges => increase loads.
-    # repeat, until find a point where trust region method converges and newton doesn't.
-    # (if these values stop working, could automate the above process via taking midpoint or centroid.)
-    @test_logs (:info, r"converged.*TrustRegionNRMethod") match_mode = :any run_pf(
+    @test_logs (:info, r".*TrustRegionACPowerFlow solver converged") match_mode = :any run_pf(
         [
         35.407000101,
         23.5000028166,
         50.0,
     ])
     # test trust region kwargs.
-    @test_logs (:info, r"converged.*TrustRegionNRMethod") match_mode = :any run_pf(
+    @test_logs (:info, r".*TrustRegionACPowerFlow solver converged") match_mode = :any run_pf(
         [
             35.407000101,
             23.5000028166,

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -1,35 +1,19 @@
-sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
-function run_pf(loads::Vector{Float64}; kwargs...)
-    sys2 = deepcopy(sys)
-    @assert(length(get_components(PSY.PowerLoad, sys2)) == length(loads))
-    for (i, comp) in enumerate(get_components(PSY.PowerLoad, sys2))
-        set_max_active_power!(comp, loads[i])
-        set_active_power!(comp, loads[i])
-    end
-    return PF.solve_powerflow(
-        ACPowerFlow{TrustRegionACPowerFlow}(),
-        sys2;
-        kwargs...
-    )
-end
-
-@testset "trust region" begin
-    @test_logs (:info, r".*TrustRegionACPowerFlow solver converged") match_mode = :any run_pf(
-        [
-        35.407000101,
-        23.5000028166,
-        50.0,
-    ])
+@testset "TrustRegionACPowerFlow" begin
     # test trust region kwargs.
-    @test_logs (:info, r".*TrustRegionACPowerFlow solver converged") match_mode = :any run_pf(
-        [
-            35.407000101,
-            23.5000028166,
-            50.0,
-        ]; maxIterations = 30, eta = 1e-4, factor = 1.0)
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
+    tr_pf = ACPowerFlow{TrustRegionACPowerFlow}()
+    @test_logs (:info, r".*TrustRegionACPowerFlow solver converged"
+        ) match_mode = :any PF.solve_powerflow(tr_pf, sys; eta = 1e-5,
+             tol = 1e-10, factor = 1.1, maxIterations = 50)
     # TODO better tests? i.e. more granularly compare behavior to expected, not just check end result.
     # could check behavior of delta, ie that delta is increased/decreased properly.
 end
 
-# TODO: can I create an input such that newton doesn't converge, but iterative_refinement does?
-# need jacobian to be ill-conditioned...
+@testset "NewtonRaphsonACPowerFlow" begin
+    # test NR kwargs.
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
+    nr_pf = ACPowerFlow{NewtonRaphsonACPowerFlow}()
+    @test_logs (:info, r".*NewtonRaphsonACPowerFlow solver converged"
+        ) match_mode = :any PF.solve_powerflow(nr_pf, sys; maxIterations = 50,
+            tol = 1e-10, refinement_threshold = 0.01, refinement_eps = 1e-7)
+end

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -3,8 +3,8 @@
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
     tr_pf = ACPowerFlow{TrustRegionACPowerFlow}()
     @test_logs (:info, r".*TrustRegionACPowerFlow solver converged"
-        ) match_mode = :any PF.solve_powerflow(tr_pf, sys; eta = 1e-5,
-             tol = 1e-10, factor = 1.1, maxIterations = 50)
+    ) match_mode = :any PF.solve_powerflow(tr_pf, sys; eta = 1e-5,
+        tol = 1e-10, factor = 1.1, maxIterations = 50)
     # TODO better tests? i.e. more granularly compare behavior to expected, not just check end result.
     # could check behavior of delta, ie that delta is increased/decreased properly.
 end
@@ -14,6 +14,6 @@ end
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
     nr_pf = ACPowerFlow{NewtonRaphsonACPowerFlow}()
     @test_logs (:info, r".*NewtonRaphsonACPowerFlow solver converged"
-        ) match_mode = :any PF.solve_powerflow(nr_pf, sys; maxIterations = 50,
-            tol = 1e-10, refinement_threshold = 0.01, refinement_eps = 1e-7)
+    ) match_mode = :any PF.solve_powerflow(nr_pf, sys; maxIterations = 50,
+        tol = 1e-10, refinement_threshold = 0.01, refinement_eps = 1e-7)
 end

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -122,6 +122,7 @@ function _legacy_J(
 end
 
 # legacy NR implementation - here we do not care about allocations, we use this function only for testing purposes
+# FIXME: why can't _ac_powerflow inside solve_ac_powerflow.jl find this???
 function _newton_powerflow(
     pf::ACPowerFlow{LUACPowerFlow},
     data::PowerFlows.ACPowerFlowData,

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -122,16 +122,15 @@ function _legacy_J(
 end
 
 # legacy NR implementation - here we do not care about allocations, we use this function only for testing purposes
-# FIXME: why can't _ac_powerflow inside solve_ac_powerflow.jl find this???
-function _newton_powerflow(
+function PowerFlows._newton_powerflow(
     pf::ACPowerFlow{LUACPowerFlow},
     data::PowerFlows.ACPowerFlowData,
     time_step::Int64;
     kwargs...,
 )
     # Fetch maxIter and tol from kwargs, or use defaults if not provided
-    maxIter = get(kwargs, :maxIter, DEFAULT_NR_MAX_ITER)
-    tol = get(kwargs, :tol, DEFAULT_NR_TOL)
+    maxIter = get(kwargs, :maxIter, PowerFlows.DEFAULT_NR_MAX_ITER)
+    tol = get(kwargs, :tol, PowerFlows.DEFAULT_NR_TOL)
     i = 0
 
     Ybus = data.power_network_matrix.data
@@ -174,7 +173,7 @@ function _newton_powerflow(
     while i < maxIter && !converged
         i += 1
 
-        # using a different factorization that KLU for testing
+        # using a different factorization than KLU for testing
         factor_J = LinearAlgebra.lu(J)
         dx .= factor_J \ F
 
@@ -220,7 +219,7 @@ function _newton_powerflow(
         if data.calculate_loss_factors
             dSbus_dV_ref = collect(real.(hcat(dSbus_dVa[ref, pvpq], dSbus_dVm[ref, pq]))[:])
             J_t = sparse(transpose(J))
-            fact = KLU.klu(J_t)
+            fact = PowerFlows.KLU.klu(J_t)
             lf = fact \ dSbus_dV_ref  # only take the dPref_dP loss factors, ignore dPref_dQ
             data.loss_factors[pvpq, time_step] .= lf[1:npvpq]
             data.loss_factors[ref, time_step] .= 1.0


### PR DESCRIPTION
I made a separate subtype of `ACPowerFlowSolverType` called `TrustRegionACPowerFlow`, for that strategy. I also combined the simple Newton Raphson and the version with iterative refinement into one, `NewtonRaphsonACPowerFlow`. It decides whether to do iterative refinement based off the relative error (a kwarg parameter, default 5%).