### PR TITLE
Trust Region: Singular J's

### DIFF
--- a/src/powerflow_method.jl
+++ b/src/powerflow_method.jl
@@ -96,7 +96,13 @@ function _set_Δx_nr!(stateVector::StateVectorCache,
         end
     else
         _solve_Δx_nr!(stateVector, linSolveCache)
-        _do_refinement!(stateVector, J.Jv, linSolveCache, refinement_threshold, refinement_eps)
+        _do_refinement!(
+            stateVector,
+            J.Jv,
+            linSolveCache,
+            refinement_threshold,
+            refinement_eps,
+        )
         LinearAlgebra.rmul!(stateVector.Δx_nr, -1.0)
     end
     return

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -34,3 +34,14 @@ end
         ) match_mode = :any solve_powerflow!(data)
     end
 end
+
+@testset "singular Jacobian trust region" begin
+    # NewtonRaphsonACPowerFlow fails to converge on this system.
+    pf = ACPowerFlow{TrustRegionACPowerFlow}()
+    sys = build_system(MatpowerTestSystems, "matpower_ACTIVSg10k_sys")
+    data = PowerFlowData(pf, sys)
+    @test_logs (:warn, Regex(".*Jacobian is singular.*")
+    ) match_mode = :any for _ in 1:20
+        solve_powerflow!(data; pf = pf)
+    end
+end

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -37,6 +37,9 @@ end
 
 @testset "singular Jacobian trust region" begin
     # NewtonRaphsonACPowerFlow fails to converge on this system.
+    # Empirically found: this system happens to have singular J's right next to the solution,
+    # and if we call solve_powerflow! repeatedly, TrustRegion happens to pick such a point.
+    # (May break if trust region is changed. TODO eventually: find a better test case.)
     pf = ACPowerFlow{TrustRegionACPowerFlow}()
     sys = build_system(MatpowerTestSystems, "matpower_ACTIVSg10k_sys")
     data = PowerFlowData(pf, sys)


### PR DESCRIPTION
I implemented a fallback for singular J's for the trust region and made a single helper function `_set_Δx_nr!` that calculates the Newton-Raphson step for both methods. Also, now the `Δx_nr` field is used to store the Newton-Raphson step in both methods.