### PR TITLE
Throw an error for wrong bus type

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -58,7 +58,12 @@ function _get_injections!(
     bus_lookup::Dict{Int, Int},
     sys::PSY.System,
 )
-    sources = PSY.get_components(d -> !isa(d, PSY.ElectricLoad), PSY.StaticInjection, sys)
+    # PSS/E counts buses with switched shunts as voltage-controlled, PV, so we do the same.
+    sources = PSY.get_components(
+        d -> !isa(d, PSY.ElectricLoad) || isa(d, PSY.SwitchedAdmittance),
+        PSY.StaticInjection,
+        sys,
+    )
     has_generator = falses(length(bus_lookup))
     for source in sources
         !PSY.get_available(source) && continue

--- a/src/common.jl
+++ b/src/common.jl
@@ -79,7 +79,8 @@ function _get_injections!(
     # Throw an error if there's a PV/REF bus without an available source.
     for bus in PSY.get_components(PSY.ACBus, sys)
         bus_ix = bus_lookup[PSY.get_number(bus)]
-        if PSY.get_bustype(bus) != PSY.ACBusTypes.PQ && !has_generator[bus_ix]
+        if PSY.get_bustype(bus) in [PSY.ACBusTypes.PV, PSY.ACBusTypes.REF] &&
+           !has_generator[bus_ix]
             throw(
                 ArgumentError(
                     "No available generator at bus $(PSY.get_name(bus)) with number $(PSY.get_number(bus))." *

--- a/test/test_powerflow_data.jl
+++ b/test/test_powerflow_data.jl
@@ -70,13 +70,14 @@ function set_availability_at_bus(
     bus::PSY.ACBus,
     availability::Bool,
 )
-    for source in
-        PSY.get_components(d -> !isa(d, PSY.ElectricLoad), PSY.StaticInjection, sys)
-        if get_number(get_bus(source)) == get_number(bus)
-            set_available!(source, availability)
-        end
-    end
-    return nothing
+    set_available!.(
+        PSY.get_components(
+            d -> !isa(d, PSY.ElectricLoad) && get_number(get_bus(d)) == get_number(bus),
+            PSY.StaticInjection,
+            sys,
+        ),
+        (availability,),
+    )
 end
 
 @testset "Wrong bus type" begin


### PR DESCRIPTION
Downstream effect of [PR 1398](https://github.com/NREL-Sienna/PowerSystems.jl/pull/1398) in PSY: since we're no longer correcting "wrong bus type" inputs in the parser in PSY (and instead logging an error message), we need to check the bus types here in PF and throw a hard error if they're wrong.