### PR TITLE
Eliminate allocations in hotloops

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PowerNetworkMatrices = "bed98974-b02a-5e2f-9fe0-a103f5c450dd"
 PowerSystems = "bcd98974-b02a-5e2f-9ee0-a103f5c450dd"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 DataFrames = "1"
@@ -28,4 +29,5 @@ Logging = "1"
 PowerNetworkMatrices = "^0.13"
 PowerSystems = "^4.6"
 SparseArrays = "1"
+StaticArrays = "1.9.13"
 julia = "^1.6"

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -30,6 +30,7 @@ import SparseArrays
 import InfrastructureSystems
 import PowerNetworkMatrices
 import SparseArrays: SparseMatrixCSC, SparseVector, sparse, sparsevec
+import StaticArrays: MVector
 import JSON3
 import DataStructures: OrderedDict
 import Dates

--- a/src/ac_power_flow_residual.jl
+++ b/src/ac_power_flow_residual.jl
@@ -294,17 +294,45 @@ function _update_residual_values!(
 
         for (ix, bt, p_bus_slack) in
             zip(subnetwork_buses, bus_types[subnetwork_buses], P_slack)
-            _set_state_variables_at_bus!(
-                ix,
-                P_net,
-                Q_net,
-                P_net_set,
-                p_bus_slack,
-                x,
-                data,
-                time_step,
-                Val(bt),
-            )
+            # creating Val(bt) at runtime is slow, requires allocating: split into cases
+            # explicitly, so instead it's Val(compile-time constant).
+            if bt == PSY.ACBusTypes.PQ
+                _set_state_variables_at_bus!(
+                    ix,
+                    P_net,
+                    Q_net,
+                    P_net_set,
+                    p_bus_slack,
+                    x,
+                    data,
+                    time_step,
+                    Val(PSY.ACBusTypes.PQ),
+                )
+            elseif bt == PSY.ACBusTypes.PV
+                _set_state_variables_at_bus!(
+                    ix,
+                    P_net,
+                    Q_net,
+                    P_net_set,
+                    p_bus_slack,
+                    x,
+                    data,
+                    time_step,
+                    Val(PSY.ACBusTypes.PV),
+                )
+            elseif bt == PSY.ACBusTypes.REF
+                _set_state_variables_at_bus!(
+                    ix,
+                    P_net,
+                    Q_net,
+                    P_net_set,
+                    p_bus_slack,
+                    x,
+                    data,
+                    time_step,
+                    Val(PSY.ACBusTypes.REF),
+                )
+            end
         end
     end
 


### PR DESCRIPTION
Eliminate some allocations in hotloops. This doesn't have that significant of an impact on the Trust Region method, but it does shave 10% off the robust homotopy method.  (The profiling tool I was using counted number of allocations, not size, which is why it flagged those tiny-but-frequent allocations.)
Current performance, robust homotopy:
<img width="631" height="206" alt="as-is" src="https://github.com/user-attachments/assets/44175a1a-afa4-46b8-8fa1-98e5f251cf88" />
With these changes, robust homotopy:
<img width="625" height="213" alt="with-changes" src="https://github.com/user-attachments/assets/154228ce-a597-46e3-95b2-4cfe4de1d87d" />
Current performance, levenberg-marquardt:
<img width="661" height="181" alt="current-lm" src="https://github.com/user-attachments/assets/05a9a1a0-fae2-4448-a99b-2b3fd6905d58" />
With these changes, levenberg-marquardt:
<img width="687" height="212" alt="with-changes-lm" src="https://github.com/user-attachments/assets/2932f29f-f1bb-4d12-9b10-410cc0a65cc6" />
Here, to profile, I'm doing
```julia
using PowerFlows, PowerSystemCaseBuilder, PowerSystems, BenchmarkTools
const PF = PowerFlows
sys = build_system(MatpowerTestSystems, "matpower_ACTIVSg10k_sys")
solverType = PF.RobustHomotopyPowerFlow
pf = ACPowerFlow{solverType}()
pf_data = PF.PowerFlowData(pf, sys; correct_bustypes = true)
solve_powerflow!(pf_data; pf = pf)

@benchmark solve_powerflow!(pf_data; pf = $pf) setup =
    (pf_data = PF.PowerFlowData($pf, $sys; correct_bustypes = true))
```
You need the `setup` part, else it re-uses the same `pf_data` object and so subsequent solves take 0 iterations.