### PR TITLE
Consistently use `SYSTEM_BASE`

### DIFF
--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -399,16 +399,18 @@ function make_and_initialize_powerflow_data(
     neighbors = Vector{Set{Int}}(),
     correct_bustypes::Bool = false,
 ) where {M <: PNM.PowerNetworkMatrix, N <: Union{PNM.PowerNetworkMatrix, Nothing}}
-    data = PowerFlowData(
-        pf,
-        power_network_matrix,
-        aux_network_matrix,
-        time_steps;
-        timestep_names = timestep_names,
-        neighbors = neighbors,
-    )
-    initialize_powerflow_data!(data, pf, sys; correct_bustypes = correct_bustypes)
-    return data
+    with_units_base(sys, "SYSTEM_BASE") do
+        data = PowerFlowData(
+            pf,
+            power_network_matrix,
+            aux_network_matrix,
+            time_steps;
+            timestep_names = timestep_names,
+            neighbors = neighbors,
+        )
+        initialize_powerflow_data!(data, pf, sys; correct_bustypes = correct_bustypes)
+        return data
+    end
 end
 
 """

--- a/src/post_processing.jl
+++ b/src/post_processing.jl
@@ -43,6 +43,9 @@ function _power_redistribution_ref(
         Nothing,
         Dict{Tuple{DataType, String}, Float64},
     } = nothing)
+    PSY.get_units_base(sys) == "SYSTEM_BASE" || throw(
+        ArgumentError("Power redistribution requires the system to be in SYSTEM_BASE"),
+    )
     devices_ =
         PSY.get_components(x -> _is_available_source(x, bus), PSY.StaticInjection, sys)
     all_devices = devices_
@@ -180,6 +183,9 @@ function _reactive_power_redistribution_pv(
     bus::PSY.ACBus,
     max_iterations::Int,
 )
+    PSY.get_units_base(sys) == "SYSTEM_BASE" || throw(
+        ArgumentError("Power redistribution requires the system to be in SYSTEM_BASE"),
+    )
     @debug "Reactive Power Distribution $(PSY.get_name(bus))"
     devices_ =
         PSY.get_components(x -> _is_available_source(x, bus), PSY.StaticInjection, sys)

--- a/src/solve_dc_powerflow.jl
+++ b/src/solve_dc_powerflow.jl
@@ -98,9 +98,11 @@ function solve_powerflow(
     sys::PSY.System;
     kargs...,
 ) where {T <: AbstractDCPowerFlow}
-    data = PowerFlowData(T(), sys; kargs...)
-    solve_powerflow!(data)
-    return write_results(data, sys)
+    with_units_base(sys, PSY.UnitSystem.SYSTEM_BASE) do
+        data = PowerFlowData(T(), sys; kargs...)
+        solve_powerflow!(data)
+        return write_results(data, sys)
+    end
 end
 
 # MULTI PERIOD ###############################################################

--- a/test/test_dc_powerflow.jl
+++ b/test/test_dc_powerflow.jl
@@ -86,3 +86,14 @@ end
     )
     @test isapprox(solved_data_vPTDF["1"]["bus_results"].θ, ref_bus_angles, atol = 1e-6)
 end
+
+@testset "DC power flow: results independent of units" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
+    for T in (DCPowerFlow, PTDFDCPowerFlow, vPTDFDCPowerFlow)
+        line_name, flow_natural =
+            power_flow_with_units(sys, T, PSY.UnitSystem.NATURAL_UNITS)
+        line_name2, flow_system = power_flow_with_units(sys, T, PSY.UnitSystem.SYSTEM_BASE)
+        @test line_name == line_name2
+        @test flow_natural == flow_system
+    end
+end

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -116,6 +116,7 @@ end
 @testset "large residual warning" begin
     # a system where bus numbers aren't 1, 2,...is there a smaller one with this property?
     sys = PSB.build_system(PSB.PSISystems, "RTS_GMLC_DA_sys")
+    PSY.set_units_base_system!(sys, PSY.UnitSystem.SYSTEM_BASE)
     for i in [1, 35, 52, 57, 43, 66, 49, 68, 71, 25, 69, 58, 3, 73]
         pf = ACPowerFlow(; enhanced_flat_start = false)
         data = PowerFlowData(pf, sys; correct_bustypes = true)

--- a/test/test_powerflow_data.jl
+++ b/test/test_powerflow_data.jl
@@ -47,10 +47,6 @@ end
     for ACSolver in AC_SOLVERS_TO_TEST
         @testset "AC Solver: $(ACSolver)" begin
             sys_original = build_system(PSISystems, "RTS_GMLC_DA_sys")
-            # temporary work-around for PSB issue #174
-            for sc in PSY.get_components(PSY.SynchronousCondenser, sys_original)
-                PSY.set_base_power!(sc, 100.0)
-            end
             data_original =
                 PowerFlowData(
                     ACPowerFlow{ACSolver}(),

--- a/test/test_solve_powerflow.jl
+++ b/test/test_solve_powerflow.jl
@@ -696,3 +696,13 @@ end
     )
     @test isapprox(data1.bus_angles[:, 1], data2.bus_angles[:, 1], atol = 1e-6, rtol = 0)
 end
+
+@testset "AC power flow: results independent of units" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
+    line_name_ac, flow_natural_ac =
+        power_flow_with_units(sys, ACPowerFlow, PSY.UnitSystem.NATURAL_UNITS)
+    line_name2_ac, flow_system_ac =
+        power_flow_with_units(sys, ACPowerFlow, PSY.UnitSystem.SYSTEM_BASE)
+    @test line_name_ac == line_name2_ac
+    @test flow_natural_ac == flow_system_ac
+end

--- a/test/test_utils/common.jl
+++ b/test/test_utils/common.jl
@@ -46,34 +46,37 @@ end
 
 "Take RTS_GMLC_DA_sys and make some changes to it that are fully captured in the PowerFlowData(ACPowerFlow(), ...)"
 function modify_rts_system!(sys::System)
-    # For REF bus, voltage and angle are fixed; update active and reactive
-    ref_bus = get_bus(sys, 113)  # "Arne"
-    @assert get_bustype(ref_bus) == ACBusTypes.REF
-    # NOTE: we are not testing the correctness of _power_redistribution_ref here, it is used on both sides of the test
-    PF._power_redistribution_ref(
-        sys,
-        2.4375,
-        0.1875,
-        ref_bus,
-        PF.DEFAULT_MAX_REDISTRIBUTION_ITERATIONS,
-    )
+    with_units_base(sys, "SYSTEM_BASE") do
+        # For REF bus, voltage and angle are fixed; update active and reactive
+        ref_bus = get_bus(sys, 113)  # "Arne"
+        @assert get_bustype(ref_bus) == ACBusTypes.REF
+        # NOTE: we are not testing the correctness of _power_redistribution_ref here, it is used on both sides of the test
+        PF._power_redistribution_ref(
+            sys,
+            2.4375,
+            0.1875,
+            ref_bus,
+            PF.DEFAULT_MAX_REDISTRIBUTION_ITERATIONS,
+        )
 
-    # For PV bus, active and voltage are fixed; update reactive and angle
-    pv_bus = get_bus(sys, 202)  # "Bacon"
-    @assert get_bustype(pv_bus) == ACBusTypes.PV
-    PF._reactive_power_redistribution_pv(
-        sys,
-        0.37267,
-        pv_bus,
-        PF.DEFAULT_MAX_REDISTRIBUTION_ITERATIONS,
-    )
-    set_angle!(pv_bus, -0.13778)
+        # For PV bus, active and voltage are fixed; update reactive and angle
+        pv_bus = get_bus(sys, 202)  # "Bacon"
+        @assert get_bustype(pv_bus) == ACBusTypes.PV
+        PF._reactive_power_redistribution_pv(
+            sys,
+            0.37267,
+            pv_bus,
+            PF.DEFAULT_MAX_REDISTRIBUTION_ITERATIONS,
+        )
+        set_angle!(pv_bus, -0.13778)
 
-    # For PQ bus, active and reactive are fixed; update voltage and angle
-    pq_bus = get_bus(sys, 117)  # "Aston"
-    @assert get_bustype(pq_bus) == ACBusTypes.PQ
-    set_magnitude!(pq_bus, 0.84783)
-    set_angle!(pq_bus, 0.14956)
+        # For PQ bus, active and reactive are fixed; update voltage and angle
+        pq_bus = get_bus(sys, 117)  # "Aston"
+        @assert get_bustype(pq_bus) == ACBusTypes.PQ
+        set_magnitude!(pq_bus, 0.84783)
+        # @assert PNM.BUS_VOLTAGE_MAGNITUDE_CUTOFF_MIN <= 0.84783 <= PNM.BUS_VOLTAGE_MAGNITUDE_CUTOFF_MAX
+        set_angle!(pq_bus, 0.14956)
+    end
 end
 
 "Make the same changes to the PowerFlowData that modify_rts_system! makes to the System"
@@ -82,14 +85,17 @@ function modify_rts_powerflow!(data::PowerFlowData)
     # For REF bus, voltage and angle are fixed; update active and reactive
     data.bus_activepower_injection[bus_lookup[113]] = 2.4375
     data.bus_reactivepower_injection[bus_lookup[113]] = 0.1875
+    @assert data.bus_type[bus_lookup[113], 1] == PSY.ACBusTypes.REF
 
     # For PV bus, active and voltage are fixed; update reactive and angle
     data.bus_reactivepower_injection[bus_lookup[202]] = 0.37267
     data.bus_angles[bus_lookup[202]] = -0.13778
+    @assert data.bus_type[bus_lookup[202], 1] == PSY.ACBusTypes.PV
 
     # For PQ bus, active and reactive are fixed; update voltage and angle
     data.bus_magnitude[bus_lookup[117]] = 0.84783
     data.bus_angles[bus_lookup[117]] = 0.14956
+    @assert data.bus_type[bus_lookup[117], 1] == PSY.ACBusTypes.PQ
 end
 
 function _system_generation_power(


### PR DESCRIPTION
Resolve #256 by adding `with_unit_base`. Also add tests that ensure our reported line flows don't depend on the unit system.

With these changes, I'm getting a few new failures in `"System <-> PowerFlowData round trip"`: might be an actual bug or might be due to PSY issue [#1575](https://github.com/NREL-Sienna/PowerSystems.jl/issues/1575). Will revisit once that issue is resolved.