### PR TITLE
disable enhanced flat start by default

### DIFF
--- a/src/powerflow_types.jl
+++ b/src/powerflow_types.jl
@@ -13,6 +13,7 @@ struct ACPowerFlow{ACSolver <: ACPowerFlowSolverType} <: PowerFlowEvaluationMode
         Dict{Tuple{DataType, String}, Float64},
         Vector{Dict{Tuple{DataType, String}, Float64}},
     }
+    enhanced_flat_start::Bool
     robust_power_flow::Bool
 end
 
@@ -25,6 +26,7 @@ ACPowerFlow{ACSolver}(;
         Dict{Tuple{DataType, String}, Float64},
         Vector{Dict{Tuple{DataType, String}, Float64}},
     } = nothing,
+    enhanced_flat_start::Bool = true,
     robust_power_flow::Bool = false,
 ) where {ACSolver <: ACPowerFlowSolverType} =
     ACPowerFlow{ACSolver}(
@@ -32,6 +34,7 @@ ACPowerFlow{ACSolver}(;
         exporter,
         calculate_loss_factors,
         generator_slack_participation_factors,
+        enhanced_flat_start,
         robust_power_flow,
     )
 
@@ -45,15 +48,19 @@ ACPowerFlow(
         Dict{Tuple{DataType, String}, Float64},
         Vector{Dict{Tuple{DataType, String}, Float64}},
     } = nothing,
+    enhanced_flat_start::Bool = true,
     robust_power_flow::Bool = false,
 ) = ACPowerFlow{ACSolver}(
     check_reactive_power_limits,
     exporter,
     calculate_loss_factors,
     generator_slack_participation_factors,
+    enhanced_flat_start,
     robust_power_flow,
 )
 
+get_enhanced_flat_start(pf::ACPowerFlow{ACSolver}) where {ACSolver} =
+    pf.enhanced_flat_start
 get_robust_power_flow(pf::ACPowerFlow{ACSolver}) where {ACSolver} = pf.robust_power_flow
 
 abstract type AbstractDCPowerFlow <: PowerFlowEvaluationModel end

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -28,11 +28,18 @@ function bad_x0!(sys::PSY.System)
 end
 
 @testset "dc fallback" begin
-    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; robust_power_flow = true)
+    dc_pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(;
+        robust_power_flow = true,
+        enhanced_flat_start = false,
+    )
+    no_dc_pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(;
+        robust_power_flow = false,
+        enhanced_flat_start = false,
+    )
     # test that _dc_powerflow_fallback! solves correctly.
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
     sys2 = deepcopy(sys)
-    data = PowerFlowData(pf, sys2)
+    data = PowerFlowData(dc_pf, sys2)
     PF._dc_powerflow_fallback!(data, 1)
     ABA_angles = data.bus_angles[data.valid_ix, 1]
     p_inj =
@@ -43,7 +50,7 @@ end
     # check behavior of improved_x0 via creating bogus awful starting point.
     sys3 = deepcopy(sys)
     bad_x0!(sys3)
-    data3 = PowerFlowData(pf, sys3)
+    data3 = PowerFlowData(no_dc_pf, sys3)
     x0 = PF.calculate_x0(data3, 1)
     residual = PF.ACPowerFlowResidual(data3, 1)
     residual(x0, 1)
@@ -62,22 +69,21 @@ end
     bad_x0!(sys4)
     improvement_regex = r".*DC powerflow fallback yields smaller residual.*"
     @test_logs (:info, improvement_regex) match_mode = :any PF.solve_powerflow(
-        pf,
+        dc_pf,
         sys4,
-        robust_power_flow = true,
     )
-    pf_no_dc = ACPowerFlow{NewtonRaphsonACPowerFlow}(; robust_power_flow = false)
     sys5 = deepcopy(sys)
     bad_x0!(sys5)
-    @test_logs (:debug, "skipping efforts to improve initial guess") match_mode = :any min_level =
-        Logging.Debug PF.solve_powerflow(pf_no_dc, sys5)
+    @test_logs (:debug, "skipping running DC powerflow fallback") match_mode = :any min_level =
+        Logging.Debug PF.solve_powerflow(no_dc_pf, sys5)
 end
 
 @testset "large residual warning" begin
     # a system where bus numbers aren't 1, 2,...is there a smaller one with this property?
     sys = PSB.build_system(PSB.PSISystems, "RTS_GMLC_DA_sys")
     for i in [1, 35, 52, 57, 43, 66, 49, 68, 71, 25, 69, 58, 3, 73]
-        data = PowerFlowData(ACPowerFlow(), sys; correct_bustypes = true)
+        pf = ACPowerFlow(; enhanced_flat_start = false)
+        data = PowerFlowData(pf, sys; correct_bustypes = true)
         # First, write solution to data. Then set magnitude of a random-ish bus to a huge number
         # and try to solve again: the "large residual warning" should be about that bus.
         solve_powerflow!(data)
@@ -86,7 +92,7 @@ end
         bus_ix = PowerFlows.get_bus_lookup(data)[bus_no]
         data.bus_magnitude[bus_ix] = 100.0
         @test_logs (:warn, Regex(".*Largest residual at bus $(bus_no).*")
-        ) match_mode = :any solve_powerflow!(data)
+        ) match_mode = :any solve_powerflow!(data; pf = pf)
     end
 end
 


### PR DESCRIPTION
Only try the "enhanced flat start" strategy if `robust_power_flow` is `true`, and only replace `x0` if that strategy produces a smaller initial residual. (The `TrustRegion` strategy fails to converge on the 10k bus system, if we indiscriminately use the "enhanced flat start" strategy.)