### PR TITLE
refactor power flow data constructor

### DIFF
--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -22,6 +22,7 @@ export get_psse_export_paths
 import Base: @kwdef
 import Logging
 import DataFrames
+import DataFrames: Not
 import PowerSystems
 import PowerSystems: System, with_units_base
 import LinearAlgebra
@@ -32,7 +33,8 @@ import KLU
 import SparseArrays
 import InfrastructureSystems
 import PowerNetworkMatrices
-import SparseArrays: SparseMatrixCSC, SparseVector, sparse, sparsevec, AbstractSparseMatrix
+import SparseArrays:
+    SparseMatrixCSC, SparseVector, sparse, sparsevec, AbstractSparseMatrix, spzeros
 import StaticArrays: MVector
 import DataStructures: OrderedDict
 import Dates
@@ -43,11 +45,13 @@ const PSY = PowerSystems
 const PNM = PowerNetworkMatrices
 
 include("psi_utils.jl")
+include("powerflow_types.jl")
+include("PowerFlowData.jl")
 include("common.jl")
 include("powersystems_utils.jl")
 include("definitions.jl")
-include("powerflow_types.jl")
-include("PowerFlowData.jl")
+include("make_powerflow_data.jl")
+include("initialize_powerflow_data.jl")
 include("psse_export.jl")
 include("LinearSolverCache/linear_solver_cache.jl")
 include("LinearSolverCache/klu_linear_solver.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -272,45 +272,6 @@ my_mul_mt(
     X::Matrix{Float64},
 ) = vcat((A[name_, :]' * X for name_ in A.axes[1])...)
 
-function make_dc_powerflowdata(
-    sys,
-    time_steps,
-    timestep_names,
-    power_network_matrix,
-    aux_network_matrix,
-    bus_lookup,
-    arc_lookup,
-    valid_ix,
-    converged,
-    loss_factors,
-    calculate_loss_factors,
-    voltage_stability_factors,
-    calculate_voltage_stability_factors,
-    generator_slack_participation_factors,
-    correct_bustypes,
-)
-    timestep_map = Dict(zip([i for i in 1:time_steps], timestep_names))
-    neighbors = Vector{Set{Int}}()
-    return make_powerflowdata(
-        sys,
-        time_steps,
-        power_network_matrix,
-        aux_network_matrix,
-        bus_lookup,
-        arc_lookup,
-        timestep_map,
-        valid_ix,
-        neighbors,
-        converged,
-        loss_factors,
-        calculate_loss_factors,
-        voltage_stability_factors,
-        calculate_voltage_stability_factors,
-        generator_slack_participation_factors,
-        correct_bustypes,
-    )
-end
-
 function _add_gspf_to_ijv!(
     I::Vector{Int},
     J::Vector{Int},
@@ -337,9 +298,10 @@ function _add_gspf_to_ijv!(
     return
 end
 
-function make_bus_slack_participation_factors(
+function make_bus_slack_participation_factors!(
+    data::PowerFlowData,
     sys::System,
-    generator_slack_participation_factors::Dict{Tuple{DataType, String}, Float64},
+    generator_slack_participation_factors_input::Dict{Tuple{DataType, String}, Float64},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
     time_steps::Int,
@@ -355,45 +317,57 @@ function make_bus_slack_participation_factors(
         J,
         V,
         sys,
-        generator_slack_participation_factors,
+        generator_slack_participation_factors_input,
         bus_lookup,
         reverse_bus_search_map,
         1:time_steps,
     )
 
-    bus_slack_participation_factors = sparse(I, J, V, n_buses, time_steps)
-    return bus_slack_participation_factors,
-    repeat([generator_slack_participation_factors], time_steps)
+    data.bus_slack_participation_factors .= sparse(I, J, V, n_buses, time_steps)
+    append!(
+        data.generator_slack_participation_factors,
+        repeat([generator_slack_participation_factors_input], time_steps),
+    )
+    return
 end
 
-function make_bus_slack_participation_factors(
+function make_bus_slack_participation_factors!(
+    data::PowerFlowData,
     sys::System,
-    generator_slack_participation_factors::Vector{Dict{Tuple{DataType, String}, Float64}},
+    generator_slack_participation_factors_input::Vector{
+        Dict{Tuple{DataType, String}, Float64},
+    },
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
     time_steps::Int,
     n_buses::Int,
     bus_type::Matrix{PSY.ACBusTypes},
 )
-    if length(generator_slack_participation_factors) == 1
-        return make_bus_slack_participation_factors(
+    if length(generator_slack_participation_factors_input) == 1
+        make_bus_slack_participation_factors!(
+            data,
             sys,
-            generator_slack_participation_factors[1],
+            generator_slack_participation_factors_input[1],
             bus_lookup,
             reverse_bus_search_map,
             time_steps,
             n_buses,
             bus_type,
         )
+        return
     end
 
-    if length(generator_slack_participation_factors) < time_steps
+    if length(generator_slack_participation_factors_input) < time_steps
         throw(
             ArgumentError(
                 "slack_participation_factors must have at least the same length as time_steps",
             ),
         )
     end
+    append!(
+        data.generator_slack_participation_factors,
+        generator_slack_participation_factors_input,
+    )
 
     # A sparse matrix constructor is used here, and the duplicates at the same locations are summed by default.
     # This way, the generator slack participation factors are aggregated per bus.
@@ -401,7 +375,7 @@ function make_bus_slack_participation_factors(
     J = Int[]
     V = Float64[]
 
-    for (time_step, factors) in enumerate(generator_slack_participation_factors)
+    for (time_step, factors) in enumerate(generator_slack_participation_factors_input)
         _add_gspf_to_ijv!(
             I,
             J,
@@ -414,11 +388,12 @@ function make_bus_slack_participation_factors(
         )
     end
 
-    bus_slack_participation_factors = sparse(I, J, V, n_buses, time_steps)
-    return bus_slack_participation_factors, generator_slack_participation_factors
+    data.bus_slack_participation_factors .= sparse(I, J, V, n_buses, time_steps)
+    return
 end
 
-function make_bus_slack_participation_factors(
+function make_bus_slack_participation_factors!(
+    data::PowerFlowData,
     ::System,
     ::Nothing,
     ::Dict{Int, Int},
@@ -440,9 +415,8 @@ function make_bus_slack_participation_factors(
         end
     end
 
-    bus_slack_participation_factors = sparse(I, J, V, n_buses, time_steps)
-
-    return bus_slack_participation_factors, nothing
+    data.bus_slack_participation_factors .= sparse(I, J, V, n_buses, time_steps)
+    return
 end
 
 """Return set of all bus numbers that must be PV: i.e. have an available generator."""
@@ -469,171 +443,6 @@ function can_be_PV(sys::System)
         push!(source_buses, PSY.get_number(PSY.get_bus(source)))
     end
     return source_buses
-end
-
-function make_powerflowdata(
-    sys,
-    time_steps,
-    power_network_matrix,
-    aux_network_matrix,
-    bus_lookup,
-    arc_lookup,
-    timestep_map,
-    valid_ix,
-    neighbors,
-    converged,
-    loss_factors,
-    calculate_loss_factors,
-    voltage_stability_factors = nothing,
-    calculate_voltage_stability_factors = nothing,
-    generator_slack_participation_factors = nothing,
-    correct_bustypes::Bool = false,
-)
-    n_buses = length(bus_lookup)
-    n_arcs = length(arc_lookup)
-    bus_type = Vector{PSY.ACBusTypes}(undef, n_buses)
-    bus_angles = zeros(Float64, n_buses)
-    bus_magnitude = ones(Float64, n_buses)
-    nrd = PNM.get_network_reduction_data(power_network_matrix)
-    reverse_bus_search_map = PNM.get_reverse_bus_search_map(nrd)
-    bus_reduction_map = PNM.get_bus_reduction_map(nrd)
-
-    _initialize_bus_data!(
-        bus_type,
-        bus_angles,
-        bus_magnitude,
-        bus_lookup,
-        bus_reduction_map,
-        reverse_bus_search_map,
-        sys,
-        correct_bustypes,
-    )
-
-    # define injection vectors related to the first timestep
-    bus_activepower_injection = zeros(Float64, n_buses)
-    bus_reactivepower_injection = zeros(Float64, n_buses)
-    _get_injections!(
-        bus_activepower_injection,
-        bus_reactivepower_injection,
-        bus_lookup,
-        reverse_bus_search_map,
-        sys,
-    )
-
-    bus_activepower_withdrawals = zeros(Float64, n_buses)
-    bus_reactivepower_withdrawals = zeros(Float64, n_buses)
-    bus_activepower_constant_current_withdrawals = zeros(Float64, n_buses)
-    bus_reactivepower_constant_current_withdrawals = zeros(Float64, n_buses)
-    bus_activepower_constant_impedance_withdrawals = zeros(Float64, n_buses)
-    bus_reactivepower_constant_impedance_withdrawals = zeros(Float64, n_buses)
-    _get_withdrawals!(
-        bus_activepower_withdrawals,
-        bus_reactivepower_withdrawals,
-        bus_activepower_constant_current_withdrawals,
-        bus_reactivepower_constant_current_withdrawals,
-        bus_activepower_constant_impedance_withdrawals,
-        bus_reactivepower_constant_impedance_withdrawals,
-        bus_lookup,
-        reverse_bus_search_map,
-        sys,
-    )
-
-    # Define fields as matrices whose number of columns is equal to the number of time_steps
-    bus_activepower_injection_1 = zeros(Float64, n_buses, time_steps)
-    bus_reactivepower_injection_1 = zeros(Float64, n_buses, time_steps)
-    bus_activepower_withdrawals_1 = zeros(Float64, n_buses, time_steps)
-    bus_reactivepower_withdrawals_1 = zeros(Float64, n_buses, time_steps)
-    bus_activepower_constant_current_withdrawals_1 = zeros(Float64, n_buses, time_steps)
-    bus_reactivepower_constant_current_withdrawals_1 = zeros(Float64, n_buses, time_steps)
-    bus_activepower_constant_impedance_withdrawals_1 = zeros(Float64, n_buses, time_steps)
-    bus_reactivepower_constant_impedance_withdrawals_1 = zeros(Float64, n_buses, time_steps)
-    # TODO: our bus reactive power bounds are undefined for all timesteps besides the first?!
-    bus_reactivepower_bounds_1 = fill((NaN, NaN), n_buses, time_steps)
-    bus_magnitude_1 = ones(Float64, n_buses, time_steps)
-    bus_angles_1 = zeros(Float64, n_buses, time_steps)
-
-    # Initial values related to first timestep allocated in the first column
-    bus_activepower_injection_1[:, 1] .= bus_activepower_injection
-    bus_reactivepower_injection_1[:, 1] .= bus_reactivepower_injection
-    bus_activepower_withdrawals_1[:, 1] .= bus_activepower_withdrawals
-    bus_reactivepower_withdrawals_1[:, 1] .= bus_reactivepower_withdrawals
-    bus_activepower_constant_current_withdrawals_1[:, 1] .=
-        bus_activepower_constant_current_withdrawals
-    bus_reactivepower_constant_current_withdrawals_1[:, 1] .=
-        bus_reactivepower_constant_current_withdrawals
-    bus_activepower_constant_impedance_withdrawals_1[:, 1] .=
-        bus_activepower_constant_impedance_withdrawals
-    bus_reactivepower_constant_impedance_withdrawals_1[:, 1] .=
-        bus_reactivepower_constant_impedance_withdrawals
-    bus_magnitude_1[:, 1] .= bus_magnitude
-    bus_angles_1[:, 1] .= bus_angles
-
-    bus_reactivepower_bounds = Vector{Tuple{Float64, Float64}}(undef, n_buses)
-    for i in 1:n_buses
-        bus_reactivepower_bounds[i] = (0.0, 0.0)
-    end
-    _get_reactive_power_bound!(
-        bus_reactivepower_bounds,
-        bus_lookup,
-        reverse_bus_search_map,
-        sys,
-    )
-    bus_reactivepower_bounds_1[:, 1] .= bus_reactivepower_bounds
-
-    # Initial bus types are same for every time period
-    bus_type_1 = repeat(bus_type; outer = [1, time_steps])
-    @assert size(bus_type_1) == (n_buses, time_steps)
-
-    # Initial slack participation factors are same for every time period
-    bus_slack_participation_factors, generator_slack_participation_factors =
-        make_bus_slack_participation_factors(
-            sys,
-            generator_slack_participation_factors,
-            bus_lookup,
-            reverse_bus_search_map,
-            time_steps,
-            n_buses,
-            bus_type_1,
-        )
-
-    # Initial flows are all zero
-    arc_activepower_flow_from_to = zeros(Float64, n_arcs, time_steps)
-    arc_reactivepower_flow_from_to = zeros(Float64, n_arcs, time_steps)
-    arc_activepower_flow_to_from = zeros(Float64, n_arcs, time_steps)
-    arc_reactivepower_flow_to_from = zeros(Float64, n_arcs, time_steps)
-
-    return PowerFlowData(
-        bus_lookup,
-        arc_lookup,
-        bus_activepower_injection_1,
-        bus_reactivepower_injection_1,
-        bus_activepower_withdrawals_1,
-        bus_reactivepower_withdrawals_1,
-        bus_activepower_constant_current_withdrawals_1,
-        bus_reactivepower_constant_current_withdrawals_1,
-        bus_activepower_constant_impedance_withdrawals_1,
-        bus_reactivepower_constant_impedance_withdrawals_1,
-        bus_reactivepower_bounds_1,
-        generator_slack_participation_factors,
-        bus_slack_participation_factors,
-        bus_type_1,
-        bus_magnitude_1,
-        bus_angles_1,
-        arc_activepower_flow_from_to,
-        arc_reactivepower_flow_from_to,
-        arc_activepower_flow_to_from,
-        arc_reactivepower_flow_to_from,
-        timestep_map,
-        valid_ix,
-        power_network_matrix,
-        aux_network_matrix,
-        neighbors,
-        converged,
-        loss_factors,
-        calculate_loss_factors,
-        voltage_stability_factors,
-        calculate_voltage_stability_factors,
-    )
 end
 
 function validate_voltages(x::Vector{Float64},

--- a/src/initialize_powerflow_data.jl
+++ b/src/initialize_powerflow_data.jl
@@ -1,0 +1,107 @@
+"""
+Sets the fields of a PowerFlowData struct to match the given System.
+"""
+function initialize_powerflow_data!(
+    data::PowerFlowData,
+    pf::PowerFlowEvaluationModel,
+    sys::System;
+    correct_bustypes = false,
+)
+    # basically a copy-paste of make_powerflowdata from common.jl
+    # but now that we already have a PowerFlowData object, we don't need to pass
+    # a boatload of arguments, and we can use existing getters for the maps and lookups.
+    nrd = get_network_reduction_data(data)
+    reverse_bus_search_map = PNM.get_reverse_bus_search_map(nrd)
+    bus_reduction_map = PNM.get_bus_reduction_map(nrd)
+    bus_lookup = get_bus_lookup(data)
+    n_buses = length(bus_lookup)
+
+    # bus types, angles, magnitudes
+    bus_type = Vector{PSY.ACBusTypes}(undef, n_buses)
+    bus_angles = zeros(Float64, n_buses)
+    bus_magnitude = ones(Float64, n_buses)
+    _initialize_bus_data!(
+        bus_type,
+        bus_angles,
+        bus_magnitude,
+        bus_lookup,
+        bus_reduction_map,
+        reverse_bus_search_map,
+        sys,
+        correct_bustypes,
+    )
+    for i in 1:size(data.bus_type, 2)
+        data.bus_type[:, i] .= bus_type
+    end
+    data.bus_angles[:, 1] .= bus_angles
+    data.bus_magnitude[:, 1] .= bus_magnitude
+
+    # active power injections, withdrawals
+    bus_activepower_injection = zeros(Float64, n_buses)
+    bus_reactivepower_injection = zeros(Float64, n_buses)
+    _get_injections!(
+        bus_activepower_injection,
+        bus_reactivepower_injection,
+        bus_lookup,
+        reverse_bus_search_map,
+        sys,
+    )
+    data.bus_activepower_injection[:, 1] .= bus_activepower_injection
+    data.bus_reactivepower_injection[:, 1] .= bus_reactivepower_injection
+
+    # active power withdrawals, constant current and impedance withdrawals
+    bus_activepower_withdrawals = zeros(Float64, n_buses)
+    bus_reactivepower_withdrawals = zeros(Float64, n_buses)
+    bus_activepower_constant_current_withdrawals = zeros(Float64, n_buses)
+    bus_reactivepower_constant_current_withdrawals = zeros(Float64, n_buses)
+    bus_activepower_constant_impedance_withdrawals = zeros(Float64, n_buses)
+    bus_reactivepower_constant_impedance_withdrawals = zeros(Float64, n_buses)
+    _get_withdrawals!(
+        bus_activepower_withdrawals,
+        bus_reactivepower_withdrawals,
+        bus_activepower_constant_current_withdrawals,
+        bus_reactivepower_constant_current_withdrawals,
+        bus_activepower_constant_impedance_withdrawals,
+        bus_reactivepower_constant_impedance_withdrawals,
+        bus_lookup,
+        reverse_bus_search_map,
+        sys,
+    )
+    data.bus_activepower_withdrawals[:, 1] .= bus_activepower_withdrawals
+    data.bus_reactivepower_withdrawals[:, 1] .= bus_reactivepower_withdrawals
+    data.bus_activepower_constant_current_withdrawals[:, 1] .=
+        bus_activepower_constant_current_withdrawals
+    data.bus_reactivepower_constant_current_withdrawals[:, 1] .=
+        bus_reactivepower_constant_current_withdrawals
+    data.bus_activepower_constant_impedance_withdrawals[:, 1] .=
+        bus_activepower_constant_impedance_withdrawals
+    data.bus_reactivepower_constant_impedance_withdrawals[:, 1] .=
+        bus_reactivepower_constant_impedance_withdrawals
+
+    # reactive power bounds
+    bus_reactivepower_bounds = Vector{Tuple{Float64, Float64}}(undef, n_buses)
+    for i in 1:n_buses
+        bus_reactivepower_bounds[i] = (0.0, 0.0)
+    end
+    _get_reactive_power_bound!(
+        bus_reactivepower_bounds,
+        bus_lookup,
+        reverse_bus_search_map,
+        sys,
+    )
+    data.bus_reactivepower_bounds[:, 1] .= bus_reactivepower_bounds
+
+    # bus/generator participation factors
+    # remark: everything after the 3rd argument here is contained inside data.
+    make_bus_slack_participation_factors!(
+        data,
+        sys,
+        get_slack_participation_factors(pf),
+        bus_lookup,
+        reverse_bus_search_map,
+        length(data.timestep_map),
+        n_buses,
+        data.bus_type,
+    )
+    return data
+end

--- a/src/make_powerflow_data.jl
+++ b/src/make_powerflow_data.jl
@@ -1,0 +1,87 @@
+
+# TODO a little clunky: all of the form length(get_{arc/bus}_axis( )).
+arc_count(::ACPowerFlow,
+    power_network_matrix::PNM.PowerNetworkMatrix,
+    ::Union{PNM.PowerNetworkMatrix, Nothing}) = length(PNM.get_arc_axis(power_network_matrix.branch_admittance_from_to))
+bus_count(::ACPowerFlow,
+    power_network_matrix::PNM.PowerNetworkMatrix,
+    ::Union{PNM.PowerNetworkMatrix, Nothing}) = length(PNM.get_bus_axis(power_network_matrix))
+
+arc_count(::Union{PTDFDCPowerFlow, vPTDFDCPowerFlow},
+    power_network_matrix::PNM.PowerNetworkMatrix,
+    ::Union{PNM.PowerNetworkMatrix, Nothing}) =
+    length(PNM.get_arc_axis(power_network_matrix))
+bus_count(::Union{PTDFDCPowerFlow, vPTDFDCPowerFlow},
+    power_network_matrix::PNM.PowerNetworkMatrix,
+    ::Union{PNM.PowerNetworkMatrix, Nothing}) =
+    length(PNM.get_bus_axis(power_network_matrix))
+
+arc_count(::DCPowerFlow,
+    power_network_matrix::PNM.PowerNetworkMatrix,
+    aux_network_matrix::Union{PNM.PowerNetworkMatrix, Nothing}) =
+    length(PNM.get_arc_axis(aux_network_matrix))
+bus_count(::DCPowerFlow,
+    power_network_matrix::PNM.PowerNetworkMatrix,
+    aux_network_matrix::Union{PNM.PowerNetworkMatrix, Nothing}) =
+    length(PNM.get_bus_axis(aux_network_matrix))
+
+function make_powerflow_data(
+    pf::T,
+    power_network_matrix::M,
+    aux_network_matrix::N,
+    n_timesteps::Int;
+    timestep_names::Vector{String} = String[],
+    neighbors = Vector{Set{Int}}(),
+) where {
+    T <: PowerFlowEvaluationModel,
+    M <: PNM.PowerNetworkMatrix,
+    N <: Union{PNM.PowerNetworkMatrix, Nothing},
+}
+    if n_timesteps != 0
+        if length(timestep_names) == 0
+            timestep_names = [string(i) for i in 1:n_timesteps]
+        elseif length(timestep_names) != n_timesteps
+            error("timestep_names field must have same length as n_timesteps")
+        end
+    end
+    timestep_map = Dict(zip([i for i in 1:n_timesteps], timestep_names))
+
+    n_buses = bus_count(pf, power_network_matrix, aux_network_matrix)
+    n_arcs = arc_count(pf, power_network_matrix, aux_network_matrix)
+    calculate_loss_factors = get_calculate_loss_factors(pf)
+    calculate_voltage_stability_factors = get_calculate_voltage_stability_factors(pf)
+    if !isnothing(get_slack_participation_factors(pf))
+        empty_slack_participation_factors = Dict{Tuple{DataType, String}, Float64}[]
+    else
+        empty_slack_participation_factors = nothing
+    end
+    return PowerFlowData(
+        zeros(n_buses, n_timesteps), # bus_activepower_injection
+        zeros(n_buses, n_timesteps), # bus_reactivepower_injection
+        zeros(n_buses, n_timesteps), # bus_activepower_withdrawals
+        zeros(n_buses, n_timesteps), # bus_reactivepower_withdrawals
+        zeros(n_buses, n_timesteps), # bus_activepower_constant_current_withdrawals
+        zeros(n_buses, n_timesteps), # bus_reactivepower_constant_current_withdrawals
+        zeros(n_buses, n_timesteps), # bus_activepower_constant_impedance_withdrawals
+        zeros(n_buses, n_timesteps), # bus_reactivepower_constant_impedance_withdrawals
+        fill((-Inf, Inf), (n_buses, n_timesteps)), # bus_reactivepower_bounds
+        empty_slack_participation_factors, # generator_slack_participation_factors
+        spzeros(n_buses, n_timesteps), # bus_slack_participation_factors
+        fill(PSY.ACBusTypes.PQ, (n_buses, n_timesteps)), # bus_type
+        ones(n_buses, n_timesteps), # bus_magnitude
+        zeros(n_buses, n_timesteps), # bus_angles
+        zeros(n_arcs, n_timesteps), # arc_activepower_flow_from_to
+        zeros(n_arcs, n_timesteps), # arc_reactivepower_flow_from_to
+        zeros(n_arcs, n_timesteps), # arc_activepower_flow_to_from
+        zeros(n_arcs, n_timesteps), # arc_reactivepower_flow_to_from
+        timestep_map,
+        power_network_matrix,
+        aux_network_matrix,
+        neighbors,
+        falses(n_timesteps), # converged
+        calculate_loss_factors ? zeros(n_buses, n_timesteps) : nothing, # loss_factors
+        calculate_loss_factors,
+        calculate_voltage_stability_factors ? zeros(n_buses, n_timesteps) : nothing, # voltage_stability_factors
+        calculate_voltage_stability_factors,
+    )
+end

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -817,28 +817,28 @@ function update_system!(sys::PSY.System, data::PowerFlowData; time_step = 1)
         error("update_system! does not support systems with network reductions.")
     end
     for bus in PSY.get_components(PSY.ACBus, sys)
-        bus_number = data.bus_lookup[PSY.get_number(bus)]
-        bus_type = data.bus_type[bus_number, time_step]  # use this instead of bus.bustype to account for PV -> PQ
+        bus_index = get_bus_lookup(data)[PSY.get_number(bus)]
+        bus_type = data.bus_type[bus_index, time_step]  # use this instead of bus.bustype to account for PV -> PQ
         if bus_type == PSY.ACBusTypes.REF
             # For REF bus, voltage and angle are fixed; update active and reactive
-            P_gen = data.bus_activepower_injection[bus_number, time_step]
-            Q_gen = data.bus_reactivepower_injection[bus_number, time_step]
+            P_gen = data.bus_activepower_injection[bus_index, time_step]
+            Q_gen = data.bus_reactivepower_injection[bus_index, time_step]
             _power_redistribution_ref(sys, P_gen, Q_gen, bus,
                 DEFAULT_MAX_REDISTRIBUTION_ITERATIONS)
         elseif bus_type == PSY.ACBusTypes.PV
             # For PV bus, active and voltage are fixed; update reactive and angle
-            Q_gen = data.bus_reactivepower_injection[bus_number, time_step]
+            Q_gen = data.bus_reactivepower_injection[bus_index, time_step]
             _reactive_power_redistribution_pv(sys, Q_gen, bus,
                 DEFAULT_MAX_REDISTRIBUTION_ITERATIONS)
-            PSY.set_angle!(bus, data.bus_angles[bus_number, time_step])
+            PSY.set_angle!(bus, data.bus_angles[bus_index, time_step])
         elseif bus_type == PSY.ACBusTypes.PQ
             # For PQ bus, active and reactive are fixed; update voltage and angle
-            Vm = data.bus_magnitude[bus_number, time_step]
+            Vm = data.bus_magnitude[bus_index, time_step]
             PSY.set_magnitude!(bus, Vm)
-            PSY.set_angle!(bus, data.bus_angles[bus_number, time_step])
+            PSY.set_angle!(bus, data.bus_angles[bus_index, time_step])
             # if it used to be a PV bus, also set the Q value:
             if bus.bustype == PSY.ACBusTypes.PV
-                Q_gen = data.bus_reactivepower_injection[bus_number, time_step]
+                Q_gen = data.bus_reactivepower_injection[bus_index, time_step]
                 _reactive_power_redistribution_pv(sys, Q_gen, bus,
                     DEFAULT_MAX_REDISTRIBUTION_ITERATIONS)
                 # now both the Q and the Vm, Va are correct for this kind of buses

--- a/src/powerflow_setup.jl
+++ b/src/powerflow_setup.jl
@@ -90,8 +90,9 @@ function _enhanced_flat_start(
     time_step::Int64,
 )
     newx0 = copy(x0)
+    bus_lookup = get_bus_lookup(data)
     for subnetwork_bus_axes in values(data.power_network_matrix.subnetwork_axes)
-        subnetwork_indices = [data.bus_lookup[ix] for ix in subnetwork_bus_axes[1]]
+        subnetwork_indices = [bus_lookup[ix] for ix in subnetwork_bus_axes[1]]
         ref_bus = [
             i for
             i in subnetwork_indices if data.bus_type[i, time_step] == PSY.ACBusTypes.REF
@@ -126,9 +127,10 @@ function _dc_powerflow_fallback!(data::ACPowerFlowData, time_step::Int)
     ABA_matrix = data.aux_network_matrix.data
     solver_cache = KLULinSolveCache(ABA_matrix)
     full_factor!(solver_cache, ABA_matrix)
+    valid_ix = get_valid_ix(data)
     p_inj =
-        data.bus_activepower_injection[data.valid_ix, time_step] -
-        data.bus_activepower_withdrawals[data.valid_ix, time_step]
+        data.bus_activepower_injection[valid_ix, time_step] -
+        data.bus_activepower_withdrawals[valid_ix, time_step]
     solve!(solver_cache, p_inj)
-    data.bus_angles[data.valid_ix, time_step] .= p_inj
+    data.bus_angles[valid_ix, time_step] .= p_inj
 end

--- a/src/powerflow_types.jl
+++ b/src/powerflow_types.jl
@@ -71,11 +71,19 @@ ACPowerFlow(
     skip_redistribution,
 )
 
-get_enhanced_flat_start(pf::ACPowerFlow{ACSolver}) where {ACSolver} =
-    pf.enhanced_flat_start
-get_robust_power_flow(pf::ACPowerFlow{ACSolver}) where {ACSolver} = pf.robust_power_flow
+get_enhanced_flat_start(pf::ACPowerFlow) = pf.enhanced_flat_start
+get_robust_power_flow(pf::ACPowerFlow) = pf.robust_power_flow
+get_slack_participation_factors(pf::ACPowerFlow) = pf.generator_slack_participation_factors
+get_calculate_loss_factors(pf::ACPowerFlow) = pf.calculate_loss_factors
+get_calculate_voltage_stability_factors(pf::ACPowerFlow) =
+    pf.calculate_voltage_stability_factors
 
 abstract type AbstractDCPowerFlow <: PowerFlowEvaluationModel end
+
+# only make sense for AC power flows, but convenient to have for code reuse reasons.
+get_slack_participation_factors(::AbstractDCPowerFlow) = nothing
+get_calculate_loss_factors(::AbstractDCPowerFlow) = false
+get_calculate_voltage_stability_factors(::AbstractDCPowerFlow) = false
 
 @kwdef struct DCPowerFlow <: AbstractDCPowerFlow
     exporter::Union{Nothing, PowerFlowEvaluationModel} = nothing

--- a/src/solve_dc_powerflow.jl
+++ b/src/solve_dc_powerflow.jl
@@ -17,9 +17,10 @@ function solve_powerflow!(
         data.power_network_matrix.data' * power_injection
     data.arc_activepower_flow_to_from .= -data.arc_activepower_flow_from_to
     # evaluate bus angles
-    p_inj = power_injection[data.valid_ix, :]
+    valid_ix = get_valid_ix(data)
+    p_inj = power_injection[valid_ix, :]
     solve!(solver_cache, p_inj)
-    data.bus_angles[data.valid_ix, :] .= p_inj
+    data.bus_angles[valid_ix, :] .= p_inj
     data.converged .= true
     return
 end
@@ -40,9 +41,10 @@ function solve_powerflow!(
     data.arc_activepower_flow_from_to .=
         my_mul_mt(data.power_network_matrix, power_injection)
     data.arc_activepower_flow_to_from .= -data.arc_activepower_flow_from_to
-    p_inj = power_injection[data.valid_ix, :]
+    valid_ix = get_valid_ix(data)
+    p_inj = power_injection[valid_ix, :]
     solve!(solver_cache, p_inj)
-    data.bus_angles[data.valid_ix, :] .= p_inj
+    data.bus_angles[valid_ix, :] .= p_inj
     data.converged .= true
     return
 end
@@ -65,9 +67,10 @@ function solve_powerflow!(
     # get net injections
     power_injection = data.bus_activepower_injection - data.bus_activepower_withdrawals
     # save angles and power flows
-    p_inj = power_injection[data.valid_ix, :]
+    valid_ix = get_valid_ix(data)
+    p_inj = power_injection[valid_ix, :]
     solve!(solver_cache, p_inj)
-    data.bus_angles[data.valid_ix, :] .= p_inj
+    data.bus_angles[valid_ix, :] .= p_inj
     data.arc_activepower_flow_from_to .= data.aux_network_matrix.data' * data.bus_angles
     data.arc_activepower_flow_to_from .= -data.arc_activepower_flow_from_to
     data.converged .= true

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -41,10 +41,11 @@ end
     sys2 = deepcopy(sys)
     data = PowerFlowData(dc_pf, sys2)
     PF._dc_powerflow_fallback!(data, 1)
-    ABA_angles = data.bus_angles[data.valid_ix, 1]
+    valid_ix = PF.get_valid_ix(data)
+    ABA_angles = data.bus_angles[valid_ix, 1]
     p_inj =
-        data.bus_activepower_injection[data.valid_ix, 1] -
-        data.bus_activepower_withdrawals[data.valid_ix, 1]
+        data.bus_activepower_injection[valid_ix, 1] -
+        data.bus_activepower_withdrawals[valid_ix, 1]
     @test data.aux_network_matrix.data * ABA_angles ≈ p_inj
 
     # check behavior of improved_x0 via creating bogus awful starting point.

--- a/test/test_solve_powerflow.jl
+++ b/test/test_solve_powerflow.jl
@@ -417,7 +417,7 @@ function PowerFlowData_to_DataFrame(data::PowerFlowData)
     nbuses = size(data.bus_magnitude, 1)
     # Convert the PowerFlowData to a DataFrame
     bus_rev_lookup = fill(-1, nbuses)
-    for (bus_no, row_no) in data.bus_lookup
+    for (bus_no, row_no) in PF.get_bus_lookup(data)
         bus_rev_lookup[row_no] = bus_no
     end
     @assert !(-1 in bus_rev_lookup)

--- a/test/test_utils/common.jl
+++ b/test/test_utils/common.jl
@@ -64,17 +64,18 @@ end
 
 "Make the same changes to the PowerFlowData that modify_rts_system! makes to the System"
 function modify_rts_powerflow!(data::PowerFlowData)
+    bus_lookup = PF.get_bus_lookup(data)
     # For REF bus, voltage and angle are fixed; update active and reactive
-    data.bus_activepower_injection[data.bus_lookup[113]] = 2.4375
-    data.bus_reactivepower_injection[data.bus_lookup[113]] = 0.1875
+    data.bus_activepower_injection[bus_lookup[113]] = 2.4375
+    data.bus_reactivepower_injection[bus_lookup[113]] = 0.1875
 
     # For PV bus, active and voltage are fixed; update reactive and angle
-    data.bus_reactivepower_injection[data.bus_lookup[202]] = 0.37267
-    data.bus_angles[data.bus_lookup[202]] = -0.13778
+    data.bus_reactivepower_injection[bus_lookup[202]] = 0.37267
+    data.bus_angles[bus_lookup[202]] = -0.13778
 
     # For PQ bus, active and reactive are fixed; update voltage and angle
-    data.bus_magnitude[data.bus_lookup[117]] = 0.84783
-    data.bus_angles[data.bus_lookup[117]] = 0.14956
+    data.bus_magnitude[bus_lookup[117]] = 0.84783
+    data.bus_angles[bus_lookup[117]] = 0.14956
 end
 
 function _system_generation_power(


### PR DESCRIPTION
Overhaul of the `PowerFlowData` constructor. Changes:

1. Instead of storing `{bus/arc}_{lookup/axis}` as a field, just patch the calls through to the PNM object. Same for `valid_ix`. This means we don't need to calculate them in the bodies of the constructors.
2. Instead of passing arguments all the way down the call stack and creating the `PowerFlowData` object at the very bottom, we create a `PowerFlowData` object first and initialize the fields from the system second. This way, our functions stay short, require fewer arguments, and run the same for the different power flow types (with the differences quietly handled by multiple dispatch).

There is more I'd like to do along these lines, but I wanted to take things one step at a time. Some notes to the reviewer that may be helpful:

- `initialize_powerflow_data!` is mostly a copy-paste of the guts of `make_powerflowdata`
- `make_bus_slack_participation_factors` is basically unchanged, just happens in-place.
- the things that used to happen in the individual `PowerFlowData` constructors are either unnecessary (`{bus/arc}_{lookup/axis}`, `valid_ix`) or in `make_powerflow_data` (`timestep_map`).