### PR TITLE
Pre-allocate coordinate arrays for J

### DIFF
--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -249,6 +249,11 @@ function _create_jacobian_matrix_structure(data::ACPowerFlowData, time_step::Int
 
     num_buses = first(size(data.bus_type))
 
+    numlines = length(get_branch_lookup(data))
+    sizehint!(rows, 4*numlines)
+    sizehint!(columns, 4*numlines)
+    sizehint!(values, 4*numlines)
+
     for bus_from in 1:num_buses
         row_from_p = 2 * bus_from - 1  # Row index for the value that is related to active power
         row_from_q = 2 * bus_from      # Row index for the value that is related to reactive power

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -250,9 +250,9 @@ function _create_jacobian_matrix_structure(data::ACPowerFlowData, time_step::Int
     num_buses = first(size(data.bus_type))
 
     numlines = length(get_branch_lookup(data))
-    sizehint!(rows, 4*numlines)
-    sizehint!(columns, 4*numlines)
-    sizehint!(values, 4*numlines)
+    sizehint!(rows, 4 * numlines)
+    sizehint!(columns, 4 * numlines)
+    sizehint!(values, 4 * numlines)
 
     for bus_from in 1:num_buses
         row_from_p = 2 * bus_from - 1  # Row index for the value that is related to active power


### PR DESCRIPTION
Quick performance fix: use `sizehint!` when allocating arrays for sparse structure of J.