### PR TITLE
Handle Q limits for exporter when nothing value is found

### DIFF
--- a/src/psse_export.jl
+++ b/src/psse_export.jl
@@ -729,18 +729,25 @@ function write_to_buffers!(
             exporter.system,
             PSY.UnitSystem.NATURAL_UNITS,
         )
-        QT = reactive_power_limits.max
-        QT = _warn_finite_default(
-            QT;
-            field_name = "QT",
-            component_name = PSY.get_name(generator),
-        )
-        QB = reactive_power_limits.min
-        QB = _warn_finite_default(
-            QB;
-            field_name = "QB",
-            component_name = PSY.get_name(generator),
-        )
+        QT = if isnothing(reactive_power_limits)
+            PSSE_DEFAULT
+        else
+            _warn_finite_default(
+                reactive_power_limits.max;
+                field_name = "QT",
+                component_name = PSY.get_name(generator),
+            )
+        end
+
+        QB = if isnothing(reactive_power_limits)
+            PSSE_DEFAULT
+        else
+            _warn_finite_default(
+                reactive_power_limits.min;
+                field_name = "QB",
+                component_name = PSY.get_name(generator),
+            )
+        end
         VS = PSY.get_magnitude(PSY.get_bus(generator))
         IREG = get(PSY.get_ext(generator), "IREG", PSSE_DEFAULT)
         MBASE = PSY.get_base_power(generator)

--- a/src/psse_export.jl
+++ b/src/psse_export.jl
@@ -730,7 +730,7 @@ function write_to_buffers!(
             PSY.UnitSystem.NATURAL_UNITS,
         )
         QT = if isnothing(reactive_power_limits)
-            PSSE_DEFAULT
+            PSSE_INFINITY
         else
             _warn_finite_default(
                 reactive_power_limits.max;
@@ -740,7 +740,7 @@ function write_to_buffers!(
         end
 
         QB = if isnothing(reactive_power_limits)
-            PSSE_DEFAULT
+            PSSE_INFINITY
         else
             _warn_finite_default(
                 reactive_power_limits.min;

--- a/src/psse_export.jl
+++ b/src/psse_export.jl
@@ -1031,7 +1031,11 @@ function write_to_buffers!(
     for zone in zones
         name = PSY.get_name(zone)
         I = zone_mapping[name]
-        @assert _is_valid_psse_name(name) name
+        # @assert _is_valid_psse_name(name) name
+        if !_is_valid_psse_name(name)
+            @warn "Invalid PSS/E name, truncating" name
+            name = name[1:12]
+        end
         ZONAME = _psse_quote_string(name)
 
         @fastprintdelim_unroll(io, true, I, ZONAME)


### PR DESCRIPTION
I address here a problem with the Zone data naming, where its value exceeds the 12 character limit that the manual states. So it is truncated to use the first 12 characters to avoid triggering the assert error.