### PR TITLE
Set BLAS backend upon loading

### DIFF
--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -46,6 +46,26 @@ const IS = InfrastructureSystems
 const PSY = PowerSystems
 const PNM = PowerNetworkMatrices
 
+function __init__()
+    # Auto-load optimal BLAS backend if available in the user's environment.
+    # Oddity: PNM's __init__() runs first, so messages there appear before this one.
+    if Sys.isapple()
+        try
+            Base.require(Main, :AppleAccelerate)
+            @info "Using AppleAccelerate BLAS backend for improved performance on macOS."
+        catch
+            # AppleAccelerate not installed - will use default OpenBLAS
+        end
+    elseif Sys.iswindows()
+        try
+            Base.require(Main, :MKL)
+            @info "Using MKL BLAS backend for improved performance on Intel CPUs."
+        catch
+            # MKL not installed - will use default OpenBLAS
+        end
+    end
+end
+
 include("definitions.jl")
 include("psi_utils.jl")
 include("powersystems_utils.jl")


### PR DESCRIPTION
See also PNM PR [230](https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/pull/230). Slight oddity: PNM's `__init__()` happens first, so if that PR is also merged, users will see PNM's "you might want to use [backend]" message followed by PF's "using [backend]" message.

edit: I did a profiling comparison on locally, and the AA BLAS is faster than OpenBLAS [with the default 8 threads].

edit 2: this is a step towards addressing issue #216