### PR TITLE
add tests for jacobian, for arc types in network reductions

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,12 +9,12 @@ using LinearAlgebra
 using CSV
 using DataFrames
 using JSON3
+using InteractiveUtils
 using DataStructures
 import SparseArrays
 import SparseArrays: SparseMatrixCSC, sparse, sprandn, sprand
 import Random
 import PROPACK
-import InteractiveUtils
 
 const IS = InfrastructureSystems
 const PSB = PowerSystemCaseBuilder

--- a/test/test_arc_types_and_reductions.jl
+++ b/test/test_arc_types_and_reductions.jl
@@ -11,18 +11,17 @@ function test_all_powerflow_types(
         correct_bustypes = true,
     )
     solve_powerflow!(data; pf = pf) # should run without errors.
-    @test data isa Any
+    @test !isempty(data.arc_activepower_flow_from_to)
     solve_powerflow!(
         pf,
         sys;
         network_reductions = deepcopy(network_reductions),
         correct_bustypes = true,
     )
-    for pf in [PF.DCPowerFlow(), PF.PTDFDCPowerFlow(), PF.vPTDFDCPowerFlow()]
-        data = PF.PowerFlowData(pf, sys; network_reductions = deepcopy(network_reductions))
-        solve_powerflow!(data) # should run without errors.
-        @test data isa Any
-    end
+    pf = PF.DCPowerFlow()
+    data = PF.PowerFlowData(pf, sys; network_reductions = deepcopy(network_reductions))
+    solve_powerflow!(data) # should run without errors.
+    @test !isempty(data.arc_activepower_flow_from_to)
 end
 
 @testset "radial reduction with 3WT/parallel lines" begin

--- a/test/test_jacobian.jl
+++ b/test/test_jacobian.jl
@@ -1,5 +1,5 @@
 @testset "Jacobian Verification" begin
-    sys = build_system(MatpowerTestSystems, "matpower_ACTIVSg2000_sys")
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
     pf = PF.ACPowerFlow{NewtonRaphsonACPowerFlow}()
     data = PF.PowerFlowData(pf, sys; correct_bustypes = true)
     time_step = 1
@@ -24,6 +24,10 @@
                 push!(outputValues, deepcopy(residual.Rv))
             end
             ΔF = outputValues[2] .- outputValues[1]
+            floating_point_issues = all(isapprox.(ΔF, 0.0; atol = eps(Float32)))
+            if floating_point_issues
+                break
+            end
             ∂F_∂u_numerical = ΔF ./ Δx_mag
             ∂F_∂u_symbolic = J_x0 * u
 

--- a/test/test_reduced_dc_powerflow.jl
+++ b/test/test_reduced_dc_powerflow.jl
@@ -12,7 +12,9 @@ dc_reduction_types = Dict{String, Vector{PNM.NetworkReduction}}(
 @testset "DC power flow on 2k bus system: validate reduce-then-solve" begin
     sys = build_system(MatpowerTestSystems, "matpower_ACTIVSg2000_sys")
     @testset "$k reduction" for (k, v) in dc_reduction_types
-        @testset "$dc_pf power flow" for dc_pf in dc_powerflows
+        @testset "$pf_type power flow" for pf_type in
+                                           InteractiveUtils.subtypes(PF.AbstractDCPowerFlow)
+            dc_pf = pf_type()
             unreduced = PF.PowerFlowData(dc_pf, sys; correct_bustypes = true)
             PF.solve_powerflow!(unreduced)
             @assert all(unreduced.converged)


### PR DESCRIPTION
Add some tests: one set verifying that `J` matches a numerical derivative, another akin to [PR #184](https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/pull/184) in PNM, testing branch types in network reductions.