### PR TITLE
UI rework

### DIFF
--- a/docs/src/reference/developers/power_flow.md
+++ b/docs/src/reference/developers/power_flow.md
@@ -42,7 +42,7 @@ Solving the power flow with mode 1:
 
 ````@example generated_power_flow
 pf = ACPowerFlow()
-results = solve_powerflow(pf, system_data)
+results = solve_power_flow(system_data, pf)
 results["bus_results"]
 ````
 
@@ -57,11 +57,11 @@ for b in get_components(Bus, system_data)
 end
 ````
 
-[`solve_powerflow!`](@ref) return true or false to signal the successful result of the power
+[`solve_power_flow!`](@ref) return true or false to signal the successful result of the power
 flow. This enables the integration of a power flow into functions and use the return as check.
 
 ````@example generated_power_flow
-solve_powerflow!(pf, system_data; method = :newton)
+solve_power_flow!(system_data, pf; method = :newton)
 ````
 
 After running the power flow command this are the values of the

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -1,7 +1,7 @@
 module PowerFlows
 
-export solve_powerflow
-export solve_powerflow!
+export solve_power_flow
+export solve_power_flow!
 export PowerFlowData
 export DCPowerFlow
 export NewtonRaphsonACPowerFlow

--- a/src/powerflow_method.jl
+++ b/src/powerflow_method.jl
@@ -306,7 +306,7 @@ function _run_powerflow_method(time_step::Int,
 )
     maxIterations::Int = solver.max_iterations
     tol::Float64 = solver.tolerance
-    factor::Float64 = solver.factor
+    factor::Float64 = solver.trust_region_factor
     eta::Float64 = solver.eta
     refinement_threshold::Float64 = solver.refinement_threshold
     refinement_eps::Float64 = solver.refinement_epsilon
@@ -362,7 +362,7 @@ function _newton_powerflow(
         linSolveCache,
         residual,
         J,
-        solver
+        solver,
     )
     if converged
         @info("The $T solver converged after $i iterations.")

--- a/src/powerflow_types.jl
+++ b/src/powerflow_types.jl
@@ -11,8 +11,8 @@ abstract type ACPowerFlowSolverType end
 end
 
 @kwdef struct TrustRegionACPowerFlow <: ACPowerFlowSolverType
-    max_iterations::Int = DEFAULT_MAX_ITER
-    tolerance::Float64 = DEFAULT_TOL
+    max_iterations::Int = DEFAULT_NR_MAX_ITER
+    tolerance::Float64 = DEFAULT_NR_TOL
     refinement_threshold::Float64 = DEFAULT_REFINEMENT_THRESHOLD
     refinement_epsilon::Float64 = DEFAULT_REFINEMENT_EPS
     eta::Float64 = DEFAULT_TRUST_REGION_ETA
@@ -43,7 +43,7 @@ ACPowerFlow(
         Vector{Dict{Tuple{DataType, String}, Float64}},
     } = nothing,
 ) where {ACSolver <: ACPowerFlowSolverType} =
-    ACPowerFlow{ACPowerFlowSolverType}(
+    ACPowerFlow{ACSolver}(
         solver,
         check_reactive_power_limits,
         exporter,
@@ -52,7 +52,7 @@ ACPowerFlow(
     )
 
 # only type of solver provided: construct instance with default parameters. 
-ACPowerFlow{ACSolver}(; kwargs...) where {ACSolver <: ACPowerFlowSolverType}=
+ACPowerFlow{ACSolver}(; kwargs...) where {ACSolver <: ACPowerFlowSolverType} =
     ACPowerFlow(ACSolver(); kwargs...)
 
 # nothing specified: construct with default NR solver and default parameters.
@@ -83,6 +83,8 @@ PSSEExportPowerFlow(psse_version::Symbol, export_dir::AbstractString; kwargs...)
 
 get_exporter(pfem::PowerFlowEvaluationModel) = pfem.exporter
 get_exporter(::PSSEExportPowerFlow) = nothing
+
+get_solver(pfem::ACPowerFlow) = pfem.solver
 
 """
 Expand a single `PowerFlowEvaluationModel` into its possibly multiple parts for separate

--- a/src/psse_export.jl
+++ b/src/psse_export.jl
@@ -1180,4 +1180,4 @@ make_power_flow_container(pfem::PSSEExportPowerFlow, sys::PSY.System; kwargs...)
         step = (0, 0),
     )
 
-solve_powerflow!(exporter::PSSEExporter) = write_export(exporter)
+solve_power_flow!(exporter::PSSEExporter) = write_export(exporter)

--- a/src/solve_ac_powerflow.jl
+++ b/src/solve_ac_powerflow.jl
@@ -1,5 +1,5 @@
 """
-    solve_powerflow!(system::PSY.System, ac_pf::ACPowerFlow{<:ACPowerFlowSolverType}; kwargs...)
+    solve_power_flow!(system::PSY.System, ac_pf::ACPowerFlow{<:ACPowerFlowSolverType}; kwargs...)
 
 Solves the power flow in the system and writes the solution into the relevant structs.
 Updates active and reactive power setpoints for generators and active and reactive
@@ -23,13 +23,13 @@ The bus types can be changed from PV to PQ if the reactive power limits are viol
 # Examples
 
 ```julia
-solve_powerflow!(sys, ac_pf)
+solve_power_flow!(sys, ac_pf)
 
 # Passing kwargs
-solve_powerflow!(sys, ac_pf; check_connectivity=false)
+solve_power_flow!(sys, ac_pf; check_connectivity=false)
 ```
 """
-function solve_powerflow!(
+function solve_power_flow!(
     system::PSY.System,
     ac_pf::ACPowerFlow{<:ACPowerFlowSolverType};
     kwargs...,
@@ -51,7 +51,7 @@ function solve_powerflow!(
             write_powerflow_solution!(
                 system,
                 data,
-                DEFAULT_MAX_ITER, # could add "number of retries for reactive power limits"
+                DEFAULT_NR_MAX_ITER, # could add "number of retries for reactive power limits"
                 # as another kwarg.
             )
             @info("PowerFlow solve converged, the results have been stored in the system")
@@ -64,18 +64,19 @@ function solve_powerflow!(
 end
 
 """
-Similar to solve_powerflow!(sys, ac_pf) but does not update the system struct with results.
+Similar to solve_power_flow!(sys, ac_pf) but does not update the system struct with results.
 Returns the results in a dictionary of dataframes.
 
 ## Examples
 
 ```julia
-res = solve_powerflow(sys, ac_pf)
+res = solve_power_flow(sys, ac_pf)
 ```
 """
-function solve_powerflow(
+function solve_power_flow(
     system::PSY.System,
-    ac_pf::ACPowerFlow{<:ACPowerFlowSolverType},
+    ac_pf::ACPowerFlow{<:ACPowerFlowSolverType};
+    kwargs...,
 )
     # df_results must be defined in the outer scope first to be visible for return
     df_results = Dict{String, DataFrames.DataFrame}()
@@ -104,7 +105,7 @@ function solve_powerflow(
 end
 
 """
-    solve_powerflow!(data::ACPowerFlowData, ac_pf::ACPowerFlow{<:ACPowerFlowSolverType})
+    solve_power_flow_data!(data::ACPowerFlowData, ac_pf::ACPowerFlow{<:ACPowerFlowSolverType})
 
 Solve the multiperiod AC power flow problem for the given power flow data.
 
@@ -133,17 +134,18 @@ It preallocates memory for the results and iterates over the sorted time steps.
 
 # Examples
 ```julia
-solve_powerflow!(data)
+solve_power_flow_data!(data, ACPowerFlow())
 ```
 """
-function solve_powerflow!(
+function solve_power_flow_data!(
     data::ACPowerFlowData,
-    ac_pf::ACPowerFlow{<:ACPowerFlowSolverType},
+    ac_pf::ACPowerFlow{<:ACPowerFlowSolverType};
+    kwargs...,
 )
     # why do we need to specify time steps in 2 places like this?
     # sorted_time_steps = get(kwargs, :time_steps, sort(collect(keys(data.timestep_map))))
     sorted_time_steps = sort(collect(keys(data.timestep_map)))
-    
+
     # preallocate results
     ts_converged = fill(false, length(sorted_time_steps))
 

--- a/src/solve_dc_powerflow.jl
+++ b/src/solve_dc_powerflow.jl
@@ -41,7 +41,7 @@ Evaluates the power flows on each system's branch and updates the PowerFlowData 
 - `data::PTDFPowerFlowData`:
         PTDFPowerFlowData structure containing all the information related to the system's power flow.
 """
-function solve_powerflow!(
+function solve_power_flow_data!(
     data::PTDFPowerFlowData,
 )
     solver_cache = KLULinSolveCache(data.aux_network_matrix.data)
@@ -67,7 +67,7 @@ Evaluates the power flows on each system's branch and updates the PowerFlowData 
 - `data::vPTDFPowerFlowData`:
         vPTDFPowerFlowData structure containing all the information related to the system's power flow.
 """
-function solve_powerflow!(
+function solve_power_flow_data!(
     data::vPTDFPowerFlowData,
 )
     solver_cache = KLULinSolveCache(data.aux_network_matrix.data)
@@ -93,7 +93,7 @@ Evaluates the power flows on each system's branch and updates the PowerFlowData 
         ABAPowerFlowData structure containing all the information related to the system's power flow.
 """
 # DC flow: ABA and BA case
-function solve_powerflow!(
+function solve_power_flow_data!(
     data::ABAPowerFlowData,
 )
     solver_cache = KLULinSolveCache(data.power_network_matrix.data)
@@ -120,20 +120,20 @@ The DataFrame containts the flows and angles related to the information stored
 in the PSY.System considered as input.
 
 # Arguments:
-- `::PTDFDCPowerFlow`:
-        use PTDFDCPowerFlow() to evaluate the power flows according to the
-        method based on the PTDF matrix
 - `sys::PSY.System`:
         container gathering the system data used for the evaluation of flows
         and angles.
+- `::PTDFDCPowerFlow`:
+        use PTDFDCPowerFlow() to evaluate the power flows according to the
+        method based on the PTDF matrix
 """
-function solve_powerflow(
-    ::PTDFDCPowerFlow,
-    sys::PSY.System;
+function solve_power_flow(
+    sys::PSY.System,
+    ::PTDFDCPowerFlow;
     correct_bustypes = false,
 )
     data = PowerFlowData(PTDFDCPowerFlow(), sys; correct_bustypes = correct_bustypes)
-    solve_powerflow!(data)
+    solve_power_flow_data!(data)
     return write_results(data, sys)
 end
 
@@ -146,20 +146,20 @@ The DataFrame containts the flows and angles related to the information stored
 in the PSY.System considered as input.
 
 # Arguments:
-- `::DCPowerFlow`:
-        use DCPowerFlow() to evaluate the power flows according to the method
-        based on the ABA and BA matrices
 - `sys::PSY.System`:
         container gathering the system data used for the evaluation of flows
         and angles.
+- `::DCPowerFlow`:
+        use DCPowerFlow() to evaluate the power flows according to the method
+        based on the ABA and BA matrices
 """
-function solve_powerflow(
-    ::DCPowerFlow,
-    sys::PSY.System;
+function solve_power_flow(
+    sys::PSY.System,
+    ::DCPowerFlow;
     correct_bustypes = false,
 )
     data = PowerFlowData(DCPowerFlow(), sys; correct_bustypes = correct_bustypes)
-    solve_powerflow!(data)
+    solve_power_flow_data!(data)
     return write_results(data, sys)
 end
 
@@ -172,20 +172,20 @@ The DataFrame containts the flows and angles related to the information stored
 in the PSY.System considered as input.
 
 # Arguments:
-- `::vPTDFDCPowerFlow`:
-        use vPTDFDCPowerFlow() to evaluate the power flows according to the
-        method based on the Virtual PTDF matrix
 - `sys::PSY.System`:
         container gathering the system data used for the evaluation of flows
         and angles.
+- `::vPTDFDCPowerFlow`:
+        use vPTDFDCPowerFlow() to evaluate the power flows according to the
+        method based on the Virtual PTDF matrix
 """
-function solve_powerflow(
-    ::vPTDFDCPowerFlow,
-    sys::PSY.System;
+function solve_power_flow(
+    sys::PSY.System,
+    ::vPTDFDCPowerFlow;
     correct_bustypes = false,
 )
     data = PowerFlowData(vPTDFDCPowerFlow(), sys; correct_bustypes = correct_bustypes)
-    solve_powerflow!(data)
+    solve_power_flow_data!(data)
     return write_results(data, sys)
 end
 
@@ -204,11 +204,11 @@ Each DataFrame containts the flows and angles.
 - `sys::PSY.System`:
         container gathering the system data.
 """
-function solve_powerflow(
+function solve_power_flow_data(
     data::PTDFPowerFlowData,
     sys::PSY.System;
 )
-    solve_powerflow!(data)
+    solve_power_flow_data!(data)
     return write_results(data, sys)
 end
 
@@ -226,11 +226,11 @@ Each DataFrame containts the flows and angles.
 - `sys::PSY.System`:
         container gathering the system data.
 """
-function solve_powerflow(
+function solve_power_flow_data(
     data::ABAPowerFlowData,
     sys::PSY.System;
 )
-    solve_powerflow!(data)
+    solve_power_flow_data!(data)
     return write_results(data, sys)
 end
 
@@ -248,10 +248,10 @@ Each DataFrame containts the flows and angles.
 - `sys::PSY.System`:
         container gathering the system data.
 """
-function solve_powerflow(
+function solve_power_flow_data(
     data::vPTDFPowerFlowData,
     sys::PSY.System;
 )
-    solve_powerflow!(data)
+    solve_power_flow_data!(data)
     return write_results(data, sys)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ const DISABLED_TEST_FILES = [  # Can generate with ls -1 test | grep "test_.*.jl
 # "test_multiperiod_dc_powerflow.jl",
 # "test_powerflow_data.jl",
 # "test_psse_export.jl",
-# "test_solve_powerflow.jl",
+# "test_solve_power_flow.jl",
 ]
 
 LOG_LEVELS = Dict(

--- a/test/test_dc_powerflow.jl
+++ b/test/test_dc_powerflow.jl
@@ -26,7 +26,7 @@
     ref_flow_values = transpose(aux_network_matrix.data) * ref_bus_angles
 
     # CASE 1: ABA and BA matrices
-    solved_data_ABA = solve_powerflow(DCPowerFlow(), sys; correct_bustypes = true)
+    solved_data_ABA = solve_power_flow(sys, DCPowerFlow(); correct_bustypes = true)
     @test isapprox(
         solved_data_ABA["1"]["flow_results"].P_from_to,
         ref_flow_values,
@@ -40,7 +40,7 @@
     @test isapprox(solved_data_ABA["1"]["bus_results"].θ, ref_bus_angles, atol = 1e-6)
 
     # CASE 2: PTDF and ABA MATRICES
-    solved_data_PTDF = solve_powerflow(PTDFDCPowerFlow(), sys; correct_bustypes = true)
+    solved_data_PTDF = solve_power_flow(PTDFDCPowerFlow(), sys; correct_bustypes = true)
     @test isapprox(
         solved_data_PTDF["1"]["flow_results"].P_from_to,
         ref_flow_values,
@@ -54,7 +54,7 @@
     @test isapprox(solved_data_PTDF["1"]["bus_results"].θ, ref_bus_angles, atol = 1e-6)
 
     # CASE 3: VirtualPTDF and ABA MATRICES
-    solved_data_vPTDF = solve_powerflow(vPTDFDCPowerFlow(), sys; correct_bustypes = true)
+    solved_data_vPTDF = solve_power_flow(vPTDFDCPowerFlow(), sys; correct_bustypes = true)
     @test isapprox(
         solved_data_vPTDF["1"]["flow_results"].P_from_to,
         ref_flow_values,

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -1,19 +1,27 @@
 @testset "NewtonRaphsonACPowerFlow" begin
     # test NR kwargs.
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
-    nr_pf = ACPowerFlow{NewtonRaphsonACPowerFlow}()
+    nr_solver = NewtonRaphsonACPowerFlow(;
+        max_iterations = 50,
+        tolerance = 1e-10,
+    )
+    nr_pf = ACPowerFlow(nr_solver; check_reactive_power_limits = true)
     @test_logs (:info, r".*NewtonRaphsonACPowerFlow solver converged"
-    ) match_mode = :any PF.solve_powerflow(nr_pf, sys; maxIterations = 50,
-        tol = 1e-10, refinement_threshold = 0.01, refinement_eps = 1e-7)
+    ) match_mode = :any PF.solve_power_flow(sys, nr_pf)
 end
 
 @testset "TrustRegionACPowerFlow" begin
     # test trust region kwargs.
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
-    tr_pf = ACPowerFlow{TrustRegionACPowerFlow}()
+    tr_solver = TrustRegionACPowerFlow(;
+        max_iterations = 50,
+        tolerance = 1e-10,
+        eta = 1e-5,
+        trust_region_factor = 1.1,
+    )
+    tr_pf = ACPowerFlow(tr_solver)
     @test_logs (:info, r".*TrustRegionACPowerFlow solver converged"
-    ) match_mode = :any PF.solve_powerflow(tr_pf, sys; eta = 1e-5,
-        tol = 1e-10, factor = 1.1, maxIterations = 50)
+    ) match_mode = :any PF.solve_power_flow(sys, tr_pf)
     # TODO better tests? i.e. more granularly compare behavior to expected, not just check end result.
     # could check behavior of delta, ie that delta is increased/decreased properly.
 end
@@ -22,16 +30,17 @@ end
     # a system where bus numbers aren't 1, 2,...is there a smaller one with this property?
     sys = PSB.build_system(PSB.PSISystems, "RTS_GMLC_DA_sys")
     for i in [1, 35, 52, 57, 43, 66, 49, 68, 71, 25, 69, 58, 3, 73]
-        data = PowerFlowData(ACPowerFlow(), sys; correct_bustypes = true)
+        pf = ACPowerFlow()
+        data = PowerFlowData(pf, sys; correct_bustypes = true)
         # First, write solution to data. Then set magnitude of a random-ish bus to a huge number
         # and try to solve again: the "large residual warning" should be about that bus.
-        solve_powerflow!(data)
+        PF.solve_power_flow_data!(data, pf)
         bus = collect(PSY.get_components(PSY.ACBus, sys))[i]
         bus_no = bus.number
         bus_ix = PowerFlows.get_bus_lookup(data)[bus_no]
         data.bus_magnitude[bus_ix] = 100.0
         @test_logs (:warn, Regex(".*Largest residual at bus $(bus_no).*")
-        ) match_mode = :any solve_powerflow!(data)
+        ) match_mode = :any PF.solve_power_flow_data!(data, pf)
     end
 end
 
@@ -39,14 +48,14 @@ end
 @testset "singular Jacobian trust region" begin
     # NewtonRaphsonACPowerFlow fails to converge on this system.
     # Empirically found: this system happens to have singular J's right next to the solution,
-    # and if we call solve_powerflow! repeatedly, TrustRegion happens to pick such a point.
+    # and if we call solve_power_flow_data! repeatedly, TrustRegion happens to pick such a point.
     # (May break if trust region is changed. TODO eventually: find a better test case.)
     pf = ACPowerFlow{TrustRegionACPowerFlow}()
     sys = build_system(MatpowerTestSystems, "matpower_ACTIVSg10k_sys")
     data = PowerFlowData(pf, sys, correct_bustypes = true)
     @test_logs (:warn, Regex(".*Jacobian is singular.*")
     ) match_mode = :any for _ in 1:20
-        solve_powerflow!(data; pf = pf)
+        solve_power_flow_data!(data, pf)
     end
 end
 =#

--- a/test/test_multiperiod_ac_powerflow.jl
+++ b/test/test_multiperiod_ac_powerflow.jl
@@ -24,7 +24,7 @@ end
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
 
     # create structure for multi-period case
-    pf = ACPowerFlow(ACSolver)
+    pf = ACPowerFlow(ACSolver())
     time_steps = 24
     data = PowerFlowData(pf, sys; time_steps = time_steps)
 
@@ -32,11 +32,11 @@ end
     prepare_ts_data!(data, time_steps)
 
     # get power flows with NR KLU method and write results
-    solve_powerflow!(data; pf = pf)
+    PF.solve_power_flow_data!(data, pf)
 
     # check results
     # for t in 1:length(data.timestep_map)
-    #     res_t = solve_powerflow(pf, sys, t)  # does not work - ts data not set in sys
+    #     res_t = solve_power_flow(pf, sys, t)  # does not work - ts data not set in sys
     #     flow_ft = res_t["flow_results"].P_from_to
     #     flow_tf = res_t["flow_results"].P_to_from
     #     ts_flow_ft = results[data.timestep_map[t]]["flow_results"].P_from_to
@@ -51,8 +51,8 @@ end
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
 
     # create structure for multi-period case
-    pf_lu = ACPowerFlow(LUACPowerFlow)
-    pf_test = ACPowerFlow(NewtonRaphsonACPowerFlow)
+    pf_lu = ACPowerFlow(LUACPowerFlow())
+    pf_test = ACPowerFlow(NewtonRaphsonACPowerFlow())
 
     time_steps = 24
     data_lu = PowerFlowData(pf_lu, sys; time_steps = time_steps)
@@ -63,8 +63,8 @@ end
     prepare_ts_data!(data_test, time_steps)
 
     # get power flows with NR KLU method and write results
-    solve_powerflow!(data_lu; pf = pf_lu)
-    solve_powerflow!(data_test; pf = pf_test)
+    PF.solve_power_flow_data!(data_lu, pf_lu)
+    PF.solve_power_flow_data!(data_test, pf_test)
 
     # check results
     @test isapprox(data_lu.bus_magnitude, data_test.bus_magnitude, atol = 1e-9)
@@ -94,8 +94,8 @@ end
 @testset "test_loss_factors_case_14" for ACSolver in AC_SOLVERS_TO_TEST
     sys = build_system(PSITestSystems, "c_sys14"; add_forecasts = false)
 
-    pf = ACPowerFlow(ACSolver)
-    pf_lf = ACPowerFlow(ACSolver; calculate_loss_factors = true)
+    pf = ACPowerFlow(ACSolver())
+    pf_lf = ACPowerFlow(ACSolver(); calculate_loss_factors = true)
     time_steps = 24
     data_loss_factors =
         PowerFlowData(pf_lf, sys; time_steps = time_steps)
@@ -107,7 +107,7 @@ end
     prepare_ts_data!(data_brute_force, time_steps)
 
     # get power flows with NR KLU method and write results
-    solve_powerflow!(data_loss_factors; pf = pf_lf)
+    PF.solve_power_flow_data!(data_loss_factors, pf_lf)
 
     # get loss factors using brute force approach (sequential power flow evaluations for each bus)
     bf_loss_factors = penalty_factors_brute_force(data_brute_force, pf)
@@ -116,7 +116,7 @@ end
     @test isapprox(bf_loss_factors, data_loss_factors.loss_factors, atol = 1e-4, rtol = 0)
 
     # get power flow results without loss factors
-    solve_powerflow!(data_brute_force; pf = pf)
+    PF.solve_power_flow_data!(data_brute_force, pf)
     @test isnothing(data_brute_force.loss_factors)
 end
 
@@ -163,7 +163,7 @@ end
     prepare_ts_data!(data, time_steps)
 
     init_p_injections = copy(data.bus_activepower_injection)
-    solve_powerflow!(data; pf = pf)
+    PF.solve_power_flow_data!(data, pf)
 
     # check results
     subnetworks = PowerFlows._find_subnetworks_for_reference_buses(

--- a/test/test_multiperiod_dc_powerflow.jl
+++ b/test/test_multiperiod_dc_powerflow.jl
@@ -57,13 +57,13 @@
     data_3.bus_activepower_withdrawals .= deepcopy(withs)
 
     # case 1: get power flows with ABA method and write results
-    results_1 = solve_powerflow(data_1, sys)
+    results_1 = solve_power_flow(data_1, sys)
 
     # case 2: get power flows PTDF method and write results
-    results_2 = solve_powerflow(data_2, sys)
+    results_2 = solve_power_flow(data_2, sys)
 
     # case 3: get power flows Virtual PTDF method and write results
-    results_3 = solve_powerflow(data_3, sys)
+    results_3 = solve_power_flow(data_3, sys)
 
     # check results
 

--- a/test/test_psse_export.jl
+++ b/test/test_psse_export.jl
@@ -228,8 +228,8 @@ function test_power_flow(
     sys2::System;
     exclude_reactive_flow = false,
 )
-    result1 = solve_powerflow(pf, sys1; correct_bustypes = true)
-    result2 = solve_powerflow(pf, sys2; correct_bustypes = true)
+    result1 = solve_power_flow(sys1, pf)
+    result2 = solve_power_flow(sys2, pf)
     reactive_power_tol =
         exclude_reactive_flow ? nothing : POWERFLOW_COMPARISON_TOLERANCE
     @test compare_df_within_tolerance("bus_results", result1["bus_results"],

--- a/test/test_utils/common.jl
+++ b/test/test_utils/common.jl
@@ -151,7 +151,7 @@ function _check_ds_pf(
     data_original_bus_power::Vector{Float64};
     kwargs...,
 )
-    res = solve_powerflow(pf, sys; kwargs...)
+    res = solve_power_flow(sys, pf; kwargs...)
 
     data = PowerFlowData(pf, sys; kwargs...)
     subnetworks = PowerFlows._find_subnetworks_for_reference_buses(
@@ -166,7 +166,7 @@ function _check_ds_pf(
         original_bus_power,
     )
 
-    solve_powerflow!(pf, sys; kwargs...)
+    solve_power_flow!(sys, pf; kwargs...)
     p_solve, _ = _system_generation_power(sys, bus_numbers)
 
     @test isapprox(p_solve, res["bus_results"][:, :P_gen]; atol = 1e-6, rtol = 0)
@@ -178,7 +178,7 @@ function _check_ds_pf(
     @test original_gen_power == p_gen_reset
 
     @test data.bus_slack_participation_factors[:, 1] == bus_slack_participation_factors
-    solve_powerflow!(data; pf = pf)
+    PF.solve_power_flow_data!(data, pf)
     # now check the slack power distribution logic
     _check_distributed_slack_consistency(
         subnetworks,

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -136,8 +136,7 @@ function PowerFlows._newton_powerflow(
     Ybus = data.power_network_matrix.data
 
     # Find indices for each bus type
-    ref, pv, pq =
-        PowerFlows.bus_type_idx(data, time_step)
+    ref, pv, pq = bus_type_idx(data, time_step)
     pvpq = [pv; pq]
 
     npv = length(pv)

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -123,8 +123,8 @@ end
 
 # legacy NR implementation - here we do not care about allocations, we use this function only for testing purposes
 function PowerFlows._newton_powerflow(
-    pf::ACPowerFlow{LUACPowerFlow},
     data::PowerFlows.ACPowerFlowData,
+    ::LUACPowerFlow,
     time_step::Int64;
     kwargs...,
 )

--- a/test/test_utils/penalty_factors_brute_force.jl
+++ b/test/test_utils/penalty_factors_brute_force.jl
@@ -1,3 +1,19 @@
+"""Find all buses of the specified types at a given time step."""
+function bus_type_idx(
+    data::PF.ACPowerFlowData,
+    time_step::Int64 = 1,
+    bus_types::Tuple{Vararg{PSY.ACBusTypes}} = (
+        PSY.ACBusTypes.REF,
+        PSY.ACBusTypes.PV,
+        PSY.ACBusTypes.PQ,
+    ),
+)
+    # Find indices for each bus type
+    return [
+        findall(==(bus_type), data.bus_type[:, time_step]) for bus_type in bus_types
+    ]
+end
+
 """
     penalty_factors_brute_force(data::PowerFlowData; kwargs...)
 
@@ -30,7 +46,7 @@ function penalty_factors_brute_force(
               " this will re-compute the loss factors repeatedly, for no reason."
     end
     # we assume that the bus type for ref bus does not change between time steps
-    ref, = PowerFlows.bus_type_idx(data, 1, (PSY.ACBusTypes.REF,))
+    ref, = bus_type_idx(data, 1, (PSY.ACBusTypes.REF,))
 
     n_buses = first(size(data.bus_type))
     time_steps = collect(values(data.timestep_map))

--- a/test/test_utils/penalty_factors_brute_force.jl
+++ b/test/test_utils/penalty_factors_brute_force.jl
@@ -25,7 +25,7 @@ The loss factor value is computed as the change in the reference bus power injec
 # Arguments
 - `data::PowerFlowData`: The power flow data containing bus types, active power injections, and other relevant information.
 - `step_size::Float64 = 1e-6`: The step size used to perturb the active power injection at each bus.
-- `kwargs...`: Additional keyword arguments to be passed to the `solve_powerflow!` function.
+- `kwargs...`: Additional keyword arguments to be passed to the `solve_power_flow!` function.
 
 # Returns
 - `loss_factors::Array{Float64, 2}`: A 2D array of penalty factors for each bus and time step.
@@ -54,7 +54,7 @@ function penalty_factors_brute_force(
     loss_factors = zeros(Float64, n_buses, length(time_steps))
 
     # initial PF to establish the ref power value
-    solve_powerflow!(data; pf = pf, kwargs...)
+    PF.solve_power_flow_data!(data, pf, kwargs...)
 
     ref_power = copy(sum(data.bus_activepower_injection[ref, :]; dims = 1))
 
@@ -64,7 +64,7 @@ function penalty_factors_brute_force(
             continue
         end
         data.bus_activepower_injection[bx, :] .+= step_size
-        solve_powerflow!(data; pf = pf, kwargs...)
+        PF.solve_power_flow_data!(data, pf, kwargs...)
         loss_factors[[bx], :] .=
             (sum(data.bus_activepower_injection[ref, :]; dims = 1) .- ref_power) ./
             step_size


### PR DESCRIPTION
Implement what we discussed in #38: tidy up the interface and lay the groundwork for exposing the solver parameters in PSI.

- Added solver parameters [`tolerance`, `max_iterations`, etc.] as fields of each subtype of `ACPowerFlowSolverType`.
- Added `solver::ACSolver` as a field of `ACPowerFlow{ACSolver <: ACPowerFlowSolverType}`.
- `pf::ACPowerFlow` is now a required positional argument of `solve_power_flow(sys::PSY.System, pf::ACPowerFlow)`. I also flipped the order so that `solve_power_flow!` modifies its first argument (the system) and changed the name (power flow as 2 words, not 1).
- The version of `solve_powerflow!` that takes in a `PowerFlowData` object is now called `solve_power_flow_data!`, so that we can export the system version without exporting the `PowerFlowData` version.

Lingering details:

- eliminating duplicate fields: `calculate_loss_factors` and `generator_slack_participation_factors` ideally should only be in `PowerFlowData` or in `ACPowerFlow`, not both. [I'd be in favor of putting them in `PowerFlowData`: they're the only 2 variables that require the `ACPowerFlow` instance in the `PowerFlowData` constructor.]
- As far as I can tell, the only way to pass options to the power flow solver in PSI is via 
```
sim = run_simulation(
        # ...omitted...
        network_model = NetworkModel(
            # ...omitted...
            power_flow_evaluation = ACPowerFlow(;
                # options here
            ),
        ),
    )

```
This forces all options to reside in `ACPowerFlow`, regardless of whether they belong there! As a result, kwargs of the constructor for`ACPowerFlowData` (like `correct_buses`) cannot be specified in PSI (as far as I can tell).

Maybe these questions will clear up once I start working on the PSI side of things, so I will leave this in draft form for now.