### PR TITLE
Add tests for new psy 5 components

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -75,7 +75,11 @@ function _get_withdrawals!(
     bus_lookup::Dict{Int, Int},
     sys::PSY.System,
 )
-    loads = PSY.get_components(x -> !isa(x, PSY.FixedAdmittance), PSY.ElectricLoad, sys)
+    loads = PSY.get_components(
+        x -> !isa(x, PSY.FixedAdmittance) && !isa(x, PSY.SwitchedAdmittance),
+        PSY.ElectricLoad,
+        sys,
+    )
     for l in loads
         !PSY.get_available(l) && continue
         bus = PSY.get_bus(l)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,7 @@ const DISABLED_TEST_FILES = [  # Can generate with ls -1 test | grep "test_.*.jl
 # "test_powerflow_data.jl",
 # "test_psse_export.jl",
 # "test_solve_powerflow.jl",
+# "test_new_components.jl",
 ]
 
 LOG_LEVELS = Dict(

--- a/test/test_new_components.jl
+++ b/test/test_new_components.jl
@@ -1,0 +1,23 @@
+# FIXME this test fails. The interface for some of these objects has changed.
+@testset "new psy 5 components" begin
+    # TODO are there other components that should be included here?
+    componentToSys = Dict{Type, Tuple{Type, String}}(
+        TapTransformer => (MatpowerTestSystems, "matpower_case2_sys"),
+        TModelHVDCLine => (PSISystems, "sys10_pjm_ac_dc"),
+        TwoTerminalVSCLine => (PSSEParsingTestSystems, "pti_vsc_hvdc_test_sys"),
+        SwitchedAdmittance => (PSSEParsingTestSystems, "pti_case24_sys"),
+        TwoTerminalLCCLine => (PSSEParsingTestSystems, "pti_two_terminal_hvdc_test_sys"),
+        DiscreteControlledACBranch => (PSSEParsingTestSystems, "pti_modified_case14_sys"),
+        TwoTerminalGenericHVDCLine => (PSITestSystems, "c_sys5_dc"),
+        Transformer2W => (PSIDSystems, "psid_4bus_multigen"),
+        Transformer3W => (PSSEParsingTestSystems, "pti_frankenstein_20_sys"),
+        FACTSControlDevice => (PSSEParsingTestSystems, "pti_frankenstein_70_sys"),
+        PhaseShiftingTransformer => (PSSEParsingTestSystems, "pti_two_winding_mag_test_sys")
+    )
+    for (component, sysInfo) in componentToSys
+        sys = build_system(sysInfo...)
+        pf = ACPowerFlow()
+        data = PowerFlowData(pf, sys)
+        @test solve_powerflow(pf, sys)
+    end
+end

--- a/test/test_new_components.jl
+++ b/test/test_new_components.jl
@@ -6,13 +6,16 @@
         TModelHVDCLine => (PSISystems, "sys10_pjm_ac_dc"),
         TwoTerminalVSCLine => (PSSEParsingTestSystems, "pti_vsc_hvdc_test_sys"),
         SwitchedAdmittance => (PSSEParsingTestSystems, "pti_case24_sys"),
-        TwoTerminalLCCLine => (PSSEParsingTestSystems, "pti_two_terminal_hvdc_test_sys"),
-        DiscreteControlledACBranch => (PSSEParsingTestSystems, "pti_modified_case14_sys"),
+        TwoTerminalLCCLine =>
+            (PSSEParsingTestSystems, "pti_two_terminal_hvdc_test_sys"),
+        DiscreteControlledACBranch =>
+            (PSSEParsingTestSystems, "pti_modified_case14_sys"),
         TwoTerminalGenericHVDCLine => (PSITestSystems, "c_sys5_dc"),
         Transformer2W => (PSIDSystems, "psid_4bus_multigen"),
         Transformer3W => (PSSEParsingTestSystems, "pti_frankenstein_20_sys"),
         FACTSControlDevice => (PSSEParsingTestSystems, "pti_frankenstein_70_sys"),
-        PhaseShiftingTransformer => (PSSEParsingTestSystems, "pti_two_winding_mag_test_sys")
+        PhaseShiftingTransformer =>
+            (PSSEParsingTestSystems, "pti_two_winding_mag_test_sys"),
     )
     for (component, sysInfo) in componentToSys
         sys = build_system(sysInfo...)

--- a/test/test_solve_powerflow.jl
+++ b/test/test_solve_powerflow.jl
@@ -761,6 +761,7 @@ end
     )
 end
 
+# FIXME this test fails.
 @testset "AC PF DS with several REF buses" for ACSolver in (
     NewtonRaphsonACPowerFlow,
     TrustRegionACPowerFlow,


### PR DESCRIPTION
For each component that's new or changed significantly, run a powerflow on a system that contains said component.