### PR TITLE
Lk/psy5 pnm update

### DIFF
--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -221,9 +221,11 @@ end
 
 function error_if_has_network_reduction(m::PNM.PowerNetworkMatrix)
     if length(PNM.get_reverse_bus_search_map(m.network_reduction)) > 0
-        throw(NotImplementedError(
-            "AC Power Flow with network reduction is not implemented yet.",
-        ))
+        throw(
+            NotImplementedError(
+                "AC Power Flow with network reduction is not implemented yet.",
+            ),
+        )
     end
 end
 

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -23,7 +23,7 @@ flows and angles, as well as these ones.
 - `bus_lookup::Dict{Int, Int}`:
         dictionary linking the system's bus number with the rows of either
         "power_network_matrix" or "aux_network_matrix".
-- `branch_lookup::Dict{String, Int}`:
+- `branch_lookup::Dict{Tuple{Int, Int}, Int}`:
         dictionary linking the branch name with the column name of either the
         "power_network_matrix" or "aux_network_matrix".
 - `bus_activepower_injection::Matrix{Float64}`:
@@ -83,7 +83,7 @@ struct PowerFlowData{
     N <: Union{PNM.PowerNetworkMatrix, Nothing},
 } <: PowerFlowContainer
     bus_lookup::Dict{Int, Int}
-    branch_lookup::Dict{String, Int}
+    branch_lookup::Dict{Tuple{Int, Int}, Int}
     bus_activepower_injection::Matrix{Float64}
     bus_reactivepower_injection::Matrix{Float64}
     bus_activepower_withdrawals::Matrix{Float64}
@@ -128,8 +128,8 @@ const ACPowerFlowData = PowerFlowData{
 
 const PTDFPowerFlowData = PowerFlowData{
     PNM.PTDF{
-        Tuple{Vector{Int64}, Vector{String}},
-        Tuple{Dict{Int64, Int64}, Dict{String, Int64}},
+        Tuple{Vector{Int64}, Vector{Tuple{Int, Int}}},
+        Tuple{Dict{Int64, Int64}, Dict{Tuple{Int, Int}, Int64}},
         Matrix{Float64},
     },
     PNM.ABA_Matrix{
@@ -141,8 +141,8 @@ const PTDFPowerFlowData = PowerFlowData{
 
 const vPTDFPowerFlowData = PowerFlowData{
     PNM.VirtualPTDF{
-        Tuple{Vector{String}, Vector{Int64}},
-        Tuple{Dict{String, Int64}, Dict{Int64, Int64}},
+        Tuple{Vector{Tuple{Int, Int}}, Vector{Int64}},
+        Tuple{Dict{Tuple{Int, Int}, Int64}, Dict{Int64, Int64}},
     },
     PNM.ABA_Matrix{
         Tuple{Vector{Int64}, Vector{Int64}},
@@ -158,8 +158,8 @@ const ABAPowerFlowData = PowerFlowData{
         PNM.KLU.KLUFactorization{Float64, Int64},
     },
     PNM.BA_Matrix{
-        Tuple{Vector{Int64}, Vector{String}},
-        Tuple{Dict{Int64, Int64}, Dict{String, Int64}}},
+        Tuple{Vector{Int64}, Vector{Tuple{Int, Int}}},
+        Tuple{Dict{Int64, Int64}, Dict{Tuple{Int, Int}, Int64}}},
 }
 
 get_bus_lookup(pfd::PowerFlowData) = pfd.bus_lookup
@@ -219,6 +219,14 @@ function _calculate_neighbors(
     return neighbors
 end
 
+function error_if_has_network_reduction(m::PNM.PowerNetworkMatrix)
+    if length(PNM.get_reverse_bus_search_map(m.network_reduction)) > 0
+        throw(NotImplementedError(
+            "AC Power Flow with network reduction is not implemented yet.",
+        ))
+    end
+end
+
 """
 Function for the definition of the PowerFlowData structure given the System
 data, number of time periods to consider and their names.
@@ -270,6 +278,7 @@ function PowerFlowData(
         check_connectivity = check_connectivity,
         make_branch_admittance_matrices = true,
     )
+    error_if_has_network_reduction(power_network_matrix)
 
     # get number of buses and branches
     n_buses = length(axes(power_network_matrix, 1))
@@ -280,14 +289,12 @@ function PowerFlowData(
     n_branches = length(branches)
 
     bus_lookup = power_network_matrix.lookup[2]
-    branch_lookup = Dict{String, Int}()
+    branch_lookup = Dict{Tuple{Int, Int}, Int}()
     sizehint!(branch_lookup, n_branches)
-    temp_bus_map = Dict{Int, String}(
-        PSY.get_number(b) => PSY.get_name(b) for b in PSY.get_components(PSY.ACBus, sys)
-    )
     branch_types = Vector{DataType}(undef, n_branches)
+    # ybus doesn't have the branch lookup, so construct it here. (only works without network reduction)
     for (ix, b) in enumerate(branches)
-        branch_lookup[PSY.get_name(b)] = ix
+        branch_lookup[PNM.get_arc_tuple(b)] = ix
         branch_types[ix] = typeof(b)
     end
 
@@ -315,7 +322,6 @@ function PowerFlowData(
         n_branches,
         bus_lookup,
         branch_lookup,
-        temp_bus_map,
         branch_types,
         timestep_map,
         valid_ix,
@@ -378,9 +384,6 @@ function PowerFlowData(
 
     bus_lookup = aux_network_matrix.lookup[1]
     branch_lookup = aux_network_matrix.lookup[2]
-    temp_bus_map = Dict{Int, String}(
-        PSY.get_number(b) => PSY.get_name(b) for b in PSY.get_components(PSY.ACBus, sys)
-    )
     valid_ix = setdiff(1:n_buses, aux_network_matrix.ref_bus_positions)
     converged = fill(false, time_steps)
     loss_factors = nothing
@@ -395,7 +398,6 @@ function PowerFlowData(
         n_branches,
         bus_lookup,
         branch_lookup,
-        temp_bus_map,
         valid_ix,
         converged,
         loss_factors,
@@ -448,6 +450,7 @@ function PowerFlowData(
     # get the network matrices
     power_network_matrix = PNM.PTDF(sys)
     aux_network_matrix = PNM.ABA_Matrix(sys; factorize = true)
+    error_if_has_network_reduction(power_network_matrix)
 
     # get number of buses and branches
     n_buses = length(axes(power_network_matrix, 1))
@@ -455,9 +458,6 @@ function PowerFlowData(
 
     bus_lookup = power_network_matrix.lookup[1]
     branch_lookup = power_network_matrix.lookup[2]
-    temp_bus_map = Dict{Int, String}(
-        PSY.get_number(b) => PSY.get_name(b) for b in PSY.get_components(PSY.ACBus, sys)
-    )
     valid_ix = setdiff(1:n_buses, aux_network_matrix.ref_bus_positions)
     converged = fill(false, time_steps)
     loss_factors = nothing
@@ -472,7 +472,6 @@ function PowerFlowData(
         n_branches,
         bus_lookup,
         branch_lookup,
-        temp_bus_map,
         valid_ix,
         converged,
         loss_factors,
@@ -524,6 +523,7 @@ function PowerFlowData(
     # get the network matrices
     power_network_matrix = PNM.VirtualPTDF(sys) # evaluates an empty virtual PTDF
     aux_network_matrix = PNM.ABA_Matrix(sys; factorize = true)
+    error_if_has_network_reduction(power_network_matrix)
 
     # get number of buses and branches
     n_buses = length(axes(power_network_matrix, 2))
@@ -531,9 +531,6 @@ function PowerFlowData(
 
     bus_lookup = power_network_matrix.lookup[2]
     branch_lookup = power_network_matrix.lookup[1]
-    temp_bus_map = Dict{Int, String}(
-        PSY.get_number(b) => PSY.get_name(b) for b in PSY.get_components(PSY.ACBus, sys)
-    )
     valid_ix = setdiff(1:n_buses, aux_network_matrix.ref_bus_positions)
     converged = fill(false, time_steps)
     loss_factors = nothing
@@ -548,7 +545,6 @@ function PowerFlowData(
         n_branches,
         bus_lookup,
         branch_lookup,
-        temp_bus_map,
         valid_ix,
         converged,
         loss_factors,

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -282,7 +282,7 @@ function _create_jacobian_matrix_structure(data::ACPowerFlowData, time_step::Int
 end
 
 function _set_entries_for_neighbor(::SparseArrays.SparseMatrixCSC{Float64, Int32},
-    Y_from_to::ComplexF64,
+    Y_from_to::ComplexF32,
     Vm_from::Float64,
     Vm_to::Float64,
     θ_from_to::Float64,
@@ -310,7 +310,7 @@ function _set_entries_for_neighbor(::SparseArrays.SparseMatrixCSC{Float64, Int32
 end
 
 function _set_entries_for_neighbor(Jv::SparseArrays.SparseMatrixCSC{Float64, Int32},
-    Y_from_to::ComplexF64,
+    Y_from_to::ComplexF32,
     Vm_from::Float64,
     Vm_to::Float64,
     θ_from_to::Float64,
@@ -347,7 +347,7 @@ function _set_entries_for_neighbor(Jv::SparseArrays.SparseMatrixCSC{Float64, Int
 end
 
 function _set_entries_for_neighbor(Jv::SparseArrays.SparseMatrixCSC{Float64, Int32},
-    Y_from_to::ComplexF64,
+    Y_from_to::ComplexF32,
     Vm_from::Float64,
     Vm_to::Float64,
     θ_from_to::Float64,

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -601,7 +601,7 @@ function write_results(
 
     # get bus and branches
     branches, buses = _get_branches_buses(data)
-    
+
     branch_lookup = get_branch_lookup(data)
     # get branches from/to buses
     from_bus = first.(branches)

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -330,8 +330,13 @@ function _reactive_power_redistribution_pv(
     else
         error("No devices in bus $(PSY.get_name(bus))")
     end
-
-    total_active_power = sum(PSY.get_active_power.(devices))
+    # see issue https://github.com/NREL-Sienna/PowerSystems.jl/pull/1463
+    total_active_power = 0.0
+    for d in devices
+        if PSY.get_available(d) && !isa(d, PSY.SynchronousCondenser)
+            total_active_power += PSY.get_active_power(d)
+        end
+    end
 
     if isapprox(total_active_power, 0.0; atol = ISAPPROX_ZERO_TOLERANCE)
         @debug "Total Active Power Output at the bus is $(total_active_power). Using Unit's Base Power"
@@ -532,7 +537,7 @@ function _get_branches_buses(data::Union{PTDFPowerFlowData, vPTDFPowerFlowData})
 end
 
 function _allocate_results_data(
-    branches::Vector{String},
+    branch_names::Vector{String},
     buses::Vector{Int64},
     from_bus::Vector{Int64},
     to_bus::Vector{Int64},
@@ -560,15 +565,15 @@ function _allocate_results_data(
     DataFrames.sort!(bus_df, :bus_number)
 
     branch_df = DataFrames.DataFrame(;
-        line_name = branches,
+        line_name = branch_names,
         bus_from = from_bus,
         bus_to = to_bus,
         P_from_to = branch_activepower_flow_from_to,
         Q_from_to = branch_reactivepower_flow_from_to,
         P_to_from = branch_activepower_flow_to_from,
         Q_to_from = branch_reactivepower_flow_to_from,
-        P_losses = zeros(length(branches)),
-        Q_losses = zeros(length(branches)),
+        P_losses = zeros(length(branch_names)),
+        Q_losses = zeros(length(branch_names)),
     )
     DataFrames.sort!(branch_df, [:bus_from, :bus_to])
 
@@ -596,20 +601,27 @@ function write_results(
 
     # get bus and branches
     branches, buses = _get_branches_buses(data)
-
+    
+    branch_lookup = get_branch_lookup(data)
     # get branches from/to buses
-    from_bus = Vector{Int}(undef, length(branches))
-    to_bus = Vector{Int}(undef, length(branches))
-    for (i, branch) in enumerate(branches)
-        br = PSY.get_component(PSY.ACTransmission, sys, branch)
-        from_bus[i] = PSY.get_number(PSY.get_arc(br).from)
-        to_bus[i] = PSY.get_number(PSY.get_arc(br).to)
+    from_bus = first.(branches)
+    to_bus = last.(branches)
+
+    branch_names = fill("", length(branches))
+    branch_lookup = get_branch_lookup(data)
+    for br in PSY.get_components(PSY.ACTransmission, sys)
+        if br isa PSY.Transformer3W
+            @warn "3-winding transformers are not supported in the results export"
+            # do the math to recover the flow in each winding from the star bus model?
+            continue
+        end
+        branch_names[branch_lookup[PNM.get_arc_tuple(br)]] = PSY.get_name(br)
     end
 
     result_dict = Dict{Union{String, Char}, Dict{String, DataFrames.DataFrame}}()
     for i in 1:length(data.timestep_map)
         temp_dict = _allocate_results_data(
-            branches,
+            branch_names,
             buses,
             from_bus,
             to_bus,

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -96,8 +96,8 @@ end
 # this function is for testing purposes only
 function _legacy_dSbus_dV(
     V::Vector{Complex{Float64}},
-    Ybus::SparseMatrixCSC{Complex{Float64}, Int64},
-)::Tuple{SparseMatrixCSC{Complex{Float64}, Int32}, SparseMatrixCSC{Complex{Float64}, Int32}}
+    Ybus::SparseMatrixCSC{Complex{Float32}, Int64},
+)::Tuple{SparseMatrixCSC{Complex{Float32}, Int32}, SparseMatrixCSC{Complex{Float32}, Int32}}
     diagV = SparseArrays.spdiagm(0 => V)
     diagVnorm = SparseArrays.spdiagm(0 => V ./ abs.(V))
     diagIbus = SparseArrays.spdiagm(0 => Ybus * V)
@@ -108,8 +108,8 @@ end
 
 # this function is for testing purposes only
 function _legacy_J(
-    dSbus_dVa::SparseMatrixCSC{Complex{Float64}, Int32},
-    dSbus_dVm::SparseMatrixCSC{Complex{Float64}, Int32},
+    dSbus_dVa::SparseMatrixCSC{Complex{Float32}, Int32},
+    dSbus_dVm::SparseMatrixCSC{Complex{Float32}, Int32},
     pvpq::Vector{Int64},
     pq::Vector{Int64},
 )


### PR DESCRIPTION
Make the `psy5` branch compatible with the `mb/ybus-reductions` branch of PNM. For now, I added an error if the network reduction is nontrivial, but the other changes are working, pending PSY issue [1469](https://github.com/NREL-Sienna/PowerSystems.jl/issues/1469) and PSY PR [1463](https://github.com/NREL-Sienna/PowerSystems.jl/pull/1463).

One point of concern: numerical tests of the DC power flows are failing. @rbolgaryn could you take a look at `test_dc_powerflow.jl`? I'm not as familiar with the DC power flows: it might just be as simple as the fact that we've changed the order of the branches.