### PR TITLE
include HVDC endpoints in "must be PV"

### DIFF
--- a/src/powersystems_utils.jl
+++ b/src/powersystems_utils.jl
@@ -114,6 +114,12 @@ function must_be_PV(sys::System)
     for gen in PSY.get_available_components(PSY.SynchronousCondenser, sys)
         push!(gen_buses, PSY.get_number(PSY.get_bus(gen)))
     end
+    # Also include HVDC terminal buses.
+    for hvdc in PSY.get_available_components(PSY.TwoTerminalHVDC, sys)
+        arc = PSY.get_arc(hvdc)
+        push!(gen_buses, PSY.get_number(PSY.get_from(arc)))
+        push!(gen_buses, PSY.get_number(PSY.get_to(arc)))
+    end
     return gen_buses
 end
 


### PR DESCRIPTION
Close issue #244.

I put all endpoints of all types of HVDC lines as "must be PV," but if we want something more lenient--e.g. perhaps the from bus of an LCC being PQ is okay--then let me know and I'll change it.