### PR TITLE
Lk/issue 230

### DIFF
--- a/docs/src/reference/api/internal.md
+++ b/docs/src/reference/api/internal.md
@@ -14,7 +14,7 @@ Modules = [PowerFlows]
 Public = false
 Private = true
 Pages = [
-    "powerflow_types.jl",
+    "power_flow_types.jl",
 ]
 ```
 
@@ -38,8 +38,8 @@ Modules = [PowerFlows]
 Public = false
 Private = true
 Pages = [
-    "solve_ac_powerflow.jl",
-    "solve_dc_powerflow.jl"
+    "solve_ac_power_flow.jl",
+    "solve_dc_power_flow.jl"
 ]
 ```
 
@@ -51,8 +51,8 @@ Public = true
 Private = true
 Pages = [
     "state_indexing_helpers.jl",
-    "initialize_powerflow_data.jl",
-    "powerflow_setup.jl",
+    "initialize_power_flow_data.jl",
+    "power_flow_setup.jl",
 ]
 ```
 
@@ -100,7 +100,7 @@ Modules = [PowerFlows]
 Public = false
 Private = true
 Pages = [
-    "powerflow_method.jl",
+    "power_flow_method.jl",
 ]
 ```
 
@@ -113,7 +113,7 @@ Private = true
 Pages = [
     "RobustHomotopy/homotopy_hessian.jl",
     "RobustHomotopy/homotopy_initialization.jl",
-    "RobustHomotopy/homotopy_powerflow.jl",
+    "RobustHomotopy/homotopy_power_flow.jl",
     "RobustHomotopy/homotopy_residual.jl",
 ]
 ```

--- a/docs/src/reference/api/public.md
+++ b/docs/src/reference/api/public.md
@@ -14,7 +14,7 @@ Modules = [PowerFlows]
 Public = true
 Private = false
 Pages = [
-    "powerflow_types.jl",
+    "power_flow_types.jl",
 ]
 ```
 
@@ -24,11 +24,11 @@ Modules = [PowerFlows]
 Public = true
 Private = false
 Pages = [
-    "solve_dc_powerflow.jl",
-    "solve_ac_powerflow.jl",
+    "solve_dc_power_flow.jl",
+    "solve_ac_power_flow.jl",
     "ac_power_flow_residual.jl",
     "ac_power_flow_jacobian.jl",
-    "powerflow_method.jl",
+    "power_flow_method.jl",
     "post_processing.jl"
 ]
 ```

--- a/docs/src/reference/developers/power_flow.md
+++ b/docs/src/reference/developers/power_flow.md
@@ -42,7 +42,7 @@ Solving the power flow with mode 1:
 
 ````@example generated_power_flow
 pf = ACPowerFlow()
-results = solve_powerflow(pf, system_data)
+results = solve_power_flow(pf, system_data)
 results["bus_results"]
 ````
 

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -30,33 +30,33 @@ between network elements (post-reduction) and system objects (pre-reduction).
 Generally, do not construct this directly. Instead, use one of the later constructors to 
 pass in a `PowerFlowEvaluationModel` and a `PowerSystems.System`. 
 `aux\\_network\\_matrix` and `power\\_network\\_matrix` will then be set to the appropriate 
-matrices that are needed for computing that type of powerflow. See also `ACPowerFlowData`,
+matrices that are needed for computing that type of power_flow. See also `ACPowerFlowData`,
 `ABAPowerFlowData`, `PTDFPowerFlowData`, and `vPTDFPowerFlowData`: 
 these are all aliases for `PowerFlowData{N, M}` with specific `N`,`M`, that are used for 
 the respective type of power flow evaluations.
 
 # Fields:
-- `bus_activepower_injection::Matrix{Float64}`:
+- `bus_active_power_injections::Matrix{Float64}`:
         matrix containing the bus active power injection.
-- `bus_reactivepower_injection::Matrix{Float64}`:
+- `bus_reactive_power_injections::Matrix{Float64}`:
         matrix containing the bus reactive power injection.
-- `bus_activepower_withdrawals::Matrix{Float64}`:
+- `bus_active_power_withdrawals::Matrix{Float64}`:
         matrix containing the bus reactive power withdrawals.
-- `bus_reactivepower_withdrawals::Matrix{Float64}`:
+- `bus_reactive_power_withdrawals::Matrix{Float64}`:
         matrix containing the bus reactive power withdrawals.
-- `bus_activepower_constant_current_withdrawals::Matrix{Float64}`:
+- `bus_active_power_constant_current_withdrawals::Matrix{Float64}`:
         matrix containing the bus active power constant current
         withdrawals.
-- `bus_reactivepower_constant_current_withdrawals::Matrix{Float64}`:
+- `bus_reactive_power_constant_current_withdrawals::Matrix{Float64}`:
         matrix containing the bus reactive power constant current
         withdrawals.
-- `bus_activepower_constant_impedance_withdrawals::Matrix{Float64}`:
+- `bus_active_power_constant_impedance_withdrawals::Matrix{Float64}`:
         matrix containing the bus active power constant impedance
         withdrawals.
-- `bus_reactivepower_constant_impedance_withdrawals::Matrix{Float64}`:  
+- `bus_reactive_power_constant_impedance_withdrawals::Matrix{Float64}`:  
         matrix containing the bus reactive power constant impedance
         withdrawals.
-- `bus_reactivepower_bounds::Matrix{Float64}`:
+- `bus_reactive_power_bounds::Matrix{Float64}`:
         matrix containing upper and lower bounds for the reactive supply at each
         bus at each time period.
 - `bus_type::Matrix{PSY.ACBusTypes}`:
@@ -65,13 +65,13 @@ the respective type of power flow evaluations.
         matrix containing the bus voltage magnitudes.
 - `bus_angles::Matrix{Float64}`:
         matrix containing the bus voltage angles.
-- `arc_activepower_flow_from_to::Matrix{Float64}`:
+- `arc_active_power_flow_from_to::Matrix{Float64}`:
         matrix containing the active power flows measured at the `from` bus.
-- `arc_reactivepower_flow_from_to::Matrix{Float64}`:
+- `arc_reactive_power_flow_from_to::Matrix{Float64}`:
         matrix containing the reactive power flows measured at the `from` bus.
-- `arc_activepower_flow_to_from::Matrix{Float64}`:
+- `arc_active_power_flow_to_from::Matrix{Float64}`:
         matrix containing the active power flows measured at the `to` bus.
-- `arc_reactivepower_flow_to_from::Matrix{Float64}`:
+- `arc_reactive_power_flow_to_from::Matrix{Float64}`:
         matrix containing the reactive power flows measured at the `to` bus.
 - `generic_hvdc_flows::Dict{Tuple{Int, Int}, Tuple{Float64, Float64}}`:
         dictionary mapping each generic HVDC line (represented as a tuple of the from and to bus
@@ -80,7 +80,7 @@ the respective type of power flow evaluations.
         "(b, t)" matrix containing the net power injection from all HVDC lines at each bus.
         b: number of buses, t: number of time period. Only contains HVDCs handled as
         separate injection/withdrawal pairs: LCCs and generic for DC, or just generic for AC.
-- `timestep_map::Dict{Int, S}`:
+- `time_step_map::Dict{Int, S}`:
         dictionary mapping the number of the time periods (corresponding to the
         column number of the previously mentioned matrices) and their names.
 - `power_network_matrix::M`:
@@ -95,15 +95,15 @@ struct PowerFlowData{
     M <: PNM.PowerNetworkMatrix,
     N <: Union{PNM.PowerNetworkMatrix, Nothing},
 } <: PowerFlowContainer
-    bus_activepower_injection::Matrix{Float64}
-    bus_reactivepower_injection::Matrix{Float64}
-    bus_activepower_withdrawals::Matrix{Float64}
-    bus_reactivepower_withdrawals::Matrix{Float64}
-    bus_activepower_constant_current_withdrawals::Matrix{Float64}
-    bus_reactivepower_constant_current_withdrawals::Matrix{Float64}
-    bus_activepower_constant_impedance_withdrawals::Matrix{Float64}
-    bus_reactivepower_constant_impedance_withdrawals::Matrix{Float64}
-    bus_reactivepower_bounds::Matrix{Tuple{Float64, Float64}}
+    bus_active_power_injections::Matrix{Float64}
+    bus_reactive_power_injections::Matrix{Float64}
+    bus_active_power_withdrawals::Matrix{Float64}
+    bus_reactive_power_withdrawals::Matrix{Float64}
+    bus_active_power_constant_current_withdrawals::Matrix{Float64}
+    bus_reactive_power_constant_current_withdrawals::Matrix{Float64}
+    bus_active_power_constant_impedance_withdrawals::Matrix{Float64}
+    bus_reactive_power_constant_impedance_withdrawals::Matrix{Float64}
+    bus_reactive_power_bounds::Matrix{Tuple{Float64, Float64}}
     generator_slack_participation_factors::Union{
         Vector{Dict{Tuple{DataType, String}, Float64}},
         Nothing,
@@ -112,13 +112,13 @@ struct PowerFlowData{
     bus_type::Matrix{PSY.ACBusTypes}
     bus_magnitude::Matrix{Float64}
     bus_angles::Matrix{Float64}
-    arc_activepower_flow_from_to::Matrix{Float64}
-    arc_reactivepower_flow_from_to::Matrix{Float64}
-    arc_activepower_flow_to_from::Matrix{Float64}
-    arc_reactivepower_flow_to_from::Matrix{Float64}
+    arc_active_power_flow_from_to::Matrix{Float64}
+    arc_reactive_power_flow_from_to::Matrix{Float64}
+    arc_active_power_flow_to_from::Matrix{Float64}
+    arc_reactive_power_flow_to_from::Matrix{Float64}
     generic_hvdc_flows::Dict{Tuple{Int, Int}, Tuple{Float64, Float64}}
     bus_hvdc_net_power::Matrix{Float64}
-    timestep_map::Dict{Int, String}
+    time_step_map::Dict{Int, String}
     power_network_matrix::M
     aux_network_matrix::N
     neighbors::Vector{Set{Int}}
@@ -167,19 +167,19 @@ const ABAPowerFlowData = PowerFlowData{
 get_metadata_matrix(pfd::ABAPowerFlowData) = pfd.aux_network_matrix
 
 # true getters for fields:
-get_bus_activepower_injection(pfd::PowerFlowData) = pfd.bus_activepower_injection
-get_bus_reactivepower_injection(pfd::PowerFlowData) = pfd.bus_reactivepower_injection
-get_bus_activepower_withdrawals(pfd::PowerFlowData) = pfd.bus_activepower_withdrawals
-get_bus_activepower_constant_current_withdrawals(pfd::PowerFlowData) =
-    pfd.bus_activepower_constant_current_withdrawals
-get_bus_activepower_constant_impedance_withdrawals(pfd::PowerFlowData) =
-    pfd.bus_activepower_constant_impedance_withdrawals
-get_bus_reactivepower_withdrawals(pfd::PowerFlowData) = pfd.bus_reactivepower_withdrawals
-get_bus_reactivepower_constant_current_withdrawals(pfd::PowerFlowData) =
-    pfd.bus_reactivepower_constant_current_withdrawals
-get_bus_reactivepower_constant_impedance_withdrawals(pfd::PowerFlowData) =
-    pfd.bus_reactivepower_constant_impedance_withdrawals
-get_bus_reactivepower_bounds(pfd::PowerFlowData) = pfd.bus_reactivepower_bounds
+get_bus_active_power_injectionss(pfd::PowerFlowData) = pfd.bus_active_power_injections
+get_bus_reactive_power_injectionss(pfd::PowerFlowData) = pfd.bus_reactive_power_injections
+get_bus_active_power_withdrawals(pfd::PowerFlowData) = pfd.bus_active_power_withdrawals
+get_bus_active_power_constant_current_withdrawals(pfd::PowerFlowData) =
+    pfd.bus_active_power_constant_current_withdrawals
+get_bus_active_power_constant_impedance_withdrawals(pfd::PowerFlowData) =
+    pfd.bus_active_power_constant_impedance_withdrawals
+get_bus_reactive_power_withdrawals(pfd::PowerFlowData) = pfd.bus_reactive_power_withdrawals
+get_bus_reactive_power_constant_current_withdrawals(pfd::PowerFlowData) =
+    pfd.bus_reactive_power_constant_current_withdrawals
+get_bus_reactive_power_constant_impedance_withdrawals(pfd::PowerFlowData) =
+    pfd.bus_reactive_power_constant_impedance_withdrawals
+get_bus_reactive_power_bounds(pfd::PowerFlowData) = pfd.bus_reactive_power_bounds
 get_bus_slack_participation_factors(pfd::PowerFlowData) =
     pfd.bus_slack_participation_factors
 get_generator_slack_participation_factors(pfd::PowerFlowData) =
@@ -187,15 +187,15 @@ get_generator_slack_participation_factors(pfd::PowerFlowData) =
 get_bus_type(pfd::PowerFlowData) = pfd.bus_type
 get_bus_magnitude(pfd::PowerFlowData) = pfd.bus_magnitude
 get_bus_angles(pfd::PowerFlowData) = pfd.bus_angles
-get_arc_activepower_flow_from_to(pfd::PowerFlowData) =
-    pfd.arc_activepower_flow_from_to
-get_arc_reactivepower_flow_from_to(pfd::PowerFlowData) =
-    pfd.arc_reactivepower_flow_from_to
-get_arc_activepower_flow_to_from(pfd::PowerFlowData) =
-    pfd.arc_activepower_flow_to_from
-get_arc_reactivepower_flow_to_from(pfd::PowerFlowData) =
-    pfd.arc_reactivepower_flow_to_from
-get_timestep_map(pfd::PowerFlowData) = pfd.timestep_map
+get_arc_active_power_flow_from_to(pfd::PowerFlowData) =
+    pfd.arc_active_power_flow_from_to
+get_arc_reactive_power_flow_from_to(pfd::PowerFlowData) =
+    pfd.arc_reactive_power_flow_from_to
+get_arc_active_power_flow_to_from(pfd::PowerFlowData) =
+    pfd.arc_active_power_flow_to_from
+get_arc_reactive_power_flow_to_from(pfd::PowerFlowData) =
+    pfd.arc_reactive_power_flow_to_from
+get_time_step_map(pfd::PowerFlowData) = pfd.time_step_map
 get_power_network_matrix(pfd::PowerFlowData) = pfd.power_network_matrix
 get_aux_network_matrix(pfd::PowerFlowData) = pfd.aux_network_matrix
 get_neighbor(pfd::PowerFlowData) = pfd.neighbors
@@ -275,30 +275,30 @@ bus_count(::DCPowerFlow,
     length(PNM.get_bus_axis(aux_network_matrix))
 
 """
-Sets the two `PowerNetworkMatrix` fields and a few others (`timesteps`, `timestep_map`), 
+Sets the two `PowerNetworkMatrix` fields and a few others (`time_steps`, `time_step_map`), 
 then creates arrays of default values (usually zeros) for the rest.
 """
 function PowerFlowData(
     pf::T,
     power_network_matrix::M,
     aux_network_matrix::N,
-    n_timesteps::Int,
+    n_time_steps::Int,
     n_lccs::Int;
-    timestep_names::Vector{String} = String[],
+    time_step_names::Vector{String} = String[],
     neighbors = Vector{Set{Int}}(),
 ) where {
     T <: PowerFlowEvaluationModel,
     M <: PNM.PowerNetworkMatrix,
     N <: Union{PNM.PowerNetworkMatrix, Nothing},
 }
-    if n_timesteps != 0
-        if length(timestep_names) == 0
-            timestep_names = [string(i) for i in 1:n_timesteps]
-        elseif length(timestep_names) != n_timesteps
-            error("timestep_names field must have same length as n_timesteps")
+    if n_time_steps != 0
+        if length(time_step_names) == 0
+            time_step_names = [string(i) for i in 1:n_time_steps]
+        elseif length(time_step_names) != n_time_steps
+            error("time_step_names field must have same length as n_time_steps")
         end
     end
-    timestep_map = Dict(zip([i for i in 1:n_timesteps], timestep_names))
+    time_step_map = Dict(zip([i for i in 1:n_time_steps], time_step_names))
 
     n_buses = bus_count(pf, power_network_matrix, aux_network_matrix)
     n_arcs = arc_count(pf, power_network_matrix, aux_network_matrix)
@@ -306,75 +306,75 @@ function PowerFlowData(
     calculate_voltage_stability_factors = get_calculate_voltage_stability_factors(pf)
     if !isnothing(get_slack_participation_factors(pf))
         empty_slack_participation_factors = Dict{Tuple{DataType, String}, Float64}[]
-        sizehint!(empty_slack_participation_factors, n_timesteps)
+        sizehint!(empty_slack_participation_factors, n_time_steps)
     else
         empty_slack_participation_factors = nothing
     end
 
-    lcc_parameters = LCCParameters(n_timesteps, n_lccs)
+    lcc_parameters = LCCParameters(n_time_steps, n_lccs)
     return PowerFlowData(
-        zeros(n_buses, n_timesteps), # bus_activepower_injection
-        zeros(n_buses, n_timesteps), # bus_reactivepower_injection
-        zeros(n_buses, n_timesteps), # bus_activepower_withdrawals
-        zeros(n_buses, n_timesteps), # bus_reactivepower_withdrawals
-        zeros(n_buses, n_timesteps), # bus_activepower_constant_current_withdrawals
-        zeros(n_buses, n_timesteps), # bus_reactivepower_constant_current_withdrawals
-        zeros(n_buses, n_timesteps), # bus_activepower_constant_impedance_withdrawals
-        zeros(n_buses, n_timesteps), # bus_reactivepower_constant_impedance_withdrawals
-        fill((-Inf, Inf), (n_buses, n_timesteps)), # bus_reactivepower_bounds
+        zeros(n_buses, n_time_steps), # bus_active_power_injections
+        zeros(n_buses, n_time_steps), # bus_reactive_power_injections
+        zeros(n_buses, n_time_steps), # bus_active_power_withdrawals
+        zeros(n_buses, n_time_steps), # bus_reactive_power_withdrawals
+        zeros(n_buses, n_time_steps), # bus_active_power_constant_current_withdrawals
+        zeros(n_buses, n_time_steps), # bus_reactive_power_constant_current_withdrawals
+        zeros(n_buses, n_time_steps), # bus_active_power_constant_impedance_withdrawals
+        zeros(n_buses, n_time_steps), # bus_reactive_power_constant_impedance_withdrawals
+        fill((-Inf, Inf), (n_buses, n_time_steps)), # bus_reactive_power_bounds
         empty_slack_participation_factors, # generator_slack_participation_factors
-        spzeros(n_buses, n_timesteps), # bus_slack_participation_factors
-        fill(PSY.ACBusTypes.PQ, (n_buses, n_timesteps)), # bus_type
-        ones(n_buses, n_timesteps), # bus_magnitude
-        zeros(n_buses, n_timesteps), # bus_angles
-        zeros(n_arcs, n_timesteps), # arc_activepower_flow_from_to
-        zeros(n_arcs, n_timesteps), # arc_reactivepower_flow_from_to
-        zeros(n_arcs, n_timesteps), # arc_activepower_flow_to_from
-        zeros(n_arcs, n_timesteps), # arc_reactivepower_flow_to_from
+        spzeros(n_buses, n_time_steps), # bus_slack_participation_factors
+        fill(PSY.ACBusTypes.PQ, (n_buses, n_time_steps)), # bus_type
+        ones(n_buses, n_time_steps), # bus_magnitude
+        zeros(n_buses, n_time_steps), # bus_angles
+        zeros(n_arcs, n_time_steps), # arc_active_power_flow_from_to
+        zeros(n_arcs, n_time_steps), # arc_reactive_power_flow_from_to
+        zeros(n_arcs, n_time_steps), # arc_active_power_flow_to_from
+        zeros(n_arcs, n_time_steps), # arc_reactive_power_flow_to_from
         Dict{Tuple{Int, Int}, Tuple{Float64, Float64}}(), # generic_hvdc_flows
-        zeros(n_buses, n_timesteps), # bus_hvdc_net_power
-        timestep_map,
+        zeros(n_buses, n_time_steps), # bus_hvdc_net_power
+        time_step_map,
         power_network_matrix,
         aux_network_matrix,
         neighbors,
-        falses(n_timesteps), # converged
-        calculate_loss_factors ? zeros(n_buses, n_timesteps) : nothing, # loss_factors
+        falses(n_time_steps), # converged
+        calculate_loss_factors ? zeros(n_buses, n_time_steps) : nothing, # loss_factors
         calculate_loss_factors,
-        calculate_voltage_stability_factors ? zeros(n_buses, n_timesteps) : nothing, # voltage_stability_factors
+        calculate_voltage_stability_factors ? zeros(n_buses, n_time_steps) : nothing, # voltage_stability_factors
         calculate_voltage_stability_factors,
         lcc_parameters,
     )
 end
 
-function get_bus_activepower_total_withdrawals(pfd::PowerFlowData, ix::Int, time_step::Int)
-    return pfd.bus_activepower_withdrawals[ix, time_step] +
-           pfd.bus_activepower_constant_current_withdrawals[ix, time_step] *
+function get_bus_active_power_total_withdrawals(pfd::PowerFlowData, ix::Int, time_step::Int)
+    return pfd.bus_active_power_withdrawals[ix, time_step] +
+           pfd.bus_active_power_constant_current_withdrawals[ix, time_step] *
            pfd.bus_magnitude[ix, time_step] +
-           pfd.bus_activepower_constant_impedance_withdrawals[ix, time_step] *
+           pfd.bus_active_power_constant_impedance_withdrawals[ix, time_step] *
            pfd.bus_magnitude[ix, time_step]^2
 end
 
-function get_bus_reactivepower_total_withdrawals(
+function get_bus_reactive_power_total_withdrawals(
     pfd::PowerFlowData,
     ix::Int,
     time_step::Int,
 )
-    return pfd.bus_reactivepower_withdrawals[ix, time_step] +
-           pfd.bus_reactivepower_constant_current_withdrawals[ix, time_step] *
+    return pfd.bus_reactive_power_withdrawals[ix, time_step] +
+           pfd.bus_reactive_power_constant_current_withdrawals[ix, time_step] *
            pfd.bus_magnitude[ix, time_step] +
-           pfd.bus_reactivepower_constant_impedance_withdrawals[ix, time_step] *
+           pfd.bus_reactive_power_constant_impedance_withdrawals[ix, time_step] *
            pfd.bus_magnitude[ix, time_step]^2
 end
 
 function clear_injection_data!(pfd::PowerFlowData)
-    pfd.bus_activepower_injection .= 0.0
-    pfd.bus_reactivepower_injection .= 0.0
-    pfd.bus_activepower_withdrawals .= 0.0
-    pfd.bus_activepower_constant_current_withdrawals .= 0.0
-    pfd.bus_activepower_constant_impedance_withdrawals .= 0.0
-    pfd.bus_reactivepower_withdrawals .= 0.0
-    pfd.bus_reactivepower_constant_current_withdrawals .= 0.0
-    pfd.bus_reactivepower_constant_impedance_withdrawals .= 0.0
+    pfd.bus_active_power_injections .= 0.0
+    pfd.bus_reactive_power_injections .= 0.0
+    pfd.bus_active_power_withdrawals .= 0.0
+    pfd.bus_active_power_constant_current_withdrawals .= 0.0
+    pfd.bus_active_power_constant_impedance_withdrawals .= 0.0
+    pfd.bus_reactive_power_withdrawals .= 0.0
+    pfd.bus_reactive_power_constant_current_withdrawals .= 0.0
+    pfd.bus_reactive_power_constant_impedance_withdrawals .= 0.0
     return
 end
 
@@ -410,13 +410,13 @@ function network_reduction_message(
     return
 end
 
-function make_and_initialize_powerflow_data(
+function make_and_initialize_power_flow_data(
     pf::PowerFlowEvaluationModel,
     sys::PSY.System,
     power_network_matrix::M,
     aux_network_matrix::N;
     time_steps::Int = 1,
-    timestep_names::Vector{String} = String[],
+    time_step_names::Vector{String} = String[],
     neighbors = Vector{Set{Int}}(),
     correct_bustypes::Bool = false,
 ) where {M <: PNM.PowerNetworkMatrix, N <: Union{PNM.PowerNetworkMatrix, Nothing}}
@@ -428,11 +428,11 @@ function make_and_initialize_powerflow_data(
         aux_network_matrix,
         time_steps,
         n_lccs;
-        timestep_names = timestep_names,
+        time_step_names = time_step_names,
         neighbors = neighbors,
     )
     @assert length(data.lcc.setpoint_at_rectifier) == n_lccs
-    initialize_powerflow_data!(data, pf, sys; correct_bustypes = correct_bustypes)
+    initialize_power_flow_data!(data, pf, sys; correct_bustypes = correct_bustypes)
     return data
 end
 
@@ -441,7 +441,7 @@ end
         pf::ACPowerFlow{<:ACPowerFlowSolverType},
         sys::PSY.System;
         time_steps::Int = 1,
-        timestep_names::Vector{String} = String[],
+        time_step_names::Vector{String} = String[],
         check_connectivity::Bool = true
     ) -> ACPowerFlowData{<:ACPowerFlowSolverType} 
 
@@ -451,7 +451,7 @@ consider, and their names.
 
 Calling this function will not evaluate the power flows and angles.
 Note that first input is of type [`ACPowerFlow`](@ref): this version is used to solve 
-AC powerflows, and returns an [`ACPowerFlowData`](@ref) object.
+AC power_flows, and returns an [`ACPowerFlowData`](@ref) object.
 
 # Arguments:
 - [`pf::ACPowerFlow`](@ref ACPowerFlow):
@@ -463,7 +463,7 @@ AC powerflows, and returns an [`ACPowerFlowData`](@ref) object.
         number of time periods to consider in the `PowerFlowData` structure. It
         defines the number of columns of the matrices used to store data.
         Default value = `1`.
-- `timestep_names::Vector{String}`:
+- `time_step_names::Vector{String}`:
         names of the time periods defined by the argument `time_steps`. Default
         value = `String[]`.
 - `check_connectivity::Bool`:
@@ -476,7 +476,7 @@ function PowerFlowData(
     sys::PSY.System;
     network_reductions::Vector{PNM.NetworkReduction} = Vector{PNM.NetworkReduction}(),
     time_steps::Int = 1,
-    timestep_names::Vector{String} = String[],
+    time_step_names::Vector{String} = String[],
     correct_bustypes::Bool = false,
 )
     network_reduction_message(network_reductions, pf)
@@ -495,13 +495,13 @@ function PowerFlowData(
         aux_network_matrix = nothing
     end
 
-    return make_and_initialize_powerflow_data(
+    return make_and_initialize_power_flow_data(
         pf,
         sys,
         power_network_matrix,
         aux_network_matrix;
         time_steps = time_steps,
-        timestep_names = timestep_names,
+        time_step_names = time_step_names,
         neighbors = neighbors,
         correct_bustypes = correct_bustypes,
     )
@@ -513,7 +513,7 @@ end
         ::DCPowerFlow,
         sys::PSY.System;
         time_steps::Int = 1,
-        timestep_names::Vector{String} = String[],
+        time_step_names::Vector{String} = String[],
         check_connectivity::Bool = true
     ) -> ABAPowerFlowData
 
@@ -523,11 +523,11 @@ consider, and their names.
 
 Calling this function will not evaluate the power flows and angles.
 Note that first input is of type [`DCPowerFlow`](@ref): this version is 
-used to solve DC powerflows, and returns an [`ABAPowerFlowData`](@ref) object.
+used to solve DC power_flows, and returns an [`ABAPowerFlowData`](@ref) object.
 
 # Arguments:
 - [`::DCPowerFlow`](@ref PowerFlows.DCPowerFlow):
-        Run a DC powerflow: internally, store the ABA matrix as `power_network_matrix` and
+        Run a DC power_flow: internally, store the ABA matrix as `power_network_matrix` and
         the BA matrix as `aux_network_matrix`.
 - `sys::PSY.System`:
         A [`System`](@extref PowerSystems.System) object that represents the power 
@@ -536,7 +536,7 @@ used to solve DC powerflows, and returns an [`ABAPowerFlowData`](@ref) object.
         number of time periods to consider in the `PowerFlowData` structure. It
         defines the number of columns of the matrices used to store data.
         Default value = `1`.
-- `timestep_names::Vector{String}`:
+- `time_step_names::Vector{String}`:
         names of the time periods defined by the argument `time_steps`. Default
         value = `String[]`.
 - `check_connectivity::Bool`:
@@ -547,7 +547,7 @@ function PowerFlowData(
     sys::PSY.System;
     network_reductions::Vector{PNM.NetworkReduction} = Vector{PNM.NetworkReduction}(),
     time_steps::Int = 1,
-    timestep_names::Vector{String} = String[],
+    time_step_names::Vector{String} = String[],
     correct_bustypes = false,
 )
     network_reduction_message(network_reductions, DCPowerFlow())
@@ -555,13 +555,13 @@ function PowerFlowData(
     power_network_matrix =
         PNM.ABA_Matrix(sys; factorize = true, network_reductions = network_reductions)
     aux_network_matrix = PNM.BA_Matrix(sys; network_reductions = network_reductions)
-    return make_and_initialize_powerflow_data(
+    return make_and_initialize_power_flow_data(
         pf,
         sys,
         power_network_matrix,
         aux_network_matrix;
         time_steps = time_steps,
-        timestep_names = timestep_names,
+        time_step_names = time_step_names,
         correct_bustypes = correct_bustypes,
     )
 end
@@ -572,7 +572,7 @@ end
         ::PTDFDCPowerFlow,
         sys::PSY.System;
         time_steps::Int = 1,
-        timestep_names::Vector{String} = String[]
+        time_step_names::Vector{String} = String[]
     ) -> PTDFPowerFlowData
 
 Creates a `PowerFlowData` structure configured for a Partial Transfer 
@@ -582,12 +582,12 @@ consider, and their names.
 
 Calling this function will not evaluate the power flows and angles.
 Note that first input is of type [`PTDFDCPowerFlow`](@ref): this version is used to solve 
-DC powerflows via the Power Transfer Distribution Factor (PTDF) matrix. This function 
+DC power_flows via the Power Transfer Distribution Factor (PTDF) matrix. This function 
 returns an [`PTDFPowerFlowData`](@ref) object.
 
 # Arguments:
 - [`::PTDFDCPowerFlow`](@ref PowerFlows.PTDFDCPowerFlow):
-        Run a DC powerflow with PTDF matrix: internally, store the PTDF matrix
+        Run a DC power_flow with PTDF matrix: internally, store the PTDF matrix
         as `power_network_matrix` and the ABA matrix as `aux_network_matrix`.
 - `sys::PSY.System`:
         A [`System`](@extref PowerSystems.System) object that represents the power 
@@ -596,7 +596,7 @@ returns an [`PTDFPowerFlowData`](@ref) object.
         number of time periods to consider in the `PowerFlowData` structure. It
         defines the number of columns of the matrices used to store data.
         Default value = `1`.
-- `timestep_names::Vector{String}`:
+- `time_step_names::Vector{String}`:
         names of the time periods defined by the argument `time_steps`. Default
         value = `String[]`.
 """
@@ -605,7 +605,7 @@ function PowerFlowData(
     sys::PSY.System;
     network_reductions::Vector{PNM.NetworkReduction} = Vector{PNM.NetworkReduction}(),
     time_steps::Int = 1,
-    timestep_names::Vector{String} = String[],
+    time_step_names::Vector{String} = String[],
     correct_bustypes = false,
 )
     network_reduction_message(network_reductions, PTDFDCPowerFlow())
@@ -613,13 +613,13 @@ function PowerFlowData(
     power_network_matrix = PNM.PTDF(sys; network_reductions = network_reductions)
     aux_network_matrix =
         PNM.ABA_Matrix(sys; factorize = true, network_reductions = network_reductions)
-    return make_and_initialize_powerflow_data(
+    return make_and_initialize_power_flow_data(
         pf,
         sys,
         power_network_matrix,
         aux_network_matrix;
         time_steps = time_steps,
-        timestep_names = timestep_names,
+        time_step_names = time_step_names,
         correct_bustypes = correct_bustypes,
     )
 end
@@ -630,7 +630,7 @@ end
         ::vPTDFDCPowerFlow,
         sys::PSY.System;
         time_steps::Int = 1,
-        timestep_names::Vector{String} = String[]
+        time_step_names::Vector{String} = String[]
     ) -> vPTDFPowerFlowData
 
 Creates a `PowerFlowData` structure configured for a virtual Partial Transfer 
@@ -640,14 +640,14 @@ their names.
 
 Calling this function will not evaluate the power flows and angles.
 Note that first input is of type [`vPTDFDCPowerFlow`](@ref): this version is used to solve 
-DC powerflows using a virtual Power Transfer Distribution Factor (PTDF) matrix. This 
+DC power_flows using a virtual Power Transfer Distribution Factor (PTDF) matrix. This 
 function returns a [`vPTDFPowerFlowData`](@ref) object.
 
 For internal usage: generally, do not construct this directly.
 
 # Arguments:
 - [`::PTDFDCPowerFlow`](@ref PTDFDCPowerFlow):
-        Run a virtual PTDF powerflow: internally, store the virtual PTDF matrix
+        Run a virtual PTDF power_flow: internally, store the virtual PTDF matrix
         `power_network_matrix` and the ABA matrix as `aux_network_matrix`.
 - `sys::PSY.System`:
         A [`System`](@extref PowerSystems.System) object that represents the power 
@@ -656,7 +656,7 @@ For internal usage: generally, do not construct this directly.
         number of time periods to consider in the PowerFlowData structure. It
         defines the number of columns of the matrices used to store data.
         Default value = `1`.
-- `timestep_names::Vector{String}`:
+- `time_step_names::Vector{String}`:
         names of the time periods defined by the argument "time_steps". Default
         value = `String[]`.
 """
@@ -665,7 +665,7 @@ function PowerFlowData(
     sys::PSY.System;
     network_reductions::Vector{PNM.NetworkReduction} = Vector{PNM.NetworkReduction}(),
     time_steps::Int = 1,
-    timestep_names::Vector{String} = String[],
+    time_step_names::Vector{String} = String[],
     correct_bustypes = false)
     network_reduction_message(network_reductions, vPTDFDCPowerFlow())
 
@@ -674,13 +674,13 @@ function PowerFlowData(
     aux_network_matrix =
         PNM.ABA_Matrix(sys; factorize = true, network_reductions = network_reductions)
 
-    return make_and_initialize_powerflow_data(
+    return make_and_initialize_power_flow_data(
         pf,
         sys,
         power_network_matrix,
         aux_network_matrix;
         time_steps = time_steps,
-        timestep_names = timestep_names,
+        time_step_names = time_step_names,
         correct_bustypes = correct_bustypes,
     )
 end
@@ -693,7 +693,7 @@ Create an appropriate `PowerFlowContainer` for the given `PowerFlowEvaluationMod
 - `sys::PSY.System`: the [System](@extref PowerSystems.System) from which to initialize the 
     power flow container
 - `time_steps::Int`: number of time periods to consider (default is `1`)
-- `timestep_names::Vector{String}`: names of the time periods defines by the argument "time_steps". Default value is `String[]`.
+- `time_step_names::Vector{String}`: names of the time periods defines by the argument "time_steps". Default value is `String[]`.
 """
 function make_power_flow_container end
 

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -1,6 +1,6 @@
 module PowerFlows
 
-export solve_powerflow
+export solve_power_flow
 export solve_and_store_power_flow!
 export DCPowerFlow
 export NewtonRaphsonACPowerFlow
@@ -19,7 +19,7 @@ export update_exporter!
 export write_export
 export get_psse_export_paths
 # "protected" (semi-stable because used in PSI) but not exported:
-# PowerFlowData and related type aliases, solve_powerflow!, write_results
+# PowerFlowData and related type aliases, solve_power_flow!, write_results
 
 import Base: @kwdef
 import Logging
@@ -49,22 +49,22 @@ const PNM = PowerNetworkMatrices
 include("definitions.jl")
 include("psi_utils.jl")
 include("powersystems_utils.jl")
-include("powerflow_types.jl")
+include("power_flow_types.jl")
 include("lcc_parameters.jl")
 include("PowerFlowData.jl")
 include("lcc_utils.jl")
 include("common.jl")
-include("initialize_powerflow_data.jl")
+include("initialize_power_flow_data.jl")
 include("psse_export.jl")
 include("LinearSolverCache/linear_solver_cache.jl")
 include("LinearSolverCache/klu_linear_solver.jl")
-include("solve_dc_powerflow.jl")
+include("solve_dc_power_flow.jl")
 include("state_indexing_helpers.jl")
 include("ac_power_flow_residual.jl")
 include("ac_power_flow_jacobian.jl")
-include("solve_ac_powerflow.jl")
-include("powerflow_setup.jl")
-include("powerflow_method.jl")
+include("solve_ac_power_flow.jl")
+include("power_flow_setup.jl")
+include("power_flow_method.jl")
 include("levenberg-marquardt.jl")
 include("post_processing.jl")
 include("RobustHomotopy/HessianSolver/hessian_solver.jl")

--- a/src/RobustHomotopy/robust_homotopy_method.jl
+++ b/src/RobustHomotopy/robust_homotopy_method.jl
@@ -1,4 +1,4 @@
-function _newton_powerflow(pf::ACPowerFlow{<:RobustHomotopyPowerFlow},
+function _newton_power_flow(pf::ACPowerFlow{<:RobustHomotopyPowerFlow},
     data::ACPowerFlowData,
     time_step::Int64;
     kwargs...)

--- a/src/ac_power_flow_residual.jl
+++ b/src/ac_power_flow_residual.jl
@@ -56,12 +56,12 @@ function ACPowerFlowResidual(data::ACPowerFlowData, time_step::Int64)
 
     for (ix, bt) in zip(1:n_buses, bus_type)
         P_net[ix] =
-            data.bus_activepower_injection[ix, time_step] -
-            get_bus_activepower_total_withdrawals(data, ix, time_step) +
+            data.bus_active_power_injections[ix, time_step] -
+            get_bus_active_power_total_withdrawals(data, ix, time_step) +
             data.bus_hvdc_net_power[ix, time_step]
         Q_net[ix] =
-            data.bus_reactivepower_injection[ix, time_step] -
-            get_bus_reactivepower_total_withdrawals(data, ix, time_step)
+            data.bus_reactive_power_injections[ix, time_step] -
+            get_bus_reactive_power_total_withdrawals(data, ix, time_step)
         P_net_set[ix] = P_net[ix]
 
         bt ∈ (PSY.ACBusTypes.REF, PSY.ACBusTypes.PV) || continue
@@ -79,7 +79,7 @@ function ACPowerFlowResidual(data::ACPowerFlowData, time_step::Int64)
         throw(ArgumentError("slack_participation_factors cannot be negative"))
     end
 
-    # sum_sl_weights could differ from the sum of the timestep column of 
+    # sum_sl_weights could differ from the sum of the time_step column of 
     # slack participation factors: maybe a PV bus with nonzero weight got switched to PQ.
 
     # bus slack participation factors relevant for the current time step:
@@ -181,11 +181,11 @@ function _setpq(
 )
     # Set the active and reactive power injections at the bus. 
     # same equation as in the constructor, just solved for bus injection instead of P/Q_net.
-    data.bus_activepower_injection[ix, time_step] =
-        P_net[ix] + get_bus_activepower_total_withdrawals(data, ix, time_step) -
+    data.bus_active_power_injections[ix, time_step] =
+        P_net[ix] + get_bus_active_power_total_withdrawals(data, ix, time_step) -
         data.bus_hvdc_net_power[ix, time_step]
-    data.bus_reactivepower_injection[ix, time_step] =
-        Q_net[ix] + get_bus_reactivepower_total_withdrawals(data, ix, time_step)
+    data.bus_reactive_power_injections[ix, time_step] =
+        Q_net[ix] + get_bus_reactive_power_total_withdrawals(data, ix, time_step)
 end
 
 # dispatching on Val for performance reasons.
@@ -253,12 +253,12 @@ function _set_state_variables_at_bus!(
     data.bus_angles[ix, time_step] = StateVector[2 * ix]
     # update P_net and Q_net for ZIP loads
     P_net[ix] +=
-        data.bus_activepower_constant_current_withdrawals[ix, time_step] * (vm_1 - vm_2) +
-        data.bus_activepower_constant_impedance_withdrawals[ix, time_step] *
+        data.bus_active_power_constant_current_withdrawals[ix, time_step] * (vm_1 - vm_2) +
+        data.bus_active_power_constant_impedance_withdrawals[ix, time_step] *
         (vm_1^2 - vm_2^2)
     Q_net[ix] +=
-        data.bus_reactivepower_constant_current_withdrawals[ix, time_step] * (vm_1 - vm_2) +
-        data.bus_reactivepower_constant_impedance_withdrawals[ix, time_step] *
+        data.bus_reactive_power_constant_current_withdrawals[ix, time_step] * (vm_1 - vm_2) +
+        data.bus_reactive_power_constant_impedance_withdrawals[ix, time_step] *
         (vm_1^2 - vm_2^2)
     # set the active and reactive power injections at the bus
     _setpq(

--- a/src/ac_power_flow_residual.jl
+++ b/src/ac_power_flow_residual.jl
@@ -257,7 +257,8 @@ function _set_state_variables_at_bus!(
         data.bus_active_power_constant_impedance_withdrawals[ix, time_step] *
         (vm_1^2 - vm_2^2)
     Q_net[ix] +=
-        data.bus_reactive_power_constant_current_withdrawals[ix, time_step] * (vm_1 - vm_2) +
+        data.bus_reactive_power_constant_current_withdrawals[ix, time_step] *
+        (vm_1 - vm_2) +
         data.bus_reactive_power_constant_impedance_withdrawals[ix, time_step] *
         (vm_1^2 - vm_2^2)
     # set the active and reactive power injections at the bus

--- a/src/initialize_power_flow_data.jl
+++ b/src/initialize_power_flow_data.jl
@@ -1,7 +1,7 @@
 """
 Sets the fields of a PowerFlowData struct to match the given System.
 """
-function initialize_powerflow_data!(
+function initialize_power_flow_data!(
     data::PowerFlowData,
     pf::PowerFlowEvaluationModel,
     sys::System;
@@ -36,61 +36,61 @@ function initialize_powerflow_data!(
     data.bus_magnitude[:, 1] .= bus_magnitude
 
     # active, reactive power injections, withdrawals
-    bus_activepower_injection = zeros(Float64, n_buses)
-    bus_reactivepower_injection = zeros(Float64, n_buses)
+    bus_active_power_injections = zeros(Float64, n_buses)
+    bus_reactive_power_injections = zeros(Float64, n_buses)
     _get_injections!(
         pf,
-        bus_activepower_injection,
-        bus_reactivepower_injection,
+        bus_active_power_injections,
+        bus_reactive_power_injections,
         bus_lookup,
         reverse_bus_search_map,
         sys,
     )
-    data.bus_activepower_injection[:, 1] .= bus_activepower_injection
-    data.bus_reactivepower_injection[:, 1] .= bus_reactivepower_injection
+    data.bus_active_power_injections[:, 1] .= bus_active_power_injections
+    data.bus_reactive_power_injections[:, 1] .= bus_reactive_power_injections
 
     # active power withdrawals, constant current and impedance withdrawals
-    bus_activepower_withdrawals = zeros(Float64, n_buses)
-    bus_reactivepower_withdrawals = zeros(Float64, n_buses)
-    bus_activepower_constant_current_withdrawals = zeros(Float64, n_buses)
-    bus_reactivepower_constant_current_withdrawals = zeros(Float64, n_buses)
-    bus_activepower_constant_impedance_withdrawals = zeros(Float64, n_buses)
-    bus_reactivepower_constant_impedance_withdrawals = zeros(Float64, n_buses)
+    bus_active_power_withdrawals = zeros(Float64, n_buses)
+    bus_reactive_power_withdrawals = zeros(Float64, n_buses)
+    bus_active_power_constant_current_withdrawals = zeros(Float64, n_buses)
+    bus_reactive_power_constant_current_withdrawals = zeros(Float64, n_buses)
+    bus_active_power_constant_impedance_withdrawals = zeros(Float64, n_buses)
+    bus_reactive_power_constant_impedance_withdrawals = zeros(Float64, n_buses)
     _get_withdrawals!(
         pf,
-        bus_activepower_withdrawals,
-        bus_reactivepower_withdrawals,
-        bus_activepower_constant_current_withdrawals,
-        bus_reactivepower_constant_current_withdrawals,
-        bus_activepower_constant_impedance_withdrawals,
-        bus_reactivepower_constant_impedance_withdrawals,
+        bus_active_power_withdrawals,
+        bus_reactive_power_withdrawals,
+        bus_active_power_constant_current_withdrawals,
+        bus_reactive_power_constant_current_withdrawals,
+        bus_active_power_constant_impedance_withdrawals,
+        bus_reactive_power_constant_impedance_withdrawals,
         bus_lookup,
         reverse_bus_search_map,
         sys,
     )
-    data.bus_activepower_withdrawals[:, 1] .= bus_activepower_withdrawals
-    data.bus_reactivepower_withdrawals[:, 1] .= bus_reactivepower_withdrawals
-    data.bus_activepower_constant_current_withdrawals[:, 1] .=
-        bus_activepower_constant_current_withdrawals
-    data.bus_reactivepower_constant_current_withdrawals[:, 1] .=
-        bus_reactivepower_constant_current_withdrawals
-    data.bus_activepower_constant_impedance_withdrawals[:, 1] .=
-        bus_activepower_constant_impedance_withdrawals
-    data.bus_reactivepower_constant_impedance_withdrawals[:, 1] .=
-        bus_reactivepower_constant_impedance_withdrawals
+    data.bus_active_power_withdrawals[:, 1] .= bus_active_power_withdrawals
+    data.bus_reactive_power_withdrawals[:, 1] .= bus_reactive_power_withdrawals
+    data.bus_active_power_constant_current_withdrawals[:, 1] .=
+        bus_active_power_constant_current_withdrawals
+    data.bus_reactive_power_constant_current_withdrawals[:, 1] .=
+        bus_reactive_power_constant_current_withdrawals
+    data.bus_active_power_constant_impedance_withdrawals[:, 1] .=
+        bus_active_power_constant_impedance_withdrawals
+    data.bus_reactive_power_constant_impedance_withdrawals[:, 1] .=
+        bus_reactive_power_constant_impedance_withdrawals
 
     # reactive power bounds
-    bus_reactivepower_bounds = Vector{Tuple{Float64, Float64}}(undef, n_buses)
+    bus_reactive_power_bounds = Vector{Tuple{Float64, Float64}}(undef, n_buses)
     for i in 1:n_buses
-        bus_reactivepower_bounds[i] = (0.0, 0.0)
+        bus_reactive_power_bounds[i] = (0.0, 0.0)
     end
     _get_reactive_power_bound!(
-        bus_reactivepower_bounds,
+        bus_reactive_power_bounds,
         bus_lookup,
         reverse_bus_search_map,
         sys,
     )
-    data.bus_reactivepower_bounds[:, 1] .= bus_reactivepower_bounds
+    data.bus_reactive_power_bounds[:, 1] .= bus_reactive_power_bounds
 
     # bus/generator participation factors
     # remark: everything after the 3rd argument here is contained inside data.
@@ -100,12 +100,12 @@ function initialize_powerflow_data!(
         get_slack_participation_factors(pf),
         bus_lookup,
         reverse_bus_search_map,
-        length(data.timestep_map),
+        length(data.time_step_map),
         n_buses,
         data.bus_type,
     )
     # LCCs: initialize parameters. For DC power flow, this also writes the fixed flows to
-    # data.lcc.arc_activepower_flow_from_to and data.lcc.arc_activepower_flow_to_from.
+    # data.lcc.arc_active_power_flow_from_to and data.lcc.arc_active_power_flow_to_from.
     initialize_LCCParameters!(data, sys, bus_lookup, reverse_bus_search_map)
     # LCCs, DC only: accumulate net power into bus_hvdc_net_power.
     lcc_fixed_injections!(data, sys, bus_lookup, reverse_bus_search_map)

--- a/src/lcc_parameters.jl
+++ b/src/lcc_parameters.jl
@@ -7,11 +7,11 @@ struct LCCConverterParameters
     min_thyristor_angle::Vector{Float64}
 end
 
-LCCConverterParameters(n_timesteps::Int, n_lccs::Int) = LCCConverterParameters(
+LCCConverterParameters(n_time_steps::Int, n_lccs::Int) = LCCConverterParameters(
     zeros(Int, n_lccs),
-    zeros(Float64, n_lccs, n_timesteps),
-    zeros(Float64, n_lccs, n_timesteps),
-    zeros(Float64, n_lccs, n_timesteps),
+    zeros(Float64, n_lccs, n_time_steps),
+    zeros(Float64, n_lccs, n_time_steps),
+    zeros(Float64, n_lccs, n_time_steps),
     zeros(Float64, n_lccs),
     zeros(Float64, n_lccs),
 )
@@ -26,10 +26,10 @@ struct LCCParameters
     bus_indices::Vector{Tuple{Int, Int}}
     # (y_ff, y_tt) admittance pairs
     branch_admittances::Vector{Tuple{ComplexF64, ComplexF64}}
-    arc_activepower_flow_from_to::Matrix{Float64}
-    arc_activepower_flow_to_from::Matrix{Float64}
-    arc_reactivepower_flow_from_to::Matrix{Float64}
-    arc_reactivepower_flow_to_from::Matrix{Float64}
+    arc_active_power_flow_from_to::Matrix{Float64}
+    arc_active_power_flow_to_from::Matrix{Float64}
+    arc_reactive_power_flow_from_to::Matrix{Float64}
+    arc_reactive_power_flow_to_from::Matrix{Float64}
     setpoint_at_rectifier::Vector{Bool}
     p_set::Matrix{Float64}
     i_dc::Matrix{Float64}
@@ -38,18 +38,18 @@ struct LCCParameters
     inverter::LCCConverterParameters
 end
 
-LCCParameters(n_timesteps::Int, n_lccs::Int) = LCCParameters(
+LCCParameters(n_time_steps::Int, n_lccs::Int) = LCCParameters(
     fill((-1, -1), n_lccs),
     fill((-1, -1), n_lccs),
     fill((0, 0), n_lccs),
-    zeros(Float64, n_lccs, n_timesteps),
-    zeros(Float64, n_lccs, n_timesteps),
-    zeros(Float64, n_lccs, n_timesteps),
-    zeros(Float64, n_lccs, n_timesteps),
+    zeros(Float64, n_lccs, n_time_steps),
+    zeros(Float64, n_lccs, n_time_steps),
+    zeros(Float64, n_lccs, n_time_steps),
+    zeros(Float64, n_lccs, n_time_steps),
     falses(n_lccs),
-    zeros(Float64, n_lccs, n_timesteps),
-    zeros(Float64, n_lccs, n_timesteps),
+    zeros(Float64, n_lccs, n_time_steps),
+    zeros(Float64, n_lccs, n_time_steps),
     zeros(Float64, n_lccs),
-    LCCConverterParameters(n_timesteps, n_lccs),
-    LCCConverterParameters(n_timesteps, n_lccs),
+    LCCConverterParameters(n_time_steps, n_lccs),
+    LCCConverterParameters(n_time_steps, n_lccs),
 )

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -150,8 +150,8 @@ function initialize_LCCParameters!(
     for (i, lcc_branch) in enumerate(lccs)
         # it's an LCC, so flow can't be reversed; rhs will error if it is.
         (P_from_to, P_to_from, _) = get_hvdc_power_loss(lcc_branch, sys)
-        data.lcc.arc_activepower_flow_from_to[i, :] .= P_from_to
-        data.lcc.arc_activepower_flow_to_from[i, :] .= P_to_from
+        data.lcc.arc_active_power_flow_from_to[i, :] .= P_from_to
+        data.lcc.arc_active_power_flow_to_from[i, :] .= P_to_from
     end
     return
 end

--- a/src/levenberg-marquardt.jl
+++ b/src/levenberg-marquardt.jl
@@ -1,17 +1,17 @@
 """Driver for the LevenbergMarquardtACPowerFlow method: sets up the data 
-structures (e.g. residual), runs the powerflow method via calling `_run_powerflow_method` 
+structures (e.g. residual), runs the power_flow method via calling `_run_power_flow_method` 
 on them, then handles post-processing (e.g. loss factors)."""
-function _newton_powerflow(
+function _newton_power_flow(
     pf::ACPowerFlow{LevenbergMarquardtACPowerFlow},
     data::ACPowerFlowData,
     time_step::Int64;
     kwargs...,
 )
-    residual, J, x0 = initialize_powerflow_variables(pf, data, time_step; kwargs...)
+    residual, J, x0 = initialize_power_flow_variables(pf, data, time_step; kwargs...)
     converged = norm(residual.Rv, Inf) < get(kwargs, :tol, DEFAULT_NR_TOL)
     i = 0
     if !converged
-        converged, i = _run_powerflow_method(
+        converged, i = _run_power_flow_method(
             time_step,
             x0,
             residual,
@@ -36,7 +36,7 @@ function _newton_powerflow(
     return false
 end
 
-function _run_powerflow_method(
+function _run_power_flow_method(
     time_step::Int,
     x::Vector{Float64},
     residual::ACPowerFlowResidual,

--- a/src/power_flow_method.jl
+++ b/src/power_flow_method.jl
@@ -292,7 +292,7 @@ end
 - `refinement_eps::Float64`: run iterative refinement on `J_x Δx = r` until
     `norm(Δx_{i}-Δx_{i+1}, 1)/norm(r,1) < refinement_eps`. Default: 
     $DEFAULT_REFINEMENT_EPS """
-function _run_powerflow_method(time_step::Int,
+function _run_power_flow_method(time_step::Int,
     stateVector::StateVectorCache,
     linSolveCache::KLULinSolveCache{Int32},
     residual::ACPowerFlowResidual,
@@ -346,7 +346,7 @@ end
 - `eta::Float64`: improvement threshold. If the observed improvement in our residual
     exceeds `eta` times the predicted improvement, we accept the new `x_i`.
     Default: $DEFAULT_TRUST_REGION_ETA."""
-function _run_powerflow_method(time_step::Int,
+function _run_power_flow_method(time_step::Int,
     stateVector::StateVectorCache,
     linSolveCache::KLULinSolveCache{Int32},
     residual::ACPowerFlowResidual,
@@ -410,14 +410,14 @@ function _run_powerflow_method(time_step::Int,
     return converged, i
 end
 
-function _newton_powerflow(
+function _newton_power_flow(
     pf::ACPowerFlow{T},
     data::ACPowerFlowData,
     time_step::Int64;
     kwargs...) where {T <: Union{TrustRegionACPowerFlow, NewtonRaphsonACPowerFlow}}
 
     # setup: common code
-    residual, J, x0 = initialize_powerflow_variables(pf, data, time_step; kwargs...)
+    residual, J, x0 = initialize_power_flow_variables(pf, data, time_step; kwargs...)
     converged = norm(residual.Rv, Inf) < get(kwargs, :tol, DEFAULT_NR_TOL)
 
     i = 0
@@ -425,7 +425,7 @@ function _newton_powerflow(
         linSolveCache = KLULinSolveCache(J.Jv)
         symbolic_factor!(linSolveCache, J.Jv)
         stateVector = StateVectorCache(x0, residual.Rv)
-        converged, i = _run_powerflow_method(
+        converged, i = _run_power_flow_method(
             time_step,
             stateVector,
             linSolveCache,

--- a/src/power_flow_setup.jl
+++ b/src/power_flow_setup.jl
@@ -14,9 +14,9 @@ function improve_x0(pf::ACPowerFlow,
     end
     if norm(residual.Rv, 1) > LARGE_RESIDUAL * length(residual.Rv) &&
        get_robust_power_flow(pf)
-        dc_powerflow_start!(x0, data, time_step, residual)
+        dc_power_flow_start!(x0, data, time_step, residual)
     else
-        @debug "skipping running DC powerflow fallback"
+        @debug "skipping running DC power_flow fallback"
     end
     residual(x0, time_step)  # re-calculate residual for new x0: might have changed.
 
@@ -64,14 +64,14 @@ end
 """If initial residual is large, run a DC power flow and see if that gives
 a better starting point for angles. If so, then overwrite `x0` with the result of the DC
 power flow. If not, keep the original `x0`."""
-function dc_powerflow_start!(x0::Vector{Float64},
+function dc_power_flow_start!(x0::Vector{Float64},
     data::ACPowerFlowData,
     time_step::Int64,
     residual::ACPowerFlowResidual,
 )
-    _dc_powerflow_fallback!(data, time_step)
+    _dc_power_flow_fallback!(data, time_step)
     newx0 = calculate_x0(data, time_step)
-    _pick_better_x0(x0, newx0, time_step, residual, "DC powerflow fallback")
+    _pick_better_x0(x0, newx0, time_step, residual, "DC power_flow fallback")
     return
 end
 
@@ -108,24 +108,24 @@ function _enhanced_flat_start(
 end
 
 """When solving AC power flows, if the initial guess has large residual, we run a DC power 
-flow as a fallback. This runs a DC powerflow on `data::ACPowerFlowData` for the given
+flow as a fallback. This runs a DC power_flow on `data::ACPowerFlowData` for the given
 `time_step`, and writes the solution to `data.bus_angles`."""
-function _dc_powerflow_fallback!(data::ACPowerFlowData, time_step::Int)
-    # dev note: for DC, we can efficiently solve for all timesteps at once, and we want branch
-    # flows. For AC fallback, we're only interested in the current timestep, and no branch flows
+function _dc_power_flow_fallback!(data::ACPowerFlowData, time_step::Int)
+    # dev note: for DC, we can efficiently solve for all time_steps at once, and we want branch
+    # flows. For AC fallback, we're only interested in the current time_step, and no branch flows
     solver_cache = get_aux_network_matrix(data).K
     # factored in constructor; no need to factor again (as long as network is same)
     valid_ix = get_valid_ix(data)
     p_inj =
-        data.bus_activepower_injection[valid_ix, time_step] -
-        data.bus_activepower_withdrawals[valid_ix, time_step] +
+        data.bus_active_power_injections[valid_ix, time_step] -
+        data.bus_active_power_withdrawals[valid_ix, time_step] +
         data.bus_hvdc_net_power[valid_ix, time_step]
     # assumption: the linear algebra backend we're using implements and exports ldiv!
     ldiv!(solver_cache, p_inj)
     data.bus_angles[valid_ix, time_step] .= p_inj
 end
 
-function initialize_powerflow_variables(pf::ACPowerFlow{T},
+function initialize_power_flow_variables(pf::ACPowerFlow{T},
     data::ACPowerFlowData,
     time_step::Int64;
     kwargs...,

--- a/src/power_flow_types.jl
+++ b/src/power_flow_types.jl
@@ -73,7 +73,7 @@ end
     ) where {ACSolver <: ACPowerFlowSolverType}
 
 An evaluation model for a standard 
-[AC powerflow](https://en.wikipedia.org/wiki/Power-flow_study#Power-flow_problem_formulation) 
+[AC power_flow](https://en.wikipedia.org/wiki/Power-flow_study#Power-flow_problem_formulation) 
 with the specified solver type.
 
 
@@ -171,9 +171,9 @@ get_calculate_voltage_stability_factors(::AbstractDCPowerFlow) = false
         exporter::Union{Nothing, PowerFlowEvaluationModel} = nothing,
     )
 
-An evaluation model for a standard DC powerflow.
+An evaluation model for a standard DC power_flow.
 
-This provides a fast approximate solution to the AC powerflow problem, by solving for the 
+This provides a fast approximate solution to the AC power_flow problem, by solving for the 
 bus voltage angles under some simplifying assumptions (lossless lines, constant voltage 
 magnitudes, etc.). For details, see 
 [Wikipedia](https://en.wikipedia.org/wiki/Power-flow_study#DC_power_flow)

--- a/src/psse_export.jl
+++ b/src/psse_export.jl
@@ -2861,4 +2861,4 @@ make_power_flow_container(pfem::PSSEExportPowerFlow, sys::PSY.System; kwargs...)
         step = (0, 0),
     )
 
-solve_powerflow!(exporter::PSSEExporter) = write_export(exporter)
+solve_power_flow!(exporter::PSSEExporter) = write_export(exporter)

--- a/src/solve_ac_power_flow.jl
+++ b/src/solve_ac_power_flow.jl
@@ -49,10 +49,10 @@ function solve_and_store_power_flow!(
             network_reductions = get(kwargs, :network_reductions, PNM.NetworkReduction[]),
         )
 
-        converged = solve_powerflow!(data; pf = pf, kwargs...)
+        converged = solve_power_flow!(data; pf = pf, kwargs...)
 
         if converged
-            write_powerflow_solution!(
+            write_power_flow_solution!(
                 system,
                 pf,
                 data,
@@ -60,7 +60,7 @@ function solve_and_store_power_flow!(
             )
             @info("PowerFlow solve converged, the results have been stored in the system")
         else
-            @error("The powerflow solver returned convergence = $converged")
+            @error("The power_flow solver returned convergence = $converged")
         end
     end
 
@@ -74,10 +74,10 @@ Returns the results in a dictionary of dataframes.
 ## Examples
 
 ```julia
-res = solve_powerflow(pf, sys)
+res = solve_power_flow(pf, sys)
 ```
 """
-function solve_powerflow(
+function solve_power_flow(
     pf::ACPowerFlow{<:ACPowerFlowSolverType},
     system::PSY.System;
     kwargs...,
@@ -94,14 +94,14 @@ function solve_powerflow(
             network_reductions = get(kwargs, :network_reductions, PNM.NetworkReduction[]),
         )
 
-        converged = solve_powerflow!(data; pf = pf, kwargs...)
+        converged = solve_power_flow!(data; pf = pf, kwargs...)
 
         if converged
             @info("PowerFlow solve converged, the results are exported in DataFrames")
             df_results = write_results(pf, system, data, time_step)
         else
             df_results = missing
-            @error("The powerflow solver returned convergence = $(converged)")
+            @error("The power_flow solver returned convergence = $(converged)")
         end
     end
 
@@ -109,7 +109,7 @@ function solve_powerflow(
 end
 
 """
-    solve_powerflow!(data::ACPowerFlowData; pf::ACPowerFlow{<:ACPowerFlowSolverType} = ACPowerFlow(), kwargs...)
+    solve_power_flow!(data::ACPowerFlowData; pf::ACPowerFlow{<:ACPowerFlowSolverType} = ACPowerFlow(), kwargs...)
 
 Solve the multiperiod AC power flow problem for the given power flow data.
 
@@ -121,12 +121,12 @@ The bus types can be changed from PV to PQ if the reactive power limits are viol
 - `kwargs...`: Additional keyword arguments.
 
 # Keyword Arguments
-- `time_steps`: Specifies the time steps to solve. Defaults to sorting and collecting the keys of `data.timestep_map`.
+- `time_steps`: Specifies the time steps to solve. Defaults to sorting and collecting the keys of `data.time_step_map`.
 
 # Description
 This function solves the AC power flow problem for each time step specified in `data`. 
 It preallocates memory for the results and iterates over the sorted time steps. 
-    For each time step, it calls the `_ac_powerflow` function to solve the power flow equations and updates the `data` object with the results. 
+    For each time step, it calls the `_ac_power_flow` function to solve the power flow equations and updates the `data` object with the results. 
     If the power flow converges, it updates the active and reactive power injections, as well as the voltage magnitudes and angles for different bus types (REF, PV, PQ). 
     If the power flow does not converge, it sets the corresponding entries in `data` to `NaN`. 
     Finally, it calculates the branch power flows and updates the `data` object.
@@ -137,15 +137,15 @@ It preallocates memory for the results and iterates over the sorted time steps.
 
 # Examples
 ```julia
-solve_powerflow!(data)
+solve_power_flow!(data)
 ```
 """
-function solve_powerflow!(
+function solve_power_flow!(
     data::ACPowerFlowData;
     pf::ACPowerFlow{<:ACPowerFlowSolverType} = ACPowerFlow(),
     kwargs...,
 )
-    sorted_time_steps = get(kwargs, :time_steps, sort(collect(keys(data.timestep_map))))
+    sorted_time_steps = get(kwargs, :time_steps, sort(collect(keys(data.time_step_map))))
     # preallocate results
     ts_converged = fill(false, length(sorted_time_steps))
 
@@ -161,19 +161,19 @@ function solve_powerflow!(
     @assert length(fb_ix) == length(arcs)
 
     for time_step in sorted_time_steps
-        converged = _ac_powerflow(data, pf, time_step; kwargs...)
+        converged = _ac_power_flow(data, pf, time_step; kwargs...)
         ts_converged[time_step] = converged
 
         if OVERWRITE_NON_CONVERGED && !converged
             # set values to NaN for not converged time steps
-            data.bus_activepower_injection[:, time_step] .= NaN
-            data.bus_activepower_withdrawals[:, time_step] .= NaN
-            data.bus_activepower_constant_current_withdrawals[:, time_step] .= NaN
-            data.bus_activepower_constant_impedance_withdrawals[:, time_step] .= NaN
-            data.bus_reactivepower_injection[:, time_step] .= NaN
-            data.bus_reactivepower_withdrawals[:, time_step] .= NaN
-            data.bus_reactivepower_constant_current_withdrawals[:, time_step] .= NaN
-            data.bus_reactivepower_constant_impedance_withdrawals[:, time_step] .= NaN
+            data.bus_active_power_injections[:, time_step] .= NaN
+            data.bus_active_power_withdrawals[:, time_step] .= NaN
+            data.bus_active_power_constant_current_withdrawals[:, time_step] .= NaN
+            data.bus_active_power_constant_impedance_withdrawals[:, time_step] .= NaN
+            data.bus_reactive_power_injections[:, time_step] .= NaN
+            data.bus_reactive_power_withdrawals[:, time_step] .= NaN
+            data.bus_reactive_power_constant_current_withdrawals[:, time_step] .= NaN
+            data.bus_reactive_power_constant_impedance_withdrawals[:, time_step] .= NaN
             data.bus_magnitude[:, time_step] .= NaN
             data.bus_angles[:, time_step] .= NaN
         elseif get_lcc_count(data) > 0 && converged
@@ -187,13 +187,13 @@ function solve_powerflow!(
                 (rectifier_y, inverter_y) = self_admittances
                 S_inverter = V[inverter_ix] * conj(inverter_y * V[inverter_ix])
                 S_rectifier = V[rectifier_ix] * conj(rectifier_y * V[rectifier_ix])
-                data.lcc.arc_activepower_flow_from_to[time_step, i] =
+                data.lcc.arc_active_power_flow_from_to[time_step, i] =
                     real(S_rectifier)
-                data.lcc.arc_reactivepower_flow_from_to[time_step, i] =
+                data.lcc.arc_reactive_power_flow_from_to[time_step, i] =
                     imag(S_rectifier)
-                data.lcc.arc_activepower_flow_to_from[time_step, i] =
+                data.lcc.arc_active_power_flow_to_from[time_step, i] =
                     real(S_inverter)
-                data.lcc.arc_reactivepower_flow_to_from[time_step, i] =
+                data.lcc.arc_reactive_power_flow_to_from[time_step, i] =
                     imag(S_inverter)
             end
         end
@@ -209,17 +209,17 @@ function solve_powerflow!(
 
     Sft = ts_V[fb_ix, :] .* conj.(Yft.data * ts_V)
     Stf = ts_V[tb_ix, :] .* conj.(Ytf.data * ts_V)
-    data.arc_activepower_flow_from_to .= real.(Sft)
-    data.arc_reactivepower_flow_from_to .= imag.(Sft)
-    data.arc_activepower_flow_to_from .= real.(Stf)
-    data.arc_reactivepower_flow_to_from .= imag.(Stf)
+    data.arc_active_power_flow_from_to .= real.(Sft)
+    data.arc_reactive_power_flow_from_to .= imag.(Sft)
+    data.arc_active_power_flow_to_from .= real.(Stf)
+    data.arc_reactive_power_flow_to_from .= imag.(Stf)
 
     data.converged .= ts_converged
 
     return all(data.converged)
 end
 
-function _ac_powerflow(
+function _ac_power_flow(
     data::ACPowerFlowData,
     pf::ACPowerFlow{<:ACPowerFlowSolverType},
     time_step::Int64;
@@ -228,7 +228,7 @@ function _ac_powerflow(
     check_reactive_power_limits = pf.check_reactive_power_limits
 
     for _ in 1:MAX_REACTIVE_POWER_ITERATIONS
-        converged = _newton_powerflow(pf, data, time_step; kwargs...)
+        converged = _newton_power_flow(pf, data, time_step; kwargs...)
         if !converged || !check_reactive_power_limits ||
            _check_q_limit_bounds!(data, time_step)
             return converged
@@ -248,16 +248,16 @@ function _check_q_limit_bounds!(
     bus_types = view(data.bus_type, :, time_step)
     for (ix, bt) in enumerate(bus_types)
         bt != PSY.ACBusTypes.PV && continue
-        Q_gen = data.bus_reactivepower_injection[ix, time_step]
+        Q_gen = data.bus_reactive_power_injections[ix, time_step]
 
-        Q_max = data.bus_reactivepower_bounds[ix, time_step][2]
-        Q_min = data.bus_reactivepower_bounds[ix, time_step][1]
+        Q_max = data.bus_reactive_power_bounds[ix, time_step][2]
+        Q_min = data.bus_reactive_power_bounds[ix, time_step][1]
 
         if !(Q_min - BOUNDS_TOLERANCE <= Q_gen <= Q_max + BOUNDS_TOLERANCE)
             @info "Bus $(bus_names[ix]) changed to PSY.ACBusTypes.PQ"
             within_limits = false
             data.bus_type[ix, time_step] = PSY.ACBusTypes.PQ
-            data.bus_reactivepower_injection[ix, time_step] =
+            data.bus_reactive_power_injections[ix, time_step] =
                 clamp(Q_gen, Q_min, Q_max)
         else
             @debug "Within Limits"

--- a/src/solve_dc_power_flow.jl
+++ b/src/solve_dc_power_flow.jl
@@ -2,7 +2,7 @@
 Adjust the power injection vector to account for the power flows through LCCs.
     
 Relies on the fact that we calculate those flows during initialization and save them
-to the `active_powerflow_from_to` and `active_powerflow_to_from` fields of the
+to the `active_power_flow_from_to` and `active_power_flow_to_from` fields of the
 `LCCParameters` struct.
 """
 function adjust_power_injection_for_lccs!(power_injection::Matrix{Float64},
@@ -10,9 +10,9 @@ function adjust_power_injection_for_lccs!(power_injection::Matrix{Float64},
 )
     for (i, bus_inds) in enumerate(lcc_params.bus_indices)
         from_bus_ix, to_bus_ix = bus_inds
-        rectifier_power = lcc_params.arc_activepower_flow_from_to[i]
+        rectifier_power = lcc_params.arc_active_power_flow_from_to[i]
         # inverter_power here takes into account losses.
-        inverter_power = lcc_params.arc_activepower_flow_to_from[i]
+        inverter_power = lcc_params.arc_active_power_flow_to_from[i]
         power_injection[from_bus_ix, :] .-= rectifier_power
         power_injection[to_bus_ix, :] .+= inverter_power
     end
@@ -20,30 +20,30 @@ function adjust_power_injection_for_lccs!(power_injection::Matrix{Float64},
 end
 
 """
-    solve_powerflow!(data::PTDFPowerFlowData)
+    solve_power_flow!(data::PTDFPowerFlowData)
 Evaluates the PTDF power flow and writes the result to the fields of the 
 [`PTDFPowerFlowData`](@ref) structure.
 
 This function modifies the following fields of `data`, setting them to the computed values:
 - `data.bus_angles`: the bus angles for each bus in the system.
-- `data.branch_activepower_flow_from_to`: the active power flow from the "from" bus to the "to" bus of each branch
-- `data.branch_activepower_flow_to_from`: the active power flow from the "to" bus to the "from" bus of each branch
+- `data.branch_active_power_flow_from_to`: the active power flow from the "from" bus to the "to" bus of each branch
+- `data.branch_active_power_flow_to_from`: the active power flow from the "to" bus to the "from" bus of each branch
 
 Additionally, it sets `data.converged` to `true`, indicating that the power flow calculation was successful.
 """
-function solve_powerflow!(
+function solve_power_flow!(
     data::PTDFPowerFlowData,
 )
     solver_cache = KLULinSolveCache(data.aux_network_matrix.data)
     full_factor!(solver_cache, data.aux_network_matrix.data)
     # get net power injections
-    power_injection = data.bus_activepower_injection .- data.bus_activepower_withdrawals
+    power_injection = data.bus_active_power_injections .- data.bus_active_power_withdrawals
     power_injection .+= data.bus_hvdc_net_power
     # evaluate flows
-    data.arc_activepower_flow_from_to .=
+    data.arc_active_power_flow_from_to .=
         data.power_network_matrix.data' * power_injection
-    data.arc_activepower_flow_to_from .= -data.arc_activepower_flow_from_to
-    # HVDC flows stored separately and already calculated: see initialize_powerflow_data!
+    data.arc_active_power_flow_to_from .= -data.arc_active_power_flow_from_to
+    # HVDC flows stored separately and already calculated: see initialize_power_flow_data!
     valid_ix = get_valid_ix(data)
     p_inj = power_injection[valid_ix, :]
     solve!(solver_cache, p_inj)
@@ -53,7 +53,7 @@ function solve_powerflow!(
 end
 
 """
-    solve_powerflow!(data::vPTDFPowerFlowData)
+    solve_power_flow!(data::vPTDFPowerFlowData)
 
 Evaluates the virtual PTDF power flow and writes the results to the fields 
 of the [`vPTDFPowerFlowData`](@ref) structure.
@@ -61,22 +61,22 @@ of the [`vPTDFPowerFlowData`](@ref) structure.
 
 This function modifies the following fields of `data`, setting them to the computed values:
 - `data.bus_angles`: the bus angles for each bus in the system.
-- `data.branch_activepower_flow_from_to`: the active power flow from the "from" bus to the "to" bus of each branch
-- `data.branch_activepower_flow_to_from`: the active power flow from the "to" bus to the "from" bus of each branch
+- `data.branch_active_power_flow_from_to`: the active power flow from the "from" bus to the "to" bus of each branch
+- `data.branch_active_power_flow_to_from`: the active power flow from the "to" bus to the "from" bus of each branch
 
 Additionally, it sets `data.converged` to `true`, indicating that the power flow calculation was successful.
 """
-function solve_powerflow!(
+function solve_power_flow!(
     data::vPTDFPowerFlowData,
 )
     solver_cache = KLULinSolveCache(data.aux_network_matrix.data)
     full_factor!(solver_cache, data.aux_network_matrix.data)
-    power_injection = data.bus_activepower_injection .- data.bus_activepower_withdrawals
+    power_injection = data.bus_active_power_injections .- data.bus_active_power_withdrawals
     power_injection .+= data.bus_hvdc_net_power
-    data.arc_activepower_flow_from_to .=
+    data.arc_active_power_flow_from_to .=
         my_mul_mt(data.power_network_matrix, power_injection)
-    data.arc_activepower_flow_to_from .= -data.arc_activepower_flow_from_to
-    # HVDC flows stored separately and already calculated: see initialize_powerflow_data!
+    data.arc_active_power_flow_to_from .= -data.arc_active_power_flow_from_to
+    # HVDC flows stored separately and already calculated: see initialize_power_flow_data!
     valid_ix = get_valid_ix(data)
     p_inj = power_injection[valid_ix, :]
     solve!(solver_cache, p_inj)
@@ -88,7 +88,7 @@ end
 # TODO: solve just for some lines with vPTDF
 
 """
-    solve_powerflow!(data::ABAPowerFlowData)
+    solve_power_flow!(data::ABAPowerFlowData)
 
 Evaluates the DC power flow and writes the results (branch flows) to the fields 
 of the [`ABAPowerFlowData`](@ref) structure.
@@ -96,28 +96,28 @@ of the [`ABAPowerFlowData`](@ref) structure.
 
 This function modifies the following fields of `data`, setting them to the computed values:
 - `data.bus_angles`: the bus angles for each bus in the system.
-- `data.branch_activepower_flow_from_to`: the active power flow from the "from" bus to the "to" bus of each branch
-- `data.branch_activepower_flow_to_from`: the active power flow from the "to" bus to the "from" bus of each branch
+- `data.branch_active_power_flow_from_to`: the active power flow from the "from" bus to the "to" bus of each branch
+- `data.branch_active_power_flow_to_from`: the active power flow from the "to" bus to the "from" bus of each branch
 
 Additionally, it sets `data.converged` to `true`, indicating that the power flow calculation was successful.
 """
 # DC flow: ABA and BA case
-function solve_powerflow!(
+function solve_power_flow!(
     data::ABAPowerFlowData,
 )
     solver_cache = KLULinSolveCache(data.power_network_matrix.data)
     full_factor!(solver_cache, data.power_network_matrix.data)
     # get net injections
-    power_injection = data.bus_activepower_injection - data.bus_activepower_withdrawals
+    power_injection = data.bus_active_power_injections - data.bus_active_power_withdrawals
     power_injection .+= data.bus_hvdc_net_power
     # save angles and power flows
     valid_ix = get_valid_ix(data)
     p_inj = power_injection[valid_ix, :]
     solve!(solver_cache, p_inj)
     data.bus_angles[valid_ix, :] .= p_inj
-    data.arc_activepower_flow_from_to .= data.aux_network_matrix.data' * data.bus_angles
-    data.arc_activepower_flow_to_from .= -data.arc_activepower_flow_from_to
-    # HVDC flows stored separately and already calculated: see initialize_powerflow_data!
+    data.arc_active_power_flow_from_to .= data.aux_network_matrix.data' * data.bus_angles
+    data.arc_active_power_flow_to_from .= -data.arc_active_power_flow_from_to
+    # HVDC flows stored separately and already calculated: see initialize_power_flow_data!
     data.converged .= true
     return
 end
@@ -125,7 +125,7 @@ end
 # SINGLE PERIOD ##############################################################
 
 """
-    solve_powerflow(
+    solve_power_flow(
         ::T,
         sys::PSY.System;
     ) where T <: AbstractDCPowerFlow
@@ -141,19 +141,19 @@ struct, but that's still what's happening under the hood.
 ```julia
 using PowerFlows, PowerSystemCaseBuilder
 sys = build_system(PSITestSystems, "c_sys5")
-d = solve_powerflow(DCPowerFlow(), sys)
+d = solve_power_flow(DCPowerFlow(), sys)
 display(d["1"]["flow_results"])
 display(d["1"]["bus_results"])
 ```
 """
-function solve_powerflow(
+function solve_power_flow(
     ::T,
     sys::PSY.System;
     kargs...,
 ) where {T <: AbstractDCPowerFlow}
     with_units_base(sys, PSY.UnitSystem.SYSTEM_BASE) do
         data = PowerFlowData(T(), sys; kargs...)
-        solve_powerflow!(data)
+        solve_power_flow!(data)
         return write_results(data, sys)
     end
 end
@@ -165,11 +165,11 @@ Evaluates the power flows on the system's branches by means of the method associ
 the `PowerFlowData` structure `data`, which can be one of `PTDFPowerFlowData`,
 `vPTDFPowerFlowData`, or `ABAPowerFlowData`.
 Returns a dictionary of `DataFrame`s, each containing the branch flows and bus voltages for
-the input `PSY.System` at that timestep.
+the input `PSY.System` at that time_step.
 
 # Arguments:
 - `data::Union{PTDFPowerFlowData, vPTDFPowerFlowData, ABAPowerFlowData}`:
-        `PowerFlowData` structure containing the system's data per each timestep
+        `PowerFlowData` structure containing the system's data per each time_step
         considered, as well as the associated matrix for the power flow.
 - `sys::PSY.System`:
         container gathering the system data.
@@ -182,14 +182,14 @@ Note that `data` must have been created from the [System](@extref PowerSystems.S
 using PowerFlows, PowerSystemCaseBuilder
 sys = build_system(PSITestSystems, "c_sys14")
 data = PowerFlowData(PTDFDCPowerFlow(), sys, time_steps = 2)
-d = solve_powerflow(data, sys)
+d = solve_power_flow(data, sys)
 display(d["2"]["flow_results"])
 ```
 """
-function solve_powerflow(
+function solve_power_flow(
     data::Union{PTDFPowerFlowData, vPTDFPowerFlowData, ABAPowerFlowData},
     sys::PSY.System;
 )
-    solve_powerflow!(data)
+    solve_power_flow!(data)
     return write_results(data, sys)
 end

--- a/src/state_indexing_helpers.jl
+++ b/src/state_indexing_helpers.jl
@@ -36,16 +36,16 @@ function update_state!(x::Vector{Float64},
     for (ix, b) in enumerate(data.bus_type[:, time_step])
         if b == PSY.ACBusTypes.REF
             x[state_variable_count] =
-                data.bus_activepower_injection[ix, time_step] -
-                data.bus_activepower_withdrawals[ix, time_step]
+                data.bus_active_power_injections[ix, time_step] -
+                data.bus_active_power_withdrawals[ix, time_step]
             x[state_variable_count + 1] =
-                data.bus_reactivepower_injection[ix, time_step] -
-                data.bus_reactivepower_withdrawals[ix, time_step]
+                data.bus_reactive_power_injections[ix, time_step] -
+                data.bus_reactive_power_withdrawals[ix, time_step]
             state_variable_count += 2
         elseif b == PSY.ACBusTypes.PV
             x[state_variable_count] =
-                data.bus_reactivepower_injection[ix, time_step] -
-                data.bus_reactivepower_withdrawals[ix, time_step]
+                data.bus_reactive_power_injections[ix, time_step] -
+                data.bus_reactive_power_withdrawals[ix, time_step]
             x[state_variable_count + 1] = data.bus_angles[ix, time_step]
             state_variable_count += 2
         elseif b == PSY.ACBusTypes.PQ
@@ -97,10 +97,10 @@ function _set_state_variables_at_bus(
     time_step::Int64,
     ::Val{PSY.ACBusTypes.REF})
     # When bustype == REFERENCE PSY.Bus, state variables are Active and Reactive Power Generated
-    data.bus_activepower_injection[ix, time_step] =
-        StateVector[2 * ix - 1] + data.bus_activepower_withdrawals[ix, time_step]
-    data.bus_reactivepower_injection[ix, time_step] =
-        StateVector[2 * ix] + data.bus_reactivepower_withdrawals[ix, time_step]
+    data.bus_active_power_injections[ix, time_step] =
+        StateVector[2 * ix - 1] + data.bus_active_power_withdrawals[ix, time_step]
+    data.bus_reactive_power_injections[ix, time_step] =
+        StateVector[2 * ix] + data.bus_reactive_power_withdrawals[ix, time_step]
 end
 
 function _set_state_variables_at_bus(
@@ -110,8 +110,8 @@ function _set_state_variables_at_bus(
     time_step::Int64,
     ::Val{PSY.ACBusTypes.PV})
     # When bustype == PV PSY.Bus, state variables are Reactive Power Generated and Voltage Angle
-    data.bus_reactivepower_injection[ix, time_step] =
-        StateVector[2 * ix - 1] + data.bus_reactivepower_withdrawals[ix, time_step]
+    data.bus_reactive_power_injections[ix, time_step] =
+        StateVector[2 * ix - 1] + data.bus_reactive_power_withdrawals[ix, time_step]
     data.bus_angles[ix, time_step] = StateVector[2 * ix]
 end
 

--- a/test/PowerFlowsTests.jl
+++ b/test/PowerFlowsTests.jl
@@ -34,7 +34,7 @@ const PF = PowerFlows
 # used to be public, no longer: import here so we can use in tests
 import PowerFlows: PowerFlowData
 import PowerFlows: ACPowerFlowData, PTDFPowerFlowData, vPTDFPowerFlowData, ABAPowerFlowData
-import PowerFlows: solve_powerflow!, write_results
+import PowerFlows: solve_power_flow!, write_results
 
 const BASE_DIR = dirname(dirname(Base.find_package("PowerFlows")))
 const TEST_DATA_DIR = joinpath(
@@ -53,7 +53,7 @@ include("test_utils/common.jl")
 include("test_utils/psse_results_compare.jl")
 include("test_utils/penalty_factors_brute_force.jl")
 include("test_utils/legacy_pf.jl")
-include("test_utils/validate_reduced_powerflow.jl")
+include("test_utils/validate_reduced_power_flow.jl")
 
 const AC_SOLVERS_TO_TEST = (
     LUACPowerFlow,

--- a/test/performance/performance_test.jl
+++ b/test/performance/performance_test.jl
@@ -21,7 +21,7 @@ for (group, name) in systems
         try
             pf = ACPowerFlow{solver}()
             pf_data = PF.PowerFlowData(pf, sys; correct_bustypes = true)
-            _, time_solve_1, _, _ = @timed solve_powerflow!(pf_data; pf = pf)
+            _, time_solve_1, _, _ = @timed solve_power_flow!(pf_data; pf = pf)
             open("solve_time.txt", "a") do io
                 write(
                     io,
@@ -30,7 +30,7 @@ for (group, name) in systems
             end
             pf = ACPowerFlow{solver}()
             pf_data = PF.PowerFlowData(pf, sys; correct_bustypes = true)
-            _, time_solve_2, _, _ = @timed solve_powerflow!(pf_data; pf = pf)
+            _, time_solve_2, _, _ = @timed solve_power_flow!(pf_data; pf = pf)
             open("solve_time.txt", "a") do io
                 write(
                     io,
@@ -40,7 +40,7 @@ for (group, name) in systems
         catch e
             @error exception = (e, catch_backtrace())
             open("solve_time.txt", "a") do io
-                write(io, "| $(ARGS[1])-$(name)-Solve powerflow | FAILED TO TEST |\n")
+                write(io, "| $(ARGS[1])-$(name)-Solve power_flow | FAILED TO TEST |\n")
             end
         end
     end

--- a/test/test_arc_types_and_reductions.jl
+++ b/test/test_arc_types_and_reductions.jl
@@ -1,11 +1,11 @@
 """
-Run one DC and one AC powerflow on a system with a given set of network reductions.
+Run one DC and one AC power_flow on a system with a given set of network reductions.
 """
-function test_all_powerflow_types(
+function test_all_power_flow_types(
     sys::System,
     network_reductions::Vector{PNM.NetworkReduction},
 )
-    # AC powerflow has different syntax
+    # AC power_flow has different syntax
     pf = ACPowerFlow{PF.TrustRegionACPowerFlow}()
     if PNM.RadialReduction() in network_reductions
         # AC + radial reduction: may not converge, but should otherwise run ok.
@@ -19,8 +19,8 @@ function test_all_powerflow_types(
             )
         )
         @test_logs (:error, r"solver failed to converge"
-        ) match_mode = :any solve_powerflow!(data; pf = pf) # should run without errors.
-        @test !isempty(data.arc_activepower_flow_from_to)
+        ) match_mode = :any solve_power_flow!(data; pf = pf) # should run without errors.
+        @test !isempty(data.arc_active_power_flow_from_to)
     else
         data = PF.PowerFlowData(
             pf,
@@ -28,8 +28,8 @@ function test_all_powerflow_types(
             network_reductions = deepcopy(network_reductions),
             correct_bustypes = true,
         )
-        solve_powerflow!(data; pf = pf) # should run without errors.
-        @test !isempty(data.arc_activepower_flow_from_to)
+        solve_power_flow!(data; pf = pf) # should run without errors.
+        @test !isempty(data.arc_active_power_flow_from_to)
         solve_and_store_power_flow!(
             pf,
             sys;
@@ -39,18 +39,18 @@ function test_all_powerflow_types(
     end
     pf = PF.DCPowerFlow()
     data = PF.PowerFlowData(pf, sys; network_reductions = deepcopy(network_reductions))
-    solve_powerflow!(data) # should run without errors.
-    @test !isempty(data.arc_activepower_flow_from_to)
+    solve_power_flow!(data) # should run without errors.
+    @test !isempty(data.arc_active_power_flow_from_to)
 end
 
 @testset "radial reduction with 3WT/parallel lines" begin
     sys = build_system(PSB.PSITestSystems, "case10_radial_series_reductions")
     network_reductions = NetworkReduction[RadialReduction()]
-    test_all_powerflow_types(sys, network_reductions)
+    test_all_power_flow_types(sys, network_reductions)
 end
 
 @testset "degreee 2 reduction with 3WT/parallel lines" begin
     sys = build_system(PSB.PSITestSystems, "case10_radial_series_reductions")
     network_reductions = NetworkReduction[DegreeTwoReduction()]
-    test_all_powerflow_types(sys, network_reductions)
+    test_all_power_flow_types(sys, network_reductions)
 end

--- a/test/test_distributed_slack.jl
+++ b/test/test_distributed_slack.jl
@@ -44,8 +44,8 @@
             # allocate timeseries data from csv
             prepare_ts_data!(data, time_steps)
 
-            init_p_injections = copy(data.bus_activepower_injection)
-            solve_powerflow!(data; pf = pf)
+            init_p_injections = copy(data.bus_active_power_injections)
+            solve_power_flow!(data; pf = pf)
 
             # check results
             subnetworks = PowerFlows._find_subnetworks_for_reference_buses(
@@ -55,7 +55,7 @@
             for time_step in 1:time_steps
                 _check_distributed_slack_consistency(
                     subnetworks,
-                    data.bus_activepower_injection[:, time_step],
+                    data.bus_active_power_injections[:, time_step],
                     collect(data.bus_slack_participation_factors[:, time_step]),
                     init_p_injections[:, time_step],
                 )
@@ -164,8 +164,8 @@ end
             data = PowerFlowData(pf, sys; correct_bustypes = true)
             original_bus_power, original_gen_power =
                 _system_generation_power(sys, bus_numbers)
-            data_original_bus_power = copy(data.bus_activepower_injection[:, 1])
-            res1 = solve_powerflow(pf, sys; correct_bustypes = true)
+            data_original_bus_power = copy(data.bus_active_power_injections[:, 1])
+            res1 = solve_power_flow(pf, sys; correct_bustypes = true)
 
             bus_slack_participation_factors = zeros(Float64, length(bus_numbers))
             bus_slack_participation_factors[ref_n] .= 1.0
@@ -177,7 +177,7 @@ end
                     bus_slack_participation_factors,
                 ),
             )
-            res2 = solve_powerflow(pf2, sys; correct_bustypes = true)
+            res2 = solve_power_flow(pf2, sys; correct_bustypes = true)
 
             # basic test: if we pass the same slack participation factors as the default ones, the results
             # should be the same

--- a/test/test_hvdc.jl
+++ b/test/test_hvdc.jl
@@ -47,7 +47,7 @@ end
         sys;
         correct_bustypes = true,
     )
-    solve_powerflow!(data; pf = pf)
+    solve_power_flow!(data; pf = pf)
     @test all(data.converged)
 end
 
@@ -60,7 +60,7 @@ end
             pf,
             sys;
         )
-        solve_powerflow!(data)
+        solve_power_flow!(data)
         @test all(data.converged)
     end
 end
@@ -149,7 +149,7 @@ function test_generic_hvdc_on_big_system(pf_type::Type{<:PF.PowerFlowEvaluationM
         sys_original;
         correct_bustypes = true,
     )
-    solve_powerflow!(data_original)
+    solve_power_flow!(data_original)
     ref_bus_inds = findall(data_original.bus_type .== (PSY.ACBusTypes.REF,))
     @test all(data_original.bus_angles[ref_bus_inds] .== 0.0)
 
@@ -162,7 +162,7 @@ function test_generic_hvdc_on_big_system(pf_type::Type{<:PF.PowerFlowEvaluationM
         sys_modified;
         correct_bustypes = true,
     )
-    solve_powerflow!(data_modified)
+    solve_power_flow!(data_modified)
 
     # verify assumptions
     @assert !isempty(get_components(PSY.TwoTerminalGenericHVDCLine, sys_original))
@@ -188,13 +188,13 @@ function test_generic_hvdc_on_big_system(pf_type::Type{<:PF.PowerFlowEvaluationM
         # no need to check arc flows: since angles and aux matrices match, flows match.
         # check that the b in our Ax = b is the same
         rhs_original = (
-            data_original.bus_activepower_injection .-
-            data_original.bus_activepower_withdrawals .+
+            data_original.bus_active_power_injections .-
+            data_original.bus_active_power_withdrawals .+
             data_original.bus_hvdc_net_power
         )
         rhs_modified = (
-            data_modified.bus_activepower_injection .-
-            data_modified.bus_activepower_withdrawals
+            data_modified.bus_active_power_injections .-
+            data_modified.bus_active_power_withdrawals
         )
         @test all(abs.(rhs_original - rhs_modified) .< TIGHT_TOLERANCE)
     end
@@ -208,8 +208,8 @@ function test_generic_hvdc_on_big_system(pf_type::Type{<:PF.PowerFlowEvaluationM
         )
     end
 
-    for fieldname in (:arc_activepower_flow_from_to, :arc_activepower_flow_to_from,
-        :arc_reactivepower_flow_from_to, :arc_reactivepower_flow_to_from)
+    for fieldname in (:arc_active_power_flow_from_to, :arc_active_power_flow_to_from,
+        :arc_reactive_power_flow_from_to, :arc_reactive_power_flow_to_from)
         for (original_arc_ind, arc) in enumerate(PF.get_arc_axis(data_original))
             modified_arc_ind = PF.get_arc_lookup(data_modified)[arc]
             @test isapprox(

--- a/test/test_iterative_methods.jl
+++ b/test/test_iterative_methods.jl
@@ -3,7 +3,7 @@
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
     nr_pf = ACPowerFlow{NewtonRaphsonACPowerFlow}()
     @test_logs (:info, r".*NewtonRaphsonACPowerFlow solver converged"
-    ) match_mode = :any PF.solve_powerflow(nr_pf, sys; maxIterations = 50,
+    ) match_mode = :any PF.solve_power_flow(nr_pf, sys; maxIterations = 50,
         tol = 1e-10, refinement_threshold = 0.01, refinement_eps = 1e-7)
 end
 
@@ -12,7 +12,7 @@ end
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
     tr_pf = ACPowerFlow{TrustRegionACPowerFlow}()
     @test_logs (:info, r".*TrustRegionACPowerFlow solver converged"
-    ) match_mode = :any PF.solve_powerflow(tr_pf, sys; eta = 1e-5,
+    ) match_mode = :any PF.solve_power_flow(tr_pf, sys; eta = 1e-5,
         tol = 1e-10, factor = 1.1, maxIterations = 50)
 end
 
@@ -28,7 +28,7 @@ end
 
     # Small trust region size => Cauchy or dogleg step
     @test_logs (:debug, r"(Dogleg step selected|Cauchy step selected)") match_mode = :any min_level =
-        Logging.Debug PF.solve_powerflow(
+        Logging.Debug PF.solve_power_flow(
         tr_pf,
         sys;
         factor = 0.01,
@@ -37,7 +37,7 @@ end
 
     # Large trust region size => Newton-Raphson step
     @test_logs (:debug, r"Newton-Raphson step selected.*") match_mode = :any min_level =
-        Logging.Debug PF.solve_powerflow(
+        Logging.Debug PF.solve_power_flow(
         tr_pf,
         sys;
         factor = 10.0,
@@ -45,7 +45,7 @@ end
     )
 
     # Large eta => step rejected
-    @test_logs (:debug, r"Step rejected.*") match_mode = :any min_level = Logging.Debug PF.solve_powerflow(
+    @test_logs (:debug, r"Step rejected.*") match_mode = :any min_level = Logging.Debug PF.solve_power_flow(
         tr_pf,
         sys;
         eta = 2.0,
@@ -53,7 +53,7 @@ end
     )
 
     # Small eta => step accepted
-    @test_logs (:debug, r"Step accepted.*") match_mode = :any min_level = Logging.Debug PF.solve_powerflow(
+    @test_logs (:debug, r"Step accepted.*") match_mode = :any min_level = Logging.Debug PF.solve_power_flow(
         tr_pf,
         sys;
         eta = 1e-6,
@@ -70,16 +70,16 @@ end
         robust_power_flow = false,
         enhanced_flat_start = false,
     )
-    # test that _dc_powerflow_fallback! solves correctly.
+    # test that _dc_power_flow_fallback! solves correctly.
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
     sys2 = deepcopy(sys)
     data = PowerFlowData(dc_pf, sys2)
-    PF._dc_powerflow_fallback!(data, 1)
+    PF._dc_power_flow_fallback!(data, 1)
     valid_ix = PF.get_valid_ix(data)
     ABA_angles = data.bus_angles[valid_ix, 1]
     p_inj =
-        data.bus_activepower_injection[valid_ix, 1] -
-        data.bus_activepower_withdrawals[valid_ix, 1]
+        data.bus_active_power_injections[valid_ix, 1] -
+        data.bus_active_power_withdrawals[valid_ix, 1]
     @test data.aux_network_matrix.data * ABA_angles ≈ p_inj
 
     # check behavior of improved_x0 via creating bogus awful starting point.
@@ -91,26 +91,26 @@ end
     residual(x0, 1)
     residualSize = norm(residual.Rv, 1)
     newx0 = deepcopy(x0)
-    PF.dc_powerflow_start!(newx0, data, 1, residual)
+    PF.dc_power_flow_start!(newx0, data, 1, residual)
     residual(newx0, 1)
     newResidualSize = norm(residual.Rv, 1)
     @test x0 !== newx0
     @test newResidualSize < residualSize
-    # TODO: case with bad residual where DC powerflow doesn't yield improvement?
+    # TODO: case with bad residual where DC power_flow doesn't yield improvement?
 
     # check that it does the DC fallback.
     # _initialize_bus_data! corrects the voltages to be "reasonable," between 0.8 and 1.2
     sys4 = deepcopy(sys)
     bad_x0!(sys4)
-    improvement_regex = r".*DC powerflow fallback yields smaller residual.*"
-    @test_logs (:info, improvement_regex) match_mode = :any PF.solve_powerflow(
+    improvement_regex = r".*DC power_flow fallback yields smaller residual.*"
+    @test_logs (:info, improvement_regex) match_mode = :any PF.solve_power_flow(
         dc_pf,
         sys4,
     )
     sys5 = deepcopy(sys)
     bad_x0!(sys5)
-    @test_logs (:debug, "skipping running DC powerflow fallback") match_mode = :any min_level =
-        Logging.Debug PF.solve_powerflow(no_dc_pf, sys5)
+    @test_logs (:debug, "skipping running DC power_flow fallback") match_mode = :any min_level =
+        Logging.Debug PF.solve_power_flow(no_dc_pf, sys5)
 end
 
 @testset "large residual warning" begin
@@ -122,12 +122,12 @@ end
         data = PowerFlowData(pf, sys; correct_bustypes = true)
         # First, write solution to data. Then set magnitude of a random-ish bus to a huge number
         # and try to solve again: the "large residual warning" should be about that bus.
-        solve_powerflow!(data)
+        solve_power_flow!(data)
         bus = collect(PSY.get_components(PSY.ACBus, sys))[i]
         bus_no = bus.number
         bus_ix = PowerFlows.get_bus_lookup(data)[bus_no]
         data.bus_magnitude[bus_ix] = 100.0
         @test_logs (:warn, Regex(".*Largest residual at bus $(bus_no).*")
-        ) match_mode = :any solve_powerflow!(data; pf = pf)
+        ) match_mode = :any solve_power_flow!(data; pf = pf)
     end
 end

--- a/test/test_loss_factors.jl
+++ b/test/test_loss_factors.jl
@@ -21,7 +21,7 @@
             prepare_ts_data!(data_brute_force, time_steps)
 
             # get power flows with NR KLU method and write results
-            solve_powerflow!(data_loss_factors; pf = pf_lf)
+            solve_power_flow!(data_loss_factors; pf = pf_lf)
 
             # get loss factors using brute force approach (sequential power flow evaluations for each bus)
             bf_loss_factors = penalty_factors_brute_force(data_brute_force, pf)
@@ -37,7 +37,7 @@
             )
 
             # get power flow results without loss factors
-            solve_powerflow!(data_brute_force; pf = pf)
+            solve_power_flow!(data_brute_force; pf = pf)
             @test isnothing(data_brute_force.loss_factors)
         end
     end

--- a/test/test_multiperiod_ac_power_flow.jl
+++ b/test/test_multiperiod_ac_power_flow.jl
@@ -14,15 +14,15 @@
             prepare_ts_data!(data, time_steps)
 
             # get power flows with NR KLU method and write results
-            solve_powerflow!(data; pf = pf)
+            solve_power_flow!(data; pf = pf)
 
             # check results
-            # for t in 1:length(data.timestep_map)
-            #     res_t = solve_powerflow(pf, sys, t)  # does not work - ts data not set in sys
+            # for t in 1:length(data.time_step_map)
+            #     res_t = solve_power_flow(pf, sys, t)  # does not work - ts data not set in sys
             #     flow_ft = res_t["flow_results"].P_from_to
             #     flow_tf = res_t["flow_results"].P_to_from
-            #     ts_flow_ft = results[data.timestep_map[t]]["flow_results"].P_from_to
-            #     ts_flow_tf = results[data.timestep_map[t]]["flow_results"].P_to_from
+            #     ts_flow_ft = results[data.time_step_map[t]]["flow_results"].P_from_to
+            #     ts_flow_tf = results[data.time_step_map[t]]["flow_results"].P_to_from
             #     @test isapprox(ts_flow_ft, flow_ft, atol = 1e-9)
             #     @test isapprox(ts_flow_tf, flow_tf, atol = 1e-9)
             # end
@@ -47,30 +47,30 @@ end
     prepare_ts_data!(data_test, time_steps)
 
     # get power flows with NR KLU method and write results
-    solve_powerflow!(data_lu; pf = pf_lu)
-    solve_powerflow!(data_test; pf = pf_test)
+    solve_power_flow!(data_lu; pf = pf_lu)
+    solve_power_flow!(data_test; pf = pf_test)
 
     # check results
     @test isapprox(data_lu.bus_magnitude, data_test.bus_magnitude, atol = 1e-9)
     @test isapprox(data_lu.bus_angles, data_test.bus_angles, atol = 1e-9)
     @test isapprox(
-        data_lu.arc_activepower_flow_from_to,
-        data_test.arc_activepower_flow_from_to,
+        data_lu.arc_active_power_flow_from_to,
+        data_test.arc_active_power_flow_from_to,
         atol = 1e-9,
     )
     @test isapprox(
-        data_lu.arc_activepower_flow_to_from,
-        data_test.arc_activepower_flow_to_from,
+        data_lu.arc_active_power_flow_to_from,
+        data_test.arc_active_power_flow_to_from,
         atol = 1e-9,
     )
     @test isapprox(
-        data_lu.arc_reactivepower_flow_from_to,
-        data_test.arc_reactivepower_flow_from_to,
+        data_lu.arc_reactive_power_flow_from_to,
+        data_test.arc_reactive_power_flow_from_to,
         atol = 1e-9,
     )
     @test isapprox(
-        data_lu.arc_reactivepower_flow_to_from,
-        data_test.arc_reactivepower_flow_to_from,
+        data_lu.arc_reactive_power_flow_to_from,
+        data_test.arc_reactive_power_flow_to_from,
         atol = 1e-9,
     )
 end

--- a/test/test_multiperiod_dc_power_flow.jl
+++ b/test/test_multiperiod_dc_power_flow.jl
@@ -47,48 +47,48 @@
     injs = Matrix(injections)
     withs = Matrix(withdrawals)
 
-    data_1.bus_activepower_injection .= deepcopy(injs)
-    data_1.bus_activepower_withdrawals .= deepcopy(withs)
+    data_1.bus_active_power_injections .= deepcopy(injs)
+    data_1.bus_active_power_withdrawals .= deepcopy(withs)
 
-    data_2.bus_activepower_injection .= deepcopy(injs)
-    data_2.bus_activepower_withdrawals .= deepcopy(withs)
+    data_2.bus_active_power_injections .= deepcopy(injs)
+    data_2.bus_active_power_withdrawals .= deepcopy(withs)
 
-    data_3.bus_activepower_injection .= deepcopy(injs)
-    data_3.bus_activepower_withdrawals .= deepcopy(withs)
+    data_3.bus_active_power_injections .= deepcopy(injs)
+    data_3.bus_active_power_withdrawals .= deepcopy(withs)
 
     # case 1: get power flows with ABA method and write results
-    results_1 = solve_powerflow(data_1, sys)
+    results_1 = solve_power_flow(data_1, sys)
 
     # case 2: get power flows PTDF method and write results
-    results_2 = solve_powerflow(data_2, sys)
+    results_2 = solve_power_flow(data_2, sys)
 
     # case 3: get power flows Virtual PTDF method and write results
-    results_3 = solve_powerflow(data_3, sys)
+    results_3 = solve_power_flow(data_3, sys)
 
     # check results
     # CSVs are in p.u., line flows are in natural units: convert back to p.u.
     basepower = PSY.get_base_power(sys)
 
     # case 1
-    for i in 1:length(data_1.timestep_map)
-        net_flow = results_1[data_1.timestep_map[i]]["flow_results"].P_from_to
-        net_flow_tf = results_1[data_1.timestep_map[i]]["flow_results"].P_to_from
+    for i in 1:length(data_1.time_step_map)
+        net_flow = results_1[data_1.time_step_map[i]]["flow_results"].P_from_to
+        net_flow_tf = results_1[data_1.time_step_map[i]]["flow_results"].P_to_from
         @test isapprox(1 / basepower .* net_flow, flows[:, i], atol = 1e-5)
         @test isapprox(1 / basepower .* net_flow_tf, -flows[:, i], atol = 1e-5)
     end
 
     # case 2
-    for i in 1:length(data_1.timestep_map)
-        net_flow = results_1[data_2.timestep_map[i]]["flow_results"].P_from_to
-        net_flow_tf = results_1[data_2.timestep_map[i]]["flow_results"].P_to_from
+    for i in 1:length(data_1.time_step_map)
+        net_flow = results_1[data_2.time_step_map[i]]["flow_results"].P_from_to
+        net_flow_tf = results_1[data_2.time_step_map[i]]["flow_results"].P_to_from
         @test isapprox(1 / basepower .* net_flow, flows[:, i], atol = 1e-5)
         @test isapprox(1 / basepower .* net_flow_tf, -flows[:, i], atol = 1e-5)
     end
 
     # case 3
-    for i in 1:length(data_1.timestep_map)
-        net_flow = results_1[data_3.timestep_map[i]]["flow_results"].P_from_to
-        net_flow_tf = results_1[data_3.timestep_map[i]]["flow_results"].P_to_from
+    for i in 1:length(data_1.time_step_map)
+        net_flow = results_1[data_3.time_step_map[i]]["flow_results"].P_from_to
+        net_flow_tf = results_1[data_3.time_step_map[i]]["flow_results"].P_to_from
         @test isapprox(1 / basepower .* net_flow, flows[:, i], atol = 1e-5)
         @test isapprox(1 / basepower .* net_flow_tf, -flows[:, i], atol = 1e-5)
     end

--- a/test/test_power_flow_data.jl
+++ b/test/test_power_flow_data.jl
@@ -62,7 +62,7 @@ end
                     sys_original;
                     correct_bustypes = true,
                 )
-            modify_rts_powerflow!(data_modified)
+            modify_rts_power_flow!(data_modified)
 
             # update_system! with unmodified PowerFlowData should result in system that yields unmodified PowerFlowData
             # (NOTE does NOT necessarily yield original system due to power redistribution)
@@ -75,19 +75,19 @@ end
                     sys_null_updated;
                     correct_bustypes = true,
                 )
-            @test IS.compare_values(powerflow_match_fn, data_null_updated, data_original)
+            @test IS.compare_values(power_flow_match_fn, data_null_updated, data_original)
 
             # Modified versions should not be the same as unmodified versions
             @test !@test_logs((:error, r"values do not match"),
                 match_mode = :any, min_level = Logging.Error,
-                IS.compare_values(powerflow_match_fn, data_original, data_modified))
+                IS.compare_values(power_flow_match_fn, data_original, data_modified))
             @test !@test_logs((:error, r"values do not match"),
                 match_mode = :any, min_level = Logging.Error,
-                IS.compare_values(powerflow_match_fn, sys_original, sys_modified))
+                IS.compare_values(power_flow_match_fn, sys_original, sys_modified))
 
             # Constructing PowerFlowData from modified system should result in data_modified
             @test IS.compare_values(
-                powerflow_match_fn,
+                power_flow_match_fn,
                 PowerFlowData(
                     ACPowerFlow{ACSolver}(),
                     sys_modified;
@@ -108,7 +108,7 @@ end
                     correct_bustypes = true,
                 ),
             )
-            @test IS.compare_values(powerflow_match_fn, sys_modify_updated, sys_mod_redist)
+            @test IS.compare_values(power_flow_match_fn, sys_modify_updated, sys_mod_redist)
         end
     end
 end
@@ -172,7 +172,7 @@ end
     )
     @assert PSY.get_bustype(pv_bus) == PSY.ACBusTypes.PV
     # on the other hand, DC power flow is fine: PV vs PQ doesn't matter.
-    solve_powerflow(PF.DCPowerFlow(), sys)
+    solve_power_flow(PF.DCPowerFlow(), sys)
     # No available generators at REF bus does error for DC power flow.
     ref_bus = findfirst(bus -> PSY.get_bustype(bus) == PSY.ACBusTypes.REF, buses)
     ref_bus = buses[ref_bus]

--- a/test/test_psse_export.jl
+++ b/test/test_psse_export.jl
@@ -258,8 +258,8 @@ function test_power_flow(
     sys2::System;
     exclude_reactive_flow = false,
 )
-    result1 = solve_powerflow(pf, sys1; correct_bustypes = true)
-    result2 = solve_powerflow(pf, sys2; correct_bustypes = true)
+    result1 = solve_power_flow(pf, sys1; correct_bustypes = true)
+    result2 = solve_power_flow(pf, sys2; correct_bustypes = true)
     reactive_power_tol =
         exclude_reactive_flow ? nothing : POWERFLOW_COMPARISON_TOLERANCE
     @test compare_df_within_tolerance("bus_results", result1["bus_results"],
@@ -276,8 +276,8 @@ function test_power_flow(
     sys1::System,
     sys2::System,
 )
-    result1 = solve_powerflow(pf, sys1; correct_bustypes = true)
-    result2 = solve_powerflow(pf, sys2; correct_bustypes = true)
+    result1 = solve_power_flow(pf, sys1; correct_bustypes = true)
+    result2 = solve_power_flow(pf, sys2; correct_bustypes = true)
     @test compare_df_within_tolerance("bus_results", result1["1"]["bus_results"],
         result2["1"]["bus_results"], POWERFLOW_COMPARISON_TOLERANCE)
     @test compare_df_within_tolerance("flow_results",

--- a/test/test_reduced_ac_power_flow.jl
+++ b/test/test_reduced_ac_power_flow.jl
@@ -23,7 +23,7 @@ ac_reduction_types = Dict{String, Vector{PNM.NetworkReduction}}(
         sys;
         correct_bustypes = true,
     )
-    PF.solve_powerflow!(unreduced)
+    PF.solve_power_flow!(unreduced)
     @assert all(unreduced.converged)
     pf = ACPowerFlow(PF.TrustRegionACPowerFlow)
     for (k, v) in ac_reduction_types
@@ -33,7 +33,7 @@ ac_reduction_types = Dict{String, Vector{PNM.NetworkReduction}}(
             continue
         end
         @testset "$k reduction" begin
-            validate_reduced_powerflow(pf, sys, v, unreduced)
+            validate_reduced_power_flow(pf, sys, v, unreduced)
         end
     end
 end
@@ -48,7 +48,7 @@ end
             continue
         end
         @testset "$k reduction" begin
-            result = test_reduced_powerflow(pf, sys, v)
+            result = test_reduced_power_flow(pf, sys, v)
             @test all(result.converged)
         end
     end
@@ -57,7 +57,7 @@ end
     #=
     @testset "ward reduction" begin
         study_buses = [101, 114, 110, 111]
-        result = test_reduced_powerflow(
+        result = test_reduced_power_flow(
             pf,
             sys,
             PNM.NetworkReduction[PNM.WardReduction(study_buses)],
@@ -67,7 +67,7 @@ end
     =#
 end
 
-@testset "system + powerflow solver calls" begin
+@testset "system + power_flow solver calls" begin
     for (k, v) in ac_reduction_types
         @testset "$k reduction" begin
             sys = build_system(
@@ -79,7 +79,7 @@ end
             if !supported
                 results = @test_logs((:error, r"failed to converge"),
                     match_mode = :any,
-                    solve_powerflow(
+                    solve_power_flow(
                         pf,
                         sys;
                         correct_bustypes = true,
@@ -87,7 +87,7 @@ end
                     )
                 )
             else
-                results = solve_powerflow(
+                results = solve_power_flow(
                     pf,
                     sys;
                     correct_bustypes = true,
@@ -178,8 +178,8 @@ function compare_power_flows(
     name = PSY.get_name(branch)
     arc_lookup = PF.get_arc_lookup(unreduced)
     arc_ix = arc_lookup[PNM.get_arc_tuple(branch)]
-    unreduced_active_flow = unreduced.arc_activepower_flow_from_to[arc_ix, 1]
-    unreduced_reactive_flow = unreduced.arc_reactivepower_flow_from_to[arc_ix, 1]
+    unreduced_active_flow = unreduced.arc_active_power_flow_from_to[arc_ix, 1]
+    unreduced_reactive_flow = unreduced.arc_reactive_power_flow_from_to[arc_ix, 1]
     reduced_active_flow =
         PSY.get_active_power_flow(PSY.get_component(PSY.Branch, sys, name))
     reduced_reactive_flow =
@@ -200,7 +200,7 @@ end
         correct_bustypes = true,
     )
     pf = PF.ACPowerFlow{PF.TrustRegionACPowerFlow}(; skip_redistribution = true)
-    PF.solve_powerflow!(unreduced; pf = pf)
+    PF.solve_power_flow!(unreduced; pf = pf)
     PF.solve_and_store_power_flow!(
         pf,
         sys;
@@ -218,11 +218,11 @@ end
     for (equiv_arc, branches) in parallel_br_map
         equiv_arc_ix = arc_lookup[equiv_arc]
         net_flow_from_to =
-            unreduced.arc_activepower_flow_from_to[equiv_arc_ix, 1] +
-            im * unreduced.arc_reactivepower_flow_from_to[equiv_arc_ix, 1]
+            unreduced.arc_active_power_flow_from_to[equiv_arc_ix, 1] +
+            im * unreduced.arc_reactive_power_flow_from_to[equiv_arc_ix, 1]
         net_flow_to_from =
-            unreduced.arc_activepower_flow_to_from[equiv_arc_ix, 1] +
-            im * unreduced.arc_reactivepower_flow_to_from[equiv_arc_ix, 1]
+            unreduced.arc_active_power_flow_to_from[equiv_arc_ix, 1] +
+            im * unreduced.arc_reactive_power_flow_to_from[equiv_arc_ix, 1]
         total_flow = zero(ComplexF32)
         expected_from_bus = equiv_arc[1]
         (from_bus_no, to_bus_no) = PNM.get_arc_tuple(first(branches))
@@ -251,7 +251,7 @@ end
         correct_bustypes = true,
     )
     pf = PF.ACPowerFlow{PF.TrustRegionACPowerFlow}(; skip_redistribution = true)
-    PF.solve_powerflow!(unreduced; pf = pf)
+    PF.solve_power_flow!(unreduced; pf = pf)
     PF.solve_and_store_power_flow!(
         pf,
         sys;

--- a/test/test_reduced_dc_power_flow.jl
+++ b/test/test_reduced_dc_power_flow.jl
@@ -1,4 +1,4 @@
-dc_powerflows = (
+dc_power_flows = (
     PF.DCPowerFlow(),
     PF.PTDFDCPowerFlow(),
     PF.vPTDFDCPowerFlow(),
@@ -16,10 +16,10 @@ dc_reduction_types = Dict{String, Vector{PNM.NetworkReduction}}(
                                            InteractiveUtils.subtypes(PF.AbstractDCPowerFlow)
             dc_pf = pf_type()
             unreduced = PF.PowerFlowData(dc_pf, sys; correct_bustypes = true)
-            PF.solve_powerflow!(unreduced)
+            PF.solve_power_flow!(unreduced)
             @assert all(unreduced.converged)
-            validate_reduced_powerflow(dc_pf, sys, v, unreduced)
-            results = PF.solve_powerflow(
+            validate_reduced_power_flow(dc_pf, sys, v, unreduced)
+            results = PF.solve_power_flow(
                 dc_pf,
                 sys;
                 network_reductions = deepcopy(v),

--- a/test/test_robust_power_flow.jl
+++ b/test/test_robust_power_flow.jl
@@ -1,15 +1,15 @@
-@testset "test robust homotopy powerflow" begin
+@testset "test robust homotopy power_flow" begin
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
     sys2 = deepcopy(sys)
     pf_hom = ACPowerFlow{PF.RobustHomotopyPowerFlow}()
     data_hom = PowerFlowData(pf_hom, sys)
     # infologger = ConsoleLogger(stderr, Logging.Info)
-    # with_logger(infologger) do; solve_powerflow!(data_hom; pf = pf_hom); end;
-    solve_powerflow!(data_hom; pf = pf_hom)
+    # with_logger(infologger) do; solve_power_flow!(data_hom; pf = pf_hom); end;
+    solve_power_flow!(data_hom; pf = pf_hom)
 
     pf_nr = ACPowerFlow()
     data_nr = PowerFlowData(pf_nr, sys2)
-    solve_powerflow!(data_nr; pf = pf_nr)
+    solve_power_flow!(data_nr; pf = pf_nr)
     @test isapprox(data_nr.bus_angles, data_hom.bus_angles; atol = 1e-4)
     @test isapprox(data_nr.bus_magnitude, data_hom.bus_magnitude; atol = 1e-6)
 end

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -3,7 +3,7 @@ import PowerFlows
 
 struct LUACPowerFlow <: ACPowerFlowSolverType end  # Only for testing, a basic implementation using LinearAlgebra.lu, allocates a lot of memory
 
-"""This function is to be able to compare the results of the legacy powerflow solver with the new one"""
+"""This function is to be able to compare the results of the legacy power_flow solver with the new one"""
 function _calc_x(
     data::PowerFlows.ACPowerFlowData,
     time_step::Int64,
@@ -16,16 +16,16 @@ function _calc_x(
         if bt == PSY.ACBusTypes.REF
             # When bustype == REFERENCE PSY.ACBus, state variables are Active and Reactive Power Generated
             x[2 * ix - 1] =
-                data.bus_activepower_injection[ix, time_step] -
-                data.bus_activepower_withdrawals[ix, time_step]
+                data.bus_active_power_injections[ix, time_step] -
+                data.bus_active_power_withdrawals[ix, time_step]
             x[2 * ix] =
-                data.bus_reactivepower_injection[ix, time_step] -
-                data.bus_reactivepower_withdrawals[ix, time_step]
+                data.bus_reactive_power_injections[ix, time_step] -
+                data.bus_reactive_power_withdrawals[ix, time_step]
         elseif bt == PSY.ACBusTypes.PV
             # When bustype == PV PSY.ACBus, state variables are Reactive Power Generated and Voltage Angle
             x[2 * ix - 1] =
-                data.bus_reactivepower_injection[ix, time_step] -
-                data.bus_reactivepower_withdrawals[ix, time_step]
+                data.bus_reactive_power_injections[ix, time_step] -
+                data.bus_reactive_power_withdrawals[ix, time_step]
             x[2 * ix] = data.bus_angles[ix, time_step]
         elseif bt == PSY.ACBusTypes.PQ
             # When bustype == PQ PSY.ACBus, state variables are Voltage Magnitude and Voltage Angle
@@ -122,7 +122,7 @@ function _legacy_J(
 end
 
 # legacy NR implementation - here we do not care about allocations, we use this function only for testing purposes
-function PowerFlows._newton_powerflow(
+function PowerFlows._newton_power_flow(
     pf::ACPowerFlow{LUACPowerFlow},
     data::PowerFlows.ACPowerFlowData,
     time_step::Int64;
@@ -153,11 +153,11 @@ function PowerFlows._newton_powerflow(
     dx = zeros(Float64, npv + 2 * npq)
 
     Sbus =
-        data.bus_activepower_injection[:, time_step] -
-        data.bus_activepower_withdrawals[:, time_step] +
+        data.bus_active_power_injections[:, time_step] -
+        data.bus_active_power_withdrawals[:, time_step] +
         1im * (
-            data.bus_reactivepower_injection[:, time_step] -
-            data.bus_reactivepower_withdrawals[:, time_step]
+            data.bus_reactive_power_injections[:, time_step] -
+            data.bus_reactive_power_withdrawals[:, time_step]
         )
 
     mis = V .* conj.(Ybus * V) .- Sbus
@@ -198,19 +198,19 @@ function PowerFlows._newton_powerflow(
         if data.calculate_loss_factors
             data.loss_factors[:, time_step] .= NaN
         end
-        @error("The legacy powerflow solver with LU did not converge after $i iterations")
+        @error("The legacy power_flow solver with LU did not converge after $i iterations")
     else
         Sbus_result = V .* conj.(Ybus * V)
         data.bus_magnitude[:, time_step] .= Vm
         data.bus_angles[:, time_step] .= Va
-        P_gen = real(Sbus_result) + data.bus_activepower_withdrawals[:, time_step]
-        Q_gen = imag(Sbus_result) + data.bus_reactivepower_withdrawals[:, time_step]
+        P_gen = real(Sbus_result) + data.bus_active_power_withdrawals[:, time_step]
+        Q_gen = imag(Sbus_result) + data.bus_reactive_power_withdrawals[:, time_step]
         for (ix, bt) in enumerate(data.bus_type[:, time_step])
             if bt == PSY.ACBusTypes.REF
-                data.bus_activepower_injection[ix, time_step] = P_gen[ix]
-                data.bus_reactivepower_injection[ix, time_step] = Q_gen[ix]
+                data.bus_active_power_injections[ix, time_step] = P_gen[ix]
+                data.bus_reactive_power_injections[ix, time_step] = Q_gen[ix]
             elseif bt == PSY.ACBusTypes.PV
-                data.bus_reactivepower_injection[ix, time_step] = Q_gen[ix]
+                data.bus_reactive_power_injections[ix, time_step] = Q_gen[ix]
             end
         end
 
@@ -231,7 +231,7 @@ function PowerFlows._newton_powerflow(
             data.voltage_stability_factors[pv, time_step] .= 0.0
             data.voltage_stability_factors[pq, time_step] .= v
         end
-        @info("The legacy powerflow solver with LU converged after $i iterations")
+        @info("The legacy power_flow solver with LU converged after $i iterations")
     end
     return converged
 end

--- a/test/test_utils/penalty_factors_brute_force.jl
+++ b/test/test_utils/penalty_factors_brute_force.jl
@@ -9,7 +9,7 @@ The loss factor value is computed as the change in the reference bus power injec
 # Arguments
 - `data::PowerFlowData`: The power flow data containing bus types, active power injections, and other relevant information.
 - `step_size::Float64 = 1e-6`: The step size used to perturb the active power injection at each bus.
-- `kwargs...`: Additional keyword arguments to be passed to the `solve_powerflow!` function.
+- `kwargs...`: Additional keyword arguments to be passed to the `solve_power_flow!` function.
 
 # Returns
 - `loss_factors::Array{Float64, 2}`: A 2D array of penalty factors for each bus and time step.
@@ -33,26 +33,26 @@ function penalty_factors_brute_force(
     ref, = PowerFlows.bus_type_idx(data, 1, (PSY.ACBusTypes.REF,))
 
     n_buses = first(size(data.bus_type))
-    time_steps = collect(values(data.timestep_map))
+    time_steps = collect(values(data.time_step_map))
 
     loss_factors = zeros(Float64, n_buses, length(time_steps))
 
     # initial PF to establish the ref power value
-    solve_powerflow!(data; pf = pf, kwargs...)
+    solve_power_flow!(data; pf = pf, kwargs...)
 
-    ref_power = copy(sum(data.bus_activepower_injection[ref, :]; dims = 1))
+    ref_power = copy(sum(data.bus_active_power_injections[ref, :]; dims = 1))
 
     for bx in 1:n_buses
         if bx in ref
             loss_factors[bx, :] .= 1.0
             continue
         end
-        data.bus_activepower_injection[bx, :] .+= step_size
-        solve_powerflow!(data; pf = pf, kwargs...)
+        data.bus_active_power_injections[bx, :] .+= step_size
+        solve_power_flow!(data; pf = pf, kwargs...)
         loss_factors[[bx], :] .=
-            (sum(data.bus_activepower_injection[ref, :]; dims = 1) .- ref_power) ./
+            (sum(data.bus_active_power_injections[ref, :]; dims = 1) .- ref_power) ./
             step_size
-        data.bus_activepower_injection[bx, :] .-= step_size
+        data.bus_active_power_injections[bx, :] .-= step_size
     end
     return loss_factors
 end

--- a/test/test_utils/validate_reduced_power_flow.jl
+++ b/test/test_utils/validate_reduced_power_flow.jl
@@ -1,4 +1,4 @@
-function test_reduced_powerflow(
+function test_reduced_power_flow(
     pf::PF.PowerFlowEvaluationModel,
     sys::PSY.System,
     nrs::Vector{PNM.NetworkReduction},
@@ -11,9 +11,9 @@ function test_reduced_powerflow(
         network_reductions = deepcopy(nrs),
     )
     if pf isa PF.ACPowerFlow
-        PF.solve_powerflow!(data; pf = pf)
+        PF.solve_power_flow!(data; pf = pf)
     else
-        PF.solve_powerflow!(data)
+        PF.solve_power_flow!(data)
     end
     return data
 end
@@ -33,11 +33,11 @@ function get_branch_flows(data::PF.PowerFlowData)
     arc_ax = PF.get_arc_axis(data)
     for (i, arc) in enumerate(arc_ax)
         branch_flows[arc] =
-            data.arc_activepower_flow_from_to[i] .+
-            (im .* data.arc_reactivepower_flow_from_to[i])
+            data.arc_active_power_flow_from_to[i] .+
+            (im .* data.arc_reactive_power_flow_from_to[i])
         branch_flows[reverse(arc)] =
-            data.arc_activepower_flow_to_from[i] .+
-            (im .* data.arc_reactivepower_flow_to_from[i])
+            data.arc_active_power_flow_to_from[i] .+
+            (im .* data.arc_reactive_power_flow_to_from[i])
     end
     return branch_flows
 end
@@ -52,7 +52,7 @@ function get_reduced_buses(nrd::PNM.NetworkReductionData)
     return reduced_buses
 end
 
-function validate_reduced_powerflow(
+function validate_reduced_power_flow(
     pf::PF.PowerFlowEvaluationModel,
     sys::PSY.System,
     nrs::Vector{PNM.NetworkReduction},
@@ -65,9 +65,9 @@ function validate_reduced_powerflow(
         correct_bustypes = true,
     )
     if pf isa PF.ACPowerFlow
-        PF.solve_powerflow!(data; pf = pf)
+        PF.solve_power_flow!(data; pf = pf)
     else
-        PF.solve_powerflow!(data)
+        PF.solve_power_flow!(data)
     end
     @test all(data.converged)
     reduced_bus_results = get_bus_voltages(data)


### PR DESCRIPTION
Address the first 4 bullet points in issue #230:

- `powerflow` => `power_flow`
- `activepower` => `active_power`
- `timestep` => `time_step`
- `injection` => `injections`.

The 5th bullet point: do we want `bustype` (consistent with PSY) or `bus_type` (different)?

Note that this is compatibility-breaking, since I'm changing the names of fields and functions. But imo we should fix these things while we can. I outlined my reasoning for these changes in #265: mostly it's consistency with PSY