### PR TITLE
prep for contingencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,8 @@ $RECYCLE.BIN/
 
 ## Acknowledgements
 # Many thanks to `https://gitignore.io/`, written and maintained by Joe Blau, which contributed much material to this gitignore file.
+
+# Claude
+hooks
+settings.*.json
+settings.json

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -59,22 +59,12 @@ the respective type of power flow evaluations.
 - `bus_reactive_power_bounds::Matrix{Float64}`:
         matrix containing upper and lower bounds for the reactive supply at each
         bus at each time period.
-- `bus_type::Matrix{PSY.ACBusTypes}`:
-        matrix containing type of buses present in the system.
-- `bus_magnitude::Matrix{Float64}`:
-        matrix containing the bus voltage magnitudes.
-- `bus_angles::Matrix{Float64}`:
-        matrix containing the bus voltage angles.
-- `arc_active_power_flow_from_to::Matrix{Float64}`:
-        matrix containing the active power flows measured at the `from` bus.
-- `arc_reactive_power_flow_from_to::Matrix{Float64}`:
-        matrix containing the reactive power flows measured at the `from` bus.
-- `arc_active_power_flow_to_from::Matrix{Float64}`:
-        matrix containing the active power flows measured at the `to` bus.
-- `arc_reactive_power_flow_to_from::Matrix{Float64}`:
-        matrix containing the reactive power flows measured at the `to` bus.
-- `arc_angle_differences::Matrix{Float64}`:
-        matrix containing the voltage angle difference (θ_from − θ_to) across each arc.
+- `results::R`:
+        result storage container (see [`TimePowerFlowData`](@ref) or
+        [`TimeContingencyPowerFlowData`](@ref)). Result fields such as `bus_magnitude`,
+        `bus_angles`, `bus_type`, arc flows, `converged`, `loss_factors`, etc. are
+        stored here but accessible directly via `data.bus_magnitude` through property
+        forwarding.
 - `generic_hvdc_flows::Dict{Tuple{Int, Int}, Tuple{Float64, Float64}}`:
         dictionary mapping each generic HVDC line (represented as a tuple of the from and to bus
         numbers) to a tuple of `(P_from_to, P_to_from)` active power flows.
@@ -222,6 +212,7 @@ get_arc_reactive_power_flow_to_from(pfd::PowerFlowData) =
     pfd.arc_reactive_power_flow_to_from
 get_arc_angle_differences(pfd::PowerFlowData) = pfd.arc_angle_differences
 get_time_step_map(pfd::PowerFlowData) = pfd.time_step_map
+get_results(pfd::PowerFlowData) = pfd.results
 get_power_network_matrix(pfd::PowerFlowData) = pfd.power_network_matrix
 get_aux_network_matrix(pfd::PowerFlowData) = pfd.aux_network_matrix
 get_neighbor(pfd::PowerFlowData) = pfd.neighbors

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -97,6 +97,7 @@ struct PowerFlowData{
     T <: PowerFlowEvaluationModel,
     M <: PNM.PowerNetworkMatrix,
     N <: Union{PNM.PowerNetworkMatrix, Nothing},
+    R <: AbstractPowerFlowResults,
 } <: PowerFlowContainer
     pf::T
     bus_active_power_injections::Matrix{Float64}
@@ -113,27 +114,38 @@ struct PowerFlowData{
     computed_generator_slack_participation_factors::Vector{
         Dict{Tuple{DataType, String}, Float64},
     }
-    bus_type::Matrix{PSY.ACBusTypes}
-    bus_magnitude::Matrix{Float64}
-    bus_angles::Matrix{Float64}
-    arc_active_power_flow_from_to::Matrix{Float64}
-    arc_reactive_power_flow_from_to::Matrix{Float64}
-    arc_active_power_flow_to_from::Matrix{Float64}
-    arc_reactive_power_flow_to_from::Matrix{Float64}
-    arc_angle_differences::Matrix{Float64}
+    results::R
     generic_hvdc_flows::Dict{Tuple{Int, Int}, Tuple{Float64, Float64}}
     bus_hvdc_net_power::Matrix{Float64}
     time_step_map::Dict{Int, String}
     power_network_matrix::M
     aux_network_matrix::N
     neighbors::Vector{Set{Int}}
-    converged::BitVector
-    loss_factors::Union{Matrix{Float64}, Nothing}
-    voltage_stability_factors::Union{Matrix{Float64}, Nothing}
-    arc_active_power_losses::Union{Matrix{Float64}, Nothing}
     lcc::LCCParameters
     arc_lossy_admittance_from_to::Union{SparseMatrixCSC{YBUS_ELTYPE, Int}, Nothing}
     arc_lossy_admittance_to_from::Union{SparseMatrixCSC{YBUS_ELTYPE, Int}, Nothing}
+end
+
+const _RESULT_FIELD_NAMES = Set{Symbol}([
+    :bus_magnitude,
+    :bus_angles,
+    :bus_type,
+    :arc_active_power_flow_from_to,
+    :arc_reactive_power_flow_from_to,
+    :arc_active_power_flow_to_from,
+    :arc_reactive_power_flow_to_from,
+    :arc_angle_differences,
+    :converged,
+    :loss_factors,
+    :voltage_stability_factors,
+    :arc_active_power_losses,
+])
+
+function Base.getproperty(pfd::PowerFlowData, s::Symbol)
+    if s in _RESULT_FIELD_NAMES
+        return getfield(getfield(pfd, :results), s)
+    end
+    return getfield(pfd, s)
 end
 
 # aliases for specific type parameter combinations.
@@ -146,6 +158,7 @@ const ACPowerFlowData = PowerFlowData{
         PNM.DC_ABA_Matrix_Factorized,
         Nothing,
     },
+    <:AbstractPowerFlowResults,
 }
 get_metadata_matrix(pfd::ACPowerFlowData) = pfd.power_network_matrix
 
@@ -155,6 +168,7 @@ const PTDFPowerFlowData = PowerFlowData{
     PTDFDCPowerFlow,
     PNM.DC_PTDF_Matrix,
     PNM.DC_ABA_Matrix_Factorized,
+    <:AbstractPowerFlowResults,
 }
 
 """A type alias for a `PowerFlowData` struct whose type parameters
@@ -163,6 +177,7 @@ const vPTDFPowerFlowData = PowerFlowData{
     vPTDFDCPowerFlow,
     <:PNM.DC_vPTDF_Matrix,
     PNM.DC_ABA_Matrix_Factorized,
+    <:AbstractPowerFlowResults,
 }
 get_metadata_matrix(pfd::Union{PTDFPowerFlowData, vPTDFPowerFlowData}) =
     pfd.power_network_matrix
@@ -173,6 +188,7 @@ const ABAPowerFlowData = PowerFlowData{
     DCPowerFlow,
     PNM.DC_ABA_Matrix_Factorized,
     PNM.DC_BA_Matrix,
+    <:AbstractPowerFlowResults,
 }
 get_metadata_matrix(pfd::ABAPowerFlowData) = pfd.aux_network_matrix
 
@@ -295,10 +311,6 @@ bus_count(::DCPowerFlow,
     aux_network_matrix::Union{PNM.PowerNetworkMatrix, Nothing}) =
     length(PNM.get_bus_axis(aux_network_matrix))
 
-_make_arc_active_power_losses(::AbstractDCPowerFlow, n_arcs, n_time_steps) =
-    zeros(n_arcs, n_time_steps)
-_make_arc_active_power_losses(::PowerFlowEvaluationModel, n_arcs, n_time_steps) = nothing
-
 """
 Sets the two `PowerNetworkMatrix` fields and a few others (`time_steps`, `time_step_map`),
 then creates arrays of default values (usually zeros) for the rest.
@@ -333,6 +345,16 @@ function PowerFlowData(
     calculate_voltage_stability_factors = get_calculate_voltage_stability_factors(pf)
 
     lcc_parameters = LCCParameters(n_time_steps, n_lccs)
+
+    results = TimePowerFlowData(
+        n_buses,
+        n_arcs,
+        n_time_steps;
+        calculate_loss_factors = calculate_loss_factors,
+        calculate_voltage_stability_factors = calculate_voltage_stability_factors,
+        make_arc_active_power_losses = pf isa AbstractDCPowerFlow,
+    )
+
     return PowerFlowData(
         pf,
         zeros(n_buses, n_time_steps), # bus_active_power_injections
@@ -347,24 +369,13 @@ function PowerFlowData(
         spzeros(n_buses, n_time_steps), # bus_slack_participation_factors
         zeros(n_buses, n_time_steps), # bus_active_power_range
         Vector{Dict{Tuple{DataType, String}, Float64}}(), # computed_generator_slack_participation_factors
-        fill(PSY.ACBusTypes.PQ, (n_buses, n_time_steps)), # bus_type
-        ones(n_buses, n_time_steps), # bus_magnitude
-        zeros(n_buses, n_time_steps), # bus_angles
-        zeros(n_arcs, n_time_steps), # arc_active_power_flow_from_to
-        zeros(n_arcs, n_time_steps), # arc_reactive_power_flow_from_to
-        zeros(n_arcs, n_time_steps), # arc_active_power_flow_to_from
-        zeros(n_arcs, n_time_steps), # arc_reactive_power_flow_to_from
-        zeros(n_arcs, n_time_steps), # arc_angle_differences
+        results,
         Dict{Tuple{Int, Int}, Tuple{Float64, Float64}}(), # generic_hvdc_flows
         zeros(n_buses, n_time_steps), # bus_hvdc_net_power
         time_step_map,
         power_network_matrix,
         aux_network_matrix,
         neighbors,
-        falses(n_time_steps), # converged
-        calculate_loss_factors ? zeros(n_buses, n_time_steps) : nothing, # loss_factors
-        calculate_voltage_stability_factors ? zeros(n_buses, n_time_steps) : nothing, # voltage_stability_factors
-        _make_arc_active_power_losses(pf, n_arcs, n_time_steps), # arc_active_power_losses
         lcc_parameters,
         arc_lossy_admittance_from_to,
         arc_lossy_admittance_to_from,

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -36,14 +36,6 @@ these are all aliases for `PowerFlowData{N, M}` with specific `N`,`M`, that are 
 the respective type of power flow evaluations.
 
 # Fields:
-- `bus_active_power_injections::Matrix{Float64}`:
-        matrix containing the bus active power injections.
-- `bus_reactive_power_injections::Matrix{Float64}`:
-        matrix containing the bus reactive power injections.
-- `bus_active_power_withdrawals::Matrix{Float64}`:
-        matrix containing the bus reactive power withdrawals.
-- `bus_reactive_power_withdrawals::Matrix{Float64}`:
-        matrix containing the bus reactive power withdrawals.
 - `bus_active_power_constant_current_withdrawals::Matrix{Float64}`:
         matrix containing the bus active power constant current
         withdrawals.
@@ -90,10 +82,6 @@ struct PowerFlowData{
     R <: AbstractPowerFlowResults,
 } <: PowerFlowContainer
     pf::T
-    bus_active_power_injections::Matrix{Float64}
-    bus_reactive_power_injections::Matrix{Float64}
-    bus_active_power_withdrawals::Matrix{Float64}
-    bus_reactive_power_withdrawals::Matrix{Float64}
     bus_active_power_constant_current_withdrawals::Matrix{Float64}
     bus_reactive_power_constant_current_withdrawals::Matrix{Float64}
     bus_active_power_constant_impedance_withdrawals::Matrix{Float64}
@@ -116,26 +104,31 @@ struct PowerFlowData{
     arc_lossy_admittance_to_from::Union{SparseMatrixCSC{YBUS_ELTYPE, Int}, Nothing}
 end
 
-const _RESULT_FIELD_NAMES = Set{Symbol}([
-    :bus_magnitude,
-    :bus_angles,
-    :bus_type,
-    :arc_active_power_flow_from_to,
-    :arc_reactive_power_flow_from_to,
-    :arc_active_power_flow_to_from,
-    :arc_reactive_power_flow_to_from,
-    :arc_angle_differences,
-    :converged,
-    :loss_factors,
-    :voltage_stability_factors,
-    :arc_active_power_losses,
-])
-
+# Uses an explicit === chain instead of `s in _RESULT_FIELD_NAMES` for type stability.
 function Base.getproperty(pfd::PowerFlowData, s::Symbol)
-    if s in _RESULT_FIELD_NAMES
+    if s === :bus_magnitude ||
+       s === :bus_angles ||
+       s === :bus_type ||
+       s === :bus_active_power_injections ||
+       s === :bus_reactive_power_injections ||
+       s === :bus_active_power_withdrawals ||
+       s === :bus_reactive_power_withdrawals ||
+       s === :arc_active_power_flow_from_to ||
+       s === :arc_reactive_power_flow_from_to ||
+       s === :arc_active_power_flow_to_from ||
+       s === :arc_reactive_power_flow_to_from ||
+       s === :arc_angle_differences ||
+       s === :converged ||
+       s === :loss_factors ||
+       s === :voltage_stability_factors ||
+       s === :arc_active_power_losses
         return getfield(getfield(pfd, :results), s)
     end
     return getfield(pfd, s)
+end
+
+function Base.propertynames(pfd::PowerFlowData, private::Bool = false)
+    return (fieldnames(typeof(pfd))..., _RESULT_FIELD_NAMES...)
 end
 
 # aliases for specific type parameter combinations.
@@ -348,10 +341,6 @@ function PowerFlowData(
 
     return PowerFlowData(
         pf,
-        zeros(n_buses, n_time_steps), # bus_active_power_injections
-        zeros(n_buses, n_time_steps), # bus_reactive_power_injections
-        zeros(n_buses, n_time_steps), # bus_active_power_withdrawals
-        zeros(n_buses, n_time_steps), # bus_reactive_power_withdrawals
         zeros(n_buses, n_time_steps), # bus_active_power_constant_current_withdrawals
         zeros(n_buses, n_time_steps), # bus_reactive_power_constant_current_withdrawals
         zeros(n_buses, n_time_steps), # bus_active_power_constant_impedance_withdrawals
@@ -684,12 +673,8 @@ end
 """Compute arc angle differences for all arcs and all time steps, looking up
 bus indices from the arc axis and bus lookup stored in `data`. Used by DC solvers."""
 function _compute_arc_angle_differences_from_data!(
-    data::PowerFlowData{T, M, N},
-) where {
-    T <: PowerFlowEvaluationModel,
-    M <: PNM.PowerNetworkMatrix,
-    N <: Union{PNM.PowerNetworkMatrix, Nothing},
-}
+    data::PowerFlowData,
+)
     arcs = get_arc_axis(data)
     bus_lookup = get_bus_lookup(data)
     fb_ix = [bus_lookup[bus_no] for bus_no in first.(arcs)]
@@ -703,15 +688,11 @@ end
 over specified time steps. Used by the AC solver where `fb_ix`/`tb_ix` are
 already available from the branch flow calculation."""
 function _compute_arc_angle_differences_from_indices!(
-    data::PowerFlowData{T, M, N},
+    data::PowerFlowData,
     fb_ix::Vector{Int},
     tb_ix::Vector{Int},
     time_steps::Vector{Int},
-) where {
-    T <: PowerFlowEvaluationModel,
-    M <: PNM.PowerNetworkMatrix,
-    N <: Union{PNM.PowerNetworkMatrix, Nothing},
-}
+)
     @views data.arc_angle_differences[:, time_steps] .=
         data.bus_angles[fb_ix, time_steps] .- data.bus_angles[tb_ix, time_steps]
     return

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -104,25 +104,10 @@ struct PowerFlowData{
     arc_lossy_admittance_to_from::Union{SparseMatrixCSC{YBUS_ELTYPE, Int}, Nothing}
 end
 
-# Uses an explicit === chain instead of `s in _RESULT_FIELD_NAMES` for type stability.
-function Base.getproperty(pfd::PowerFlowData, s::Symbol)
-    if s === :bus_magnitude ||
-       s === :bus_angles ||
-       s === :bus_type ||
-       s === :bus_active_power_injections ||
-       s === :bus_reactive_power_injections ||
-       s === :bus_active_power_withdrawals ||
-       s === :bus_reactive_power_withdrawals ||
-       s === :arc_active_power_flow_from_to ||
-       s === :arc_reactive_power_flow_from_to ||
-       s === :arc_active_power_flow_to_from ||
-       s === :arc_reactive_power_flow_to_from ||
-       s === :arc_angle_differences ||
-       s === :converged ||
-       s === :loss_factors ||
-       s === :voltage_stability_factors ||
-       s === :arc_active_power_losses
-        return getfield(getfield(pfd, :results), s)
+Base.@constprop :aggressive @inline function Base.getproperty(pfd::PowerFlowData, s::Symbol)
+    results = getfield(pfd, :results)
+    if hasfield(typeof(results), s)
+        return getfield(results, s)
     end
     return getfield(pfd, s)
 end
@@ -334,6 +319,7 @@ function PowerFlowData(
         n_buses,
         n_arcs,
         n_time_steps;
+        n_lccs = n_lccs,
         calculate_loss_factors = calculate_loss_factors,
         calculate_voltage_stability_factors = calculate_voltage_stability_factors,
         make_arc_active_power_losses = pf isa AbstractDCPowerFlow,

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -20,6 +20,8 @@ export update_exporter!
 export write_export
 export get_psse_export_paths
 export FlowReporting
+export AbstractPowerFlowResults
+export TimePowerFlowData
 # "protected" (semi-stable because used in PSI) but not exported:
 # PowerFlowData and related type aliases, solve_power_flow!, write_results
 
@@ -51,6 +53,7 @@ include("psi_utils.jl")
 include("powersystems_utils.jl")
 include("power_flow_types.jl")
 include("lcc_parameters.jl")
+include("power_flow_results.jl")
 include("PowerFlowData.jl")
 include("lcc_utils.jl")
 include("common.jl")

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -22,6 +22,7 @@ export get_psse_export_paths
 export FlowReporting
 export AbstractPowerFlowResults
 export TimePowerFlowData
+export TimeContingencyPowerFlowData
 # "protected" (semi-stable because used in PSI) but not exported:
 # PowerFlowData and related type aliases, solve_power_flow!, write_results
 

--- a/src/power_flow_results.jl
+++ b/src/power_flow_results.jl
@@ -3,6 +3,26 @@ Abstract supertype for all power flow result containers.
 """
 abstract type AbstractPowerFlowResults end
 
+"""Fields stored in result containers and forwarded from `PowerFlowData` via `getproperty`."""
+const _RESULT_FIELD_NAMES = (
+    :bus_magnitude,
+    :bus_angles,
+    :bus_type,
+    :bus_active_power_injections,
+    :bus_reactive_power_injections,
+    :bus_active_power_withdrawals,
+    :bus_reactive_power_withdrawals,
+    :arc_active_power_flow_from_to,
+    :arc_reactive_power_flow_from_to,
+    :arc_active_power_flow_to_from,
+    :arc_reactive_power_flow_to_from,
+    :arc_angle_differences,
+    :converged,
+    :loss_factors,
+    :voltage_stability_factors,
+    :arc_active_power_losses,
+)
+
 """
     TimePowerFlowData <: AbstractPowerFlowResults
 
@@ -13,6 +33,10 @@ multiple time steps as matrices (rows = buses/arcs, columns = time steps).
 - `bus_magnitude::Matrix{Float64}`: bus voltage magnitudes.
 - `bus_angles::Matrix{Float64}`: bus voltage angles.
 - `bus_type::Matrix{PSY.ACBusTypes}`: bus type classification at each time step.
+- `bus_active_power_injections::Matrix{Float64}`: bus active power injections.
+- `bus_reactive_power_injections::Matrix{Float64}`: bus reactive power injections.
+- `bus_active_power_withdrawals::Matrix{Float64}`: bus active power withdrawals.
+- `bus_reactive_power_withdrawals::Matrix{Float64}`: bus reactive power withdrawals.
 - `arc_active_power_flow_from_to::Matrix{Float64}`: active power flow measured at the from bus.
 - `arc_reactive_power_flow_from_to::Matrix{Float64}`: reactive power flow measured at the from bus.
 - `arc_active_power_flow_to_from::Matrix{Float64}`: active power flow measured at the to bus.
@@ -27,6 +51,10 @@ struct TimePowerFlowData <: AbstractPowerFlowResults
     bus_magnitude::Matrix{Float64}
     bus_angles::Matrix{Float64}
     bus_type::Matrix{PSY.ACBusTypes}
+    bus_active_power_injections::Matrix{Float64}
+    bus_reactive_power_injections::Matrix{Float64}
+    bus_active_power_withdrawals::Matrix{Float64}
+    bus_reactive_power_withdrawals::Matrix{Float64}
     arc_active_power_flow_from_to::Matrix{Float64}
     arc_reactive_power_flow_from_to::Matrix{Float64}
     arc_active_power_flow_to_from::Matrix{Float64}
@@ -63,6 +91,10 @@ function TimePowerFlowData(
         ones(n_buses, n_time_steps),
         zeros(n_buses, n_time_steps),
         fill(PSY.ACBusTypes.PQ, (n_buses, n_time_steps)),
+        zeros(n_buses, n_time_steps),
+        zeros(n_buses, n_time_steps),
+        zeros(n_buses, n_time_steps),
+        zeros(n_buses, n_time_steps),
         zeros(n_arcs, n_time_steps),
         zeros(n_arcs, n_time_steps),
         zeros(n_arcs, n_time_steps),
@@ -86,6 +118,10 @@ across multiple time steps and contingencies as 3D arrays with dimensions
 - `bus_magnitude::Array{Float64, 3}`: bus voltage magnitudes.
 - `bus_angles::Array{Float64, 3}`: bus voltage angles.
 - `bus_type::Array{PSY.ACBusTypes, 3}`: bus type classification at each time step and contingency.
+- `bus_active_power_injections::Array{Float64, 3}`: bus active power injections.
+- `bus_reactive_power_injections::Array{Float64, 3}`: bus reactive power injections.
+- `bus_active_power_withdrawals::Array{Float64, 3}`: bus active power withdrawals.
+- `bus_reactive_power_withdrawals::Array{Float64, 3}`: bus reactive power withdrawals.
 - `arc_active_power_flow_from_to::Array{Float64, 3}`: active power flow measured at the from bus.
 - `arc_reactive_power_flow_from_to::Array{Float64, 3}`: reactive power flow measured at the from bus.
 - `arc_active_power_flow_to_from::Array{Float64, 3}`: active power flow measured at the to bus.
@@ -103,6 +139,10 @@ struct TimeContingencyPowerFlowData <: AbstractPowerFlowResults
     bus_magnitude::Array{Float64, 3}
     bus_angles::Array{Float64, 3}
     bus_type::Array{PSY.ACBusTypes, 3}
+    bus_active_power_injections::Array{Float64, 3}
+    bus_reactive_power_injections::Array{Float64, 3}
+    bus_active_power_withdrawals::Array{Float64, 3}
+    bus_reactive_power_withdrawals::Array{Float64, 3}
     arc_active_power_flow_from_to::Array{Float64, 3}
     arc_reactive_power_flow_from_to::Array{Float64, 3}
     arc_active_power_flow_to_from::Array{Float64, 3}
@@ -145,6 +185,18 @@ function TimeContingencyPowerFlowData(
     make_arc_active_power_losses::Bool = false,
 )
     n_ctg = length(contingency_labels)
+    seen = Set{String}()
+    duplicates = String[]
+    for label in contingency_labels
+        label in seen ? push!(duplicates, label) : push!(seen, label)
+    end
+    if !isempty(duplicates)
+        throw(
+            ArgumentError(
+                "contingency_labels must be unique. Duplicates found: $(duplicates)",
+            ),
+        )
+    end
     if length(network_modifications) != n_ctg
         throw(
             ArgumentError(
@@ -160,6 +212,10 @@ function TimeContingencyPowerFlowData(
         ones(n_buses, n_time_steps, n_ctg),
         zeros(n_buses, n_time_steps, n_ctg),
         fill(PSY.ACBusTypes.PQ, (n_buses, n_time_steps, n_ctg)),
+        zeros(n_buses, n_time_steps, n_ctg),
+        zeros(n_buses, n_time_steps, n_ctg),
+        zeros(n_buses, n_time_steps, n_ctg),
+        zeros(n_buses, n_time_steps, n_ctg),
         zeros(n_arcs, n_time_steps, n_ctg),
         zeros(n_arcs, n_time_steps, n_ctg),
         zeros(n_arcs, n_time_steps, n_ctg),
@@ -225,17 +281,47 @@ function set_network_modification!(
     return nothing
 end
 
+"""Result fields that are 3D arrays in `TimeContingencyPowerFlowData` and support slicing.
+Derived from `_RESULT_FIELD_NAMES`, excluding `:converged` (which is a 2D `BitMatrix`)."""
+const _CONTINGENCY_3D_FIELDS =
+    filter(s -> s !== :converged, _RESULT_FIELD_NAMES)
+
 """
     get_contingency_slice(r::TimeContingencyPowerFlowData, field::Symbol, idx::Int)
 
 Return a 2D view `(entity, time_step)` into the 3D result array for contingency `idx`.
+Only 3D array fields are supported; optional fields that are `nothing` will throw.
 """
 function get_contingency_slice(
     r::TimeContingencyPowerFlowData,
     field::Symbol,
     idx::Int,
 )
+    if !(field in _CONTINGENCY_3D_FIELDS)
+        throw(
+            ArgumentError(
+                "field `$field` is not a valid 3D contingency result field. " *
+                "Valid fields: $(sort(collect(_CONTINGENCY_3D_FIELDS)))",
+            ),
+        )
+    end
     arr = getfield(r, field)
+    if arr === nothing
+        throw(
+            ArgumentError(
+                "field `$field` is `nothing` (was not computed). " *
+                "Enable it at construction time.",
+            ),
+        )
+    end
+    n_ctg = get_n_contingencies(r)
+    if idx < 1 || idx > n_ctg
+        throw(
+            ArgumentError(
+                "contingency index $idx is out of bounds. Valid range: 1:$n_ctg",
+            ),
+        )
+    end
     return @view arr[:, :, idx]
 end
 
@@ -244,6 +330,15 @@ function get_contingency_slice(
     field::Symbol,
     label::String,
 )
-    idx = r.contingency_lookup[label]
+    lookup = get_contingency_lookup(r)
+    if !haskey(lookup, label)
+        throw(
+            ArgumentError(
+                "contingency label \"$label\" not found. " *
+                "Available labels: $(get_contingency_labels(r))",
+            ),
+        )
+    end
+    idx = lookup[label]
     return get_contingency_slice(r, field, idx)
 end

--- a/src/power_flow_results.jl
+++ b/src/power_flow_results.jl
@@ -139,7 +139,7 @@ function TimeContingencyPowerFlowData(
     n_time_steps::Int,
     contingency_labels::Vector{String};
     network_modifications::Vector{Union{Nothing, PNM.NetworkModification}} =
-        Union{Nothing, PNM.NetworkModification}[nothing for _ in contingency_labels],
+    Union{Nothing, PNM.NetworkModification}[nothing for _ in contingency_labels],
     calculate_loss_factors::Bool = false,
     calculate_voltage_stability_factors::Bool = false,
     make_arc_active_power_losses::Bool = false,

--- a/src/power_flow_results.jl
+++ b/src/power_flow_results.jl
@@ -224,3 +224,26 @@ function set_network_modification!(
     r.network_modifications[idx] = mod
     return nothing
 end
+
+"""
+    get_contingency_slice(r::TimeContingencyPowerFlowData, field::Symbol, idx::Int)
+
+Return a 2D view `(entity, time_step)` into the 3D result array for contingency `idx`.
+"""
+function get_contingency_slice(
+    r::TimeContingencyPowerFlowData,
+    field::Symbol,
+    idx::Int,
+)
+    arr = getfield(r, field)
+    return @view arr[:, :, idx]
+end
+
+function get_contingency_slice(
+    r::TimeContingencyPowerFlowData,
+    field::Symbol,
+    label::String,
+)
+    idx = r.contingency_lookup[label]
+    return get_contingency_slice(r, field, idx)
+end

--- a/src/power_flow_results.jl
+++ b/src/power_flow_results.jl
@@ -1,0 +1,76 @@
+"""
+Abstract supertype for all power flow result containers.
+"""
+abstract type AbstractPowerFlowResults end
+
+"""
+    TimePowerFlowData <: AbstractPowerFlowResults
+
+Container for time-series power flow results, storing bus and arc quantities across
+multiple time steps as matrices (rows = buses/arcs, columns = time steps).
+
+# Fields
+- `bus_magnitude::Matrix{Float64}`: bus voltage magnitudes.
+- `bus_angles::Matrix{Float64}`: bus voltage angles.
+- `bus_type::Matrix{PSY.ACBusTypes}`: bus type classification at each time step.
+- `arc_active_power_flow_from_to::Matrix{Float64}`: active power flow measured at the from bus.
+- `arc_reactive_power_flow_from_to::Matrix{Float64}`: reactive power flow measured at the from bus.
+- `arc_active_power_flow_to_from::Matrix{Float64}`: active power flow measured at the to bus.
+- `arc_reactive_power_flow_to_from::Matrix{Float64}`: reactive power flow measured at the to bus.
+- `arc_angle_differences::Matrix{Float64}`: voltage angle difference across each arc.
+- `converged::BitVector`: convergence status for each time step.
+- `loss_factors::Union{Matrix{Float64}, Nothing}`: bus loss factors, or `nothing` if not computed.
+- `voltage_stability_factors::Union{Matrix{Float64}, Nothing}`: voltage stability factors, or `nothing` if not computed.
+- `arc_active_power_losses::Union{Matrix{Float64}, Nothing}`: active power losses per arc, or `nothing` if not computed.
+"""
+struct TimePowerFlowData <: AbstractPowerFlowResults
+    bus_magnitude::Matrix{Float64}
+    bus_angles::Matrix{Float64}
+    bus_type::Matrix{PSY.ACBusTypes}
+    arc_active_power_flow_from_to::Matrix{Float64}
+    arc_reactive_power_flow_from_to::Matrix{Float64}
+    arc_active_power_flow_to_from::Matrix{Float64}
+    arc_reactive_power_flow_to_from::Matrix{Float64}
+    arc_angle_differences::Matrix{Float64}
+    converged::BitVector
+    loss_factors::Union{Matrix{Float64}, Nothing}
+    voltage_stability_factors::Union{Matrix{Float64}, Nothing}
+    arc_active_power_losses::Union{Matrix{Float64}, Nothing}
+end
+
+"""
+    TimePowerFlowData(n_buses::Int, n_arcs::Int, n_time_steps::Int;
+        calculate_loss_factors::Bool = false,
+        calculate_voltage_stability_factors::Bool = false,
+        make_arc_active_power_losses::Bool = false)
+
+Construct a `TimePowerFlowData` with pre-allocated arrays for the given dimensions.
+
+Bus magnitudes default to 1.0 (flat start), bus angles default to 0.0, and bus types
+default to `PSY.ACBusTypes.PQ`. Arc fields default to zeros. Optional fields
+(`loss_factors`, `voltage_stability_factors`, `arc_active_power_losses`) are `nothing`
+unless the corresponding keyword argument is `true`.
+"""
+function TimePowerFlowData(
+    n_buses::Int,
+    n_arcs::Int,
+    n_time_steps::Int;
+    calculate_loss_factors::Bool = false,
+    calculate_voltage_stability_factors::Bool = false,
+    make_arc_active_power_losses::Bool = false,
+)
+    return TimePowerFlowData(
+        ones(n_buses, n_time_steps),
+        zeros(n_buses, n_time_steps),
+        fill(PSY.ACBusTypes.PQ, (n_buses, n_time_steps)),
+        zeros(n_arcs, n_time_steps),
+        zeros(n_arcs, n_time_steps),
+        zeros(n_arcs, n_time_steps),
+        zeros(n_arcs, n_time_steps),
+        zeros(n_arcs, n_time_steps),
+        falses(n_time_steps),
+        calculate_loss_factors ? zeros(n_buses, n_time_steps) : nothing,
+        calculate_voltage_stability_factors ? zeros(n_buses, n_time_steps) : nothing,
+        make_arc_active_power_losses ? zeros(n_arcs, n_time_steps) : nothing,
+    )
+end

--- a/src/power_flow_results.jl
+++ b/src/power_flow_results.jl
@@ -74,3 +74,153 @@ function TimePowerFlowData(
         make_arc_active_power_losses ? zeros(n_arcs, n_time_steps) : nothing,
     )
 end
+
+"""
+    TimeContingencyPowerFlowData <: AbstractPowerFlowResults
+
+Container for time-series contingency power flow results, storing bus and arc quantities
+across multiple time steps and contingencies as 3D arrays with dimensions
+`(entity, time_step, contingency)`.
+
+# Fields
+- `bus_magnitude::Array{Float64, 3}`: bus voltage magnitudes.
+- `bus_angles::Array{Float64, 3}`: bus voltage angles.
+- `bus_type::Array{PSY.ACBusTypes, 3}`: bus type classification at each time step and contingency.
+- `arc_active_power_flow_from_to::Array{Float64, 3}`: active power flow measured at the from bus.
+- `arc_reactive_power_flow_from_to::Array{Float64, 3}`: reactive power flow measured at the from bus.
+- `arc_active_power_flow_to_from::Array{Float64, 3}`: active power flow measured at the to bus.
+- `arc_reactive_power_flow_to_from::Array{Float64, 3}`: reactive power flow measured at the to bus.
+- `arc_angle_differences::Array{Float64, 3}`: voltage angle difference across each arc.
+- `converged::BitMatrix`: convergence status with dimensions `(time_steps, contingencies)`.
+- `loss_factors::Union{Array{Float64, 3}, Nothing}`: bus loss factors, or `nothing` if not computed.
+- `voltage_stability_factors::Union{Array{Float64, 3}, Nothing}`: voltage stability factors, or `nothing` if not computed.
+- `arc_active_power_losses::Union{Array{Float64, 3}, Nothing}`: active power losses per arc, or `nothing` if not computed.
+- `contingency_labels::Vector{String}`: human-readable labels for each contingency.
+- `contingency_lookup::Dict{String, Int}`: mapping from contingency label to index.
+- `network_modifications::Vector{Union{Nothing, PNM.NetworkModification}}`: network modification for each contingency.
+"""
+struct TimeContingencyPowerFlowData <: AbstractPowerFlowResults
+    bus_magnitude::Array{Float64, 3}
+    bus_angles::Array{Float64, 3}
+    bus_type::Array{PSY.ACBusTypes, 3}
+    arc_active_power_flow_from_to::Array{Float64, 3}
+    arc_reactive_power_flow_from_to::Array{Float64, 3}
+    arc_active_power_flow_to_from::Array{Float64, 3}
+    arc_reactive_power_flow_to_from::Array{Float64, 3}
+    arc_angle_differences::Array{Float64, 3}
+    converged::BitMatrix
+    loss_factors::Union{Array{Float64, 3}, Nothing}
+    voltage_stability_factors::Union{Array{Float64, 3}, Nothing}
+    arc_active_power_losses::Union{Array{Float64, 3}, Nothing}
+    contingency_labels::Vector{String}
+    contingency_lookup::Dict{String, Int}
+    network_modifications::Vector{Union{Nothing, PNM.NetworkModification}}
+end
+
+"""
+    TimeContingencyPowerFlowData(n_buses::Int, n_arcs::Int, n_time_steps::Int,
+        contingency_labels::Vector{String};
+        network_modifications::Vector{Union{Nothing, PNM.NetworkModification}} = ...,
+        calculate_loss_factors::Bool = false,
+        calculate_voltage_stability_factors::Bool = false,
+        make_arc_active_power_losses::Bool = false)
+
+Construct a `TimeContingencyPowerFlowData` with pre-allocated 3D arrays of dimensions
+`(entity, time_step, contingency)`.
+
+Bus magnitudes default to 1.0 (flat start), bus angles default to 0.0, bus types default
+to `PSY.ACBusTypes.PQ`, and arc fields default to zeros. Optional fields are `nothing`
+unless the corresponding keyword argument is `true`. The `contingency_lookup` dictionary
+is built automatically from `contingency_labels`.
+"""
+function TimeContingencyPowerFlowData(
+    n_buses::Int,
+    n_arcs::Int,
+    n_time_steps::Int,
+    contingency_labels::Vector{String};
+    network_modifications::Vector{Union{Nothing, PNM.NetworkModification}} =
+        Union{Nothing, PNM.NetworkModification}[nothing for _ in contingency_labels],
+    calculate_loss_factors::Bool = false,
+    calculate_voltage_stability_factors::Bool = false,
+    make_arc_active_power_losses::Bool = false,
+)
+    n_ctg = length(contingency_labels)
+    if length(network_modifications) != n_ctg
+        throw(
+            ArgumentError(
+                "length(network_modifications) = $(length(network_modifications)) " *
+                "must equal length(contingency_labels) = $n_ctg",
+            ),
+        )
+    end
+    contingency_lookup = Dict{String, Int}(
+        label => idx for (idx, label) in enumerate(contingency_labels)
+    )
+    return TimeContingencyPowerFlowData(
+        ones(n_buses, n_time_steps, n_ctg),
+        zeros(n_buses, n_time_steps, n_ctg),
+        fill(PSY.ACBusTypes.PQ, (n_buses, n_time_steps, n_ctg)),
+        zeros(n_arcs, n_time_steps, n_ctg),
+        zeros(n_arcs, n_time_steps, n_ctg),
+        zeros(n_arcs, n_time_steps, n_ctg),
+        zeros(n_arcs, n_time_steps, n_ctg),
+        zeros(n_arcs, n_time_steps, n_ctg),
+        falses(n_time_steps, n_ctg),
+        calculate_loss_factors ? zeros(n_buses, n_time_steps, n_ctg) : nothing,
+        calculate_voltage_stability_factors ?
+        zeros(n_buses, n_time_steps, n_ctg) : nothing,
+        make_arc_active_power_losses ? zeros(n_arcs, n_time_steps, n_ctg) : nothing,
+        contingency_labels,
+        contingency_lookup,
+        network_modifications,
+    )
+end
+
+# -- Accessor functions for TimeContingencyPowerFlowData --
+
+"""Return the vector of contingency labels."""
+get_contingency_labels(r::TimeContingencyPowerFlowData) = r.contingency_labels
+
+"""Return the contingency label-to-index lookup dictionary."""
+get_contingency_lookup(r::TimeContingencyPowerFlowData) = r.contingency_lookup
+
+"""Return the vector of network modifications."""
+get_network_modifications(r::TimeContingencyPowerFlowData) = r.network_modifications
+
+"""Return the number of contingencies."""
+get_n_contingencies(r::TimeContingencyPowerFlowData) = length(r.contingency_labels)
+
+"""
+    get_network_modification(r::TimeContingencyPowerFlowData, label::String)
+
+Return the `NetworkModification` (or `nothing`) for the contingency identified by `label`.
+"""
+function get_network_modification(r::TimeContingencyPowerFlowData, label::String)
+    idx = r.contingency_lookup[label]
+    return r.network_modifications[idx]
+end
+
+"""
+    get_network_modification(r::TimeContingencyPowerFlowData, idx::Int)
+
+Return the `NetworkModification` (or `nothing`) for the contingency at index `idx`.
+"""
+function get_network_modification(r::TimeContingencyPowerFlowData, idx::Int)
+    return r.network_modifications[idx]
+end
+
+"""
+    set_network_modification!(r::TimeContingencyPowerFlowData, label::String,
+        mod::PNM.NetworkModification)
+
+Set the network modification for the contingency identified by `label`.
+"""
+function set_network_modification!(
+    r::TimeContingencyPowerFlowData,
+    label::String,
+    mod::PNM.NetworkModification,
+)
+    idx = r.contingency_lookup[label]
+    r.network_modifications[idx] = mod
+    return nothing
+end

--- a/src/power_flow_results.jl
+++ b/src/power_flow_results.jl
@@ -21,6 +21,10 @@ const _RESULT_FIELD_NAMES = (
     :loss_factors,
     :voltage_stability_factors,
     :arc_active_power_losses,
+    :lcc_active_power_flow_from_to,
+    :lcc_active_power_flow_to_from,
+    :lcc_reactive_power_flow_from_to,
+    :lcc_reactive_power_flow_to_from,
 )
 
 """
@@ -46,6 +50,10 @@ multiple time steps as matrices (rows = buses/arcs, columns = time steps).
 - `loss_factors::Union{Matrix{Float64}, Nothing}`: bus loss factors, or `nothing` if not computed.
 - `voltage_stability_factors::Union{Matrix{Float64}, Nothing}`: voltage stability factors, or `nothing` if not computed.
 - `arc_active_power_losses::Union{Matrix{Float64}, Nothing}`: active power losses per arc, or `nothing` if not computed.
+- `lcc_active_power_flow_from_to::Union{Matrix{Float64}, Nothing}`: LCC active power flow at the from bus, or `nothing` if no LCCs.
+- `lcc_active_power_flow_to_from::Union{Matrix{Float64}, Nothing}`: LCC active power flow at the to bus, or `nothing` if no LCCs.
+- `lcc_reactive_power_flow_from_to::Union{Matrix{Float64}, Nothing}`: LCC reactive power flow at the from bus, or `nothing` if no LCCs.
+- `lcc_reactive_power_flow_to_from::Union{Matrix{Float64}, Nothing}`: LCC reactive power flow at the to bus, or `nothing` if no LCCs.
 """
 struct TimePowerFlowData <: AbstractPowerFlowResults
     bus_magnitude::Matrix{Float64}
@@ -64,10 +72,15 @@ struct TimePowerFlowData <: AbstractPowerFlowResults
     loss_factors::Union{Matrix{Float64}, Nothing}
     voltage_stability_factors::Union{Matrix{Float64}, Nothing}
     arc_active_power_losses::Union{Matrix{Float64}, Nothing}
+    lcc_active_power_flow_from_to::Union{Matrix{Float64}, Nothing}
+    lcc_active_power_flow_to_from::Union{Matrix{Float64}, Nothing}
+    lcc_reactive_power_flow_from_to::Union{Matrix{Float64}, Nothing}
+    lcc_reactive_power_flow_to_from::Union{Matrix{Float64}, Nothing}
 end
 
 """
     TimePowerFlowData(n_buses::Int, n_arcs::Int, n_time_steps::Int;
+        n_lccs::Int = 0,
         calculate_loss_factors::Bool = false,
         calculate_voltage_stability_factors::Bool = false,
         make_arc_active_power_losses::Bool = false)
@@ -77,12 +90,14 @@ Construct a `TimePowerFlowData` with pre-allocated arrays for the given dimensio
 Bus magnitudes default to 1.0 (flat start), bus angles default to 0.0, and bus types
 default to `PSY.ACBusTypes.PQ`. Arc fields default to zeros. Optional fields
 (`loss_factors`, `voltage_stability_factors`, `arc_active_power_losses`) are `nothing`
-unless the corresponding keyword argument is `true`.
+unless the corresponding keyword argument is `true`. LCC flow fields are allocated
+when `n_lccs > 0`, otherwise `nothing`.
 """
 function TimePowerFlowData(
     n_buses::Int,
     n_arcs::Int,
     n_time_steps::Int;
+    n_lccs::Int = 0,
     calculate_loss_factors::Bool = false,
     calculate_voltage_stability_factors::Bool = false,
     make_arc_active_power_losses::Bool = false,
@@ -104,6 +119,10 @@ function TimePowerFlowData(
         calculate_loss_factors ? zeros(n_buses, n_time_steps) : nothing,
         calculate_voltage_stability_factors ? zeros(n_buses, n_time_steps) : nothing,
         make_arc_active_power_losses ? zeros(n_arcs, n_time_steps) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps) : nothing,
     )
 end
 
@@ -131,6 +150,10 @@ across multiple time steps and contingencies as 3D arrays with dimensions
 - `loss_factors::Union{Array{Float64, 3}, Nothing}`: bus loss factors, or `nothing` if not computed.
 - `voltage_stability_factors::Union{Array{Float64, 3}, Nothing}`: voltage stability factors, or `nothing` if not computed.
 - `arc_active_power_losses::Union{Array{Float64, 3}, Nothing}`: active power losses per arc, or `nothing` if not computed.
+- `lcc_active_power_flow_from_to::Union{Array{Float64, 3}, Nothing}`: LCC active power flow at the from bus, or `nothing` if no LCCs.
+- `lcc_active_power_flow_to_from::Union{Array{Float64, 3}, Nothing}`: LCC active power flow at the to bus, or `nothing` if no LCCs.
+- `lcc_reactive_power_flow_from_to::Union{Array{Float64, 3}, Nothing}`: LCC reactive power flow at the from bus, or `nothing` if no LCCs.
+- `lcc_reactive_power_flow_to_from::Union{Array{Float64, 3}, Nothing}`: LCC reactive power flow at the to bus, or `nothing` if no LCCs.
 - `contingency_labels::Vector{String}`: human-readable labels for each contingency.
 - `contingency_lookup::Dict{String, Int}`: mapping from contingency label to index.
 - `network_modifications::Vector{Union{Nothing, PNM.NetworkModification}}`: network modification for each contingency.
@@ -152,6 +175,10 @@ struct TimeContingencyPowerFlowData <: AbstractPowerFlowResults
     loss_factors::Union{Array{Float64, 3}, Nothing}
     voltage_stability_factors::Union{Array{Float64, 3}, Nothing}
     arc_active_power_losses::Union{Array{Float64, 3}, Nothing}
+    lcc_active_power_flow_from_to::Union{Array{Float64, 3}, Nothing}
+    lcc_active_power_flow_to_from::Union{Array{Float64, 3}, Nothing}
+    lcc_reactive_power_flow_from_to::Union{Array{Float64, 3}, Nothing}
+    lcc_reactive_power_flow_to_from::Union{Array{Float64, 3}, Nothing}
     contingency_labels::Vector{String}
     contingency_lookup::Dict{String, Int}
     network_modifications::Vector{Union{Nothing, PNM.NetworkModification}}
@@ -160,6 +187,7 @@ end
 """
     TimeContingencyPowerFlowData(n_buses::Int, n_arcs::Int, n_time_steps::Int,
         contingency_labels::Vector{String};
+        n_lccs::Int = 0,
         network_modifications::Vector{Union{Nothing, PNM.NetworkModification}} = ...,
         calculate_loss_factors::Bool = false,
         calculate_voltage_stability_factors::Bool = false,
@@ -170,7 +198,8 @@ Construct a `TimeContingencyPowerFlowData` with pre-allocated 3D arrays of dimen
 
 Bus magnitudes default to 1.0 (flat start), bus angles default to 0.0, bus types default
 to `PSY.ACBusTypes.PQ`, and arc fields default to zeros. Optional fields are `nothing`
-unless the corresponding keyword argument is `true`. The `contingency_lookup` dictionary
+unless the corresponding keyword argument is `true`. LCC flow fields are allocated
+when `n_lccs > 0`, otherwise `nothing`. The `contingency_lookup` dictionary
 is built automatically from `contingency_labels`.
 """
 function TimeContingencyPowerFlowData(
@@ -178,6 +207,7 @@ function TimeContingencyPowerFlowData(
     n_arcs::Int,
     n_time_steps::Int,
     contingency_labels::Vector{String};
+    n_lccs::Int = 0,
     network_modifications::Vector{Union{Nothing, PNM.NetworkModification}} =
     Union{Nothing, PNM.NetworkModification}[nothing for _ in contingency_labels],
     calculate_loss_factors::Bool = false,
@@ -226,6 +256,10 @@ function TimeContingencyPowerFlowData(
         calculate_voltage_stability_factors ?
         zeros(n_buses, n_time_steps, n_ctg) : nothing,
         make_arc_active_power_losses ? zeros(n_arcs, n_time_steps, n_ctg) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps, n_ctg) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps, n_ctg) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps, n_ctg) : nothing,
+        n_lccs > 0 ? zeros(n_lccs, n_time_steps, n_ctg) : nothing,
         contingency_labels,
         contingency_lookup,
         network_modifications,

--- a/test/test_hvdc.jl
+++ b/test/test_hvdc.jl
@@ -240,8 +240,8 @@ function test_generic_hvdc_on_big_system(pf_type::Type{<:PF.PowerFlowEvaluationM
     for fieldname in (:bus_angles, :bus_magnitude)
         @test all(
             abs.(
-                getfield(data_original, fieldname) .-
-                getfield(data_modified, fieldname)
+                getproperty(data_original, fieldname) .-
+                getproperty(data_modified, fieldname)
             ) .< TIGHT_TOLERANCE,
         )
     end
@@ -251,8 +251,8 @@ function test_generic_hvdc_on_big_system(pf_type::Type{<:PF.PowerFlowEvaluationM
         for (original_arc_ind, arc) in enumerate(PF.get_arc_axis(data_original))
             modified_arc_ind = PF.get_arc_lookup(data_modified)[arc]
             @test isapprox(
-                getfield(data_original, fieldname)[original_arc_ind],
-                getfield(data_modified, fieldname)[modified_arc_ind],
+                getproperty(data_original, fieldname)[original_arc_ind],
+                getproperty(data_modified, fieldname)[modified_arc_ind],
                 atol = TIGHT_TOLERANCE,
             )
         end

--- a/test/test_power_flow_results.jl
+++ b/test/test_power_flow_results.jl
@@ -226,3 +226,19 @@ end
         @test PowerFlows.get_n_contingencies(results) == 1
     end
 end
+
+@testset "PowerFlowData contains TimePowerFlowData results" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
+    pf = ACPowerFlow()
+    data = PowerFlows.PowerFlowData(pf, sys)
+
+    @test data.results isa PowerFlows.TimePowerFlowData
+    @test data.bus_magnitude === data.results.bus_magnitude
+    @test data.bus_angles === data.results.bus_angles
+    @test data.bus_type === data.results.bus_type
+    @test data.converged === data.results.converged
+
+    # Mutation through forwarding works
+    data.bus_magnitude[1, 1] = 0.95
+    @test data.results.bus_magnitude[1, 1] == 0.95
+end

--- a/test/test_power_flow_results.jl
+++ b/test/test_power_flow_results.jl
@@ -75,3 +75,154 @@
         @test length(results.converged) == 1
     end
 end
+
+@testset "TimeContingencyPowerFlowData" begin
+    n_buses = 5
+    n_arcs = 4
+    n_time_steps = 3
+    ctg_labels = ["base", "line_1_out", "line_2_out"]
+
+    @testset "Default construction" begin
+        results = TimeContingencyPowerFlowData(n_buses, n_arcs, n_time_steps, ctg_labels)
+        n_ctg = length(ctg_labels)
+
+        # Bus fields have correct 3D dimensions (entity, time_step, contingency).
+        @test size(results.bus_magnitude) == (n_buses, n_time_steps, n_ctg)
+        @test size(results.bus_angles) == (n_buses, n_time_steps, n_ctg)
+        @test size(results.bus_type) == (n_buses, n_time_steps, n_ctg)
+
+        # Bus magnitude defaults to ones (flat start).
+        @test all(results.bus_magnitude .== 1.0)
+        # Bus angles default to zeros.
+        @test all(results.bus_angles .== 0.0)
+        # Bus types default to PQ.
+        @test all(results.bus_type .== Ref(PowerSystems.ACBusTypes.PQ))
+
+        # Arc fields have correct 3D dimensions and default to zeros.
+        for field in [
+            :arc_active_power_flow_from_to,
+            :arc_reactive_power_flow_from_to,
+            :arc_active_power_flow_to_from,
+            :arc_reactive_power_flow_to_from,
+            :arc_angle_differences,
+        ]
+            arr = getfield(results, field)
+            @test size(arr) == (n_arcs, n_time_steps, n_ctg)
+            @test all(arr .== 0.0)
+        end
+
+        # Converged is a BitMatrix of (time_steps, contingencies), all false.
+        @test size(results.converged) == (n_time_steps, n_ctg)
+        @test !any(results.converged)
+
+        # Optional fields default to nothing.
+        @test results.loss_factors === nothing
+        @test results.voltage_stability_factors === nothing
+        @test results.arc_active_power_losses === nothing
+
+        # Network modifications default to nothing for each contingency.
+        @test all(isnothing, results.network_modifications)
+    end
+
+    @testset "Contingency lookup" begin
+        results = TimeContingencyPowerFlowData(n_buses, n_arcs, n_time_steps, ctg_labels)
+        lookup = PowerFlows.get_contingency_lookup(results)
+
+        @test lookup["base"] == 1
+        @test lookup["line_1_out"] == 2
+        @test lookup["line_2_out"] == 3
+        @test PowerFlows.get_contingency_labels(results) == ctg_labels
+        @test PowerFlows.get_n_contingencies(results) == 3
+    end
+
+    @testset "NetworkModification storage and access" begin
+        mod1 = PNM.NetworkModification(
+            "line_1_out",
+            [PNM.ArcModification(1, -0.5)],
+        )
+        mod2 = PNM.NetworkModification(
+            "line_2_out",
+            [PNM.ArcModification(2, -0.3)],
+        )
+        mods = Union{Nothing, PNM.NetworkModification}[nothing, mod1, mod2]
+        results = TimeContingencyPowerFlowData(
+            n_buses,
+            n_arcs,
+            n_time_steps,
+            ctg_labels;
+            network_modifications = mods,
+        )
+
+        # Access by label.
+        @test PowerFlows.get_network_modification(results, "base") === nothing
+        @test PowerFlows.get_network_modification(results, "line_1_out") === mod1
+        @test PowerFlows.get_network_modification(results, "line_2_out") === mod2
+
+        # Access by index.
+        @test PowerFlows.get_network_modification(results, 1) === nothing
+        @test PowerFlows.get_network_modification(results, 2) === mod1
+
+        # get_network_modifications returns the full vector.
+        @test length(PowerFlows.get_network_modifications(results)) == 3
+    end
+
+    @testset "set_network_modification!" begin
+        results = TimeContingencyPowerFlowData(n_buses, n_arcs, n_time_steps, ctg_labels)
+        @test PowerFlows.get_network_modification(results, "base") === nothing
+
+        new_mod = PNM.NetworkModification(
+            "base_mod",
+            [PNM.ArcModification(3, -0.1)],
+        )
+        PowerFlows.set_network_modification!(results, "base", new_mod)
+        @test PowerFlows.get_network_modification(results, "base") === new_mod
+    end
+
+    @testset "Optional fields enabled" begin
+        results = TimeContingencyPowerFlowData(
+            n_buses,
+            n_arcs,
+            n_time_steps,
+            ctg_labels;
+            calculate_loss_factors = true,
+            calculate_voltage_stability_factors = true,
+            make_arc_active_power_losses = true,
+        )
+        n_ctg = length(ctg_labels)
+
+        @test results.loss_factors !== nothing
+        @test size(results.loss_factors) == (n_buses, n_time_steps, n_ctg)
+        @test all(results.loss_factors .== 0.0)
+
+        @test results.voltage_stability_factors !== nothing
+        @test size(results.voltage_stability_factors) == (n_buses, n_time_steps, n_ctg)
+        @test all(results.voltage_stability_factors .== 0.0)
+
+        @test results.arc_active_power_losses !== nothing
+        @test size(results.arc_active_power_losses) == (n_arcs, n_time_steps, n_ctg)
+        @test all(results.arc_active_power_losses .== 0.0)
+    end
+
+    @testset "Subtype relationship" begin
+        @test TimeContingencyPowerFlowData <: AbstractPowerFlowResults
+    end
+
+    @testset "Mismatched network_modifications length throws" begin
+        bad_mods = Union{Nothing, PNM.NetworkModification}[nothing, nothing]
+        @test_throws ArgumentError TimeContingencyPowerFlowData(
+            n_buses,
+            n_arcs,
+            n_time_steps,
+            ctg_labels;
+            network_modifications = bad_mods,
+        )
+    end
+
+    @testset "Single contingency" begin
+        results =
+            TimeContingencyPowerFlowData(n_buses, n_arcs, n_time_steps, ["base_case"])
+        @test size(results.bus_magnitude) == (n_buses, n_time_steps, 1)
+        @test size(results.converged) == (n_time_steps, 1)
+        @test PowerFlows.get_n_contingencies(results) == 1
+    end
+end

--- a/test/test_power_flow_results.jl
+++ b/test/test_power_flow_results.jl
@@ -16,6 +16,10 @@
         @test results.loss_factors === nothing
         @test results.voltage_stability_factors === nothing
         @test results.arc_active_power_losses === nothing
+        @test results.lcc_active_power_flow_from_to === nothing
+        @test results.lcc_active_power_flow_to_from === nothing
+        @test results.lcc_reactive_power_flow_from_to === nothing
+        @test results.lcc_reactive_power_flow_to_from === nothing
     end
 
     @testset "Optional fields enabled" begin
@@ -31,6 +35,16 @@
         @test size(results.loss_factors) == (n_buses, n_time_steps)
         @test size(results.voltage_stability_factors) == (n_buses, n_time_steps)
         @test size(results.arc_active_power_losses) == (n_arcs, n_time_steps)
+    end
+
+    @testset "LCC fields" begin
+        n_lccs = 2
+        results = TimePowerFlowData(n_buses, n_arcs, n_time_steps; n_lccs = n_lccs)
+
+        @test size(results.lcc_active_power_flow_from_to) == (n_lccs, n_time_steps)
+        @test size(results.lcc_active_power_flow_to_from) == (n_lccs, n_time_steps)
+        @test size(results.lcc_reactive_power_flow_from_to) == (n_lccs, n_time_steps)
+        @test size(results.lcc_reactive_power_flow_to_from) == (n_lccs, n_time_steps)
     end
 end
 
@@ -52,6 +66,10 @@ end
         @test results.loss_factors === nothing
         @test results.voltage_stability_factors === nothing
         @test results.arc_active_power_losses === nothing
+        @test results.lcc_active_power_flow_from_to === nothing
+        @test results.lcc_active_power_flow_to_from === nothing
+        @test results.lcc_reactive_power_flow_from_to === nothing
+        @test results.lcc_reactive_power_flow_to_from === nothing
         @test all(isnothing, results.network_modifications)
     end
 
@@ -119,6 +137,21 @@ end
         @test size(results.loss_factors) == (n_buses, n_time_steps, n_ctg)
         @test size(results.voltage_stability_factors) == (n_buses, n_time_steps, n_ctg)
         @test size(results.arc_active_power_losses) == (n_arcs, n_time_steps, n_ctg)
+    end
+
+    @testset "LCC fields" begin
+        n_lccs = 2
+        results = TimeContingencyPowerFlowData(
+            n_buses, n_arcs, n_time_steps, ctg_labels; n_lccs = n_lccs,
+        )
+        n_ctg = length(ctg_labels)
+
+        @test size(results.lcc_active_power_flow_from_to) == (n_lccs, n_time_steps, n_ctg)
+        @test size(results.lcc_active_power_flow_to_from) == (n_lccs, n_time_steps, n_ctg)
+        @test size(results.lcc_reactive_power_flow_from_to) ==
+              (n_lccs, n_time_steps, n_ctg)
+        @test size(results.lcc_reactive_power_flow_to_from) ==
+              (n_lccs, n_time_steps, n_ctg)
     end
 
     @testset "Constructor validation" begin

--- a/test/test_power_flow_results.jl
+++ b/test/test_power_flow_results.jl
@@ -242,3 +242,39 @@ end
     data.bus_magnitude[1, 1] = 0.95
     @test data.results.bus_magnitude[1, 1] == 0.95
 end
+
+@testset "get_results accessor" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
+    pf = ACPowerFlow()
+    data = PowerFlows.PowerFlowData(pf, sys)
+
+    r = PowerFlows.get_results(data)
+    @test r isa PowerFlows.TimePowerFlowData
+    @test r.bus_magnitude === data.bus_magnitude
+end
+
+@testset "Contingency-aware slicing on TimeContingencyPowerFlowData" begin
+    n_buses = 4
+    n_arcs = 5
+    n_time_steps = 2
+    labels = ["base", "ctg_1", "ctg_2"]
+
+    results = PowerFlows.TimeContingencyPowerFlowData(
+        n_buses, n_arcs, n_time_steps, labels,
+    )
+    # Write a value into contingency 2, time_step 1, bus 3
+    results.bus_magnitude[3, 1, 2] = 0.97
+
+    # Slice by contingency index
+    slice = PowerFlows.get_contingency_slice(results, :bus_magnitude, 2)
+    @test size(slice) == (n_buses, n_time_steps)
+    @test slice[3, 1] == 0.97
+
+    # Slice by contingency label
+    slice2 = PowerFlows.get_contingency_slice(results, :bus_magnitude, "ctg_1")
+    @test slice2 === slice
+
+    # Verify it's a view (mutation reflects back)
+    slice[1, 1] = 0.5
+    @test results.bus_magnitude[1, 1, 2] == 0.5
+end

--- a/test/test_power_flow_results.jl
+++ b/test/test_power_flow_results.jl
@@ -6,36 +6,13 @@
     @testset "Default construction" begin
         results = TimePowerFlowData(n_buses, n_arcs, n_time_steps)
 
-        # Bus fields have correct dimensions.
         @test size(results.bus_magnitude) == (n_buses, n_time_steps)
         @test size(results.bus_angles) == (n_buses, n_time_steps)
         @test size(results.bus_type) == (n_buses, n_time_steps)
-
-        # Bus magnitude defaults to ones (flat start).
-        @test all(results.bus_magnitude .== 1.0)
-        # Bus angles default to zeros.
-        @test all(results.bus_angles .== 0.0)
-        # Bus types default to PQ.
-        @test all(results.bus_type .== Ref(PowerSystems.ACBusTypes.PQ))
-
-        # Arc fields have correct dimensions and default to zeros.
-        for field in [
-            :arc_active_power_flow_from_to,
-            :arc_reactive_power_flow_from_to,
-            :arc_active_power_flow_to_from,
-            :arc_reactive_power_flow_to_from,
-            :arc_angle_differences,
-        ]
-            mat = getfield(results, field)
-            @test size(mat) == (n_arcs, n_time_steps)
-            @test all(mat .== 0.0)
-        end
-
-        # Converged defaults to all false.
+        @test size(results.bus_active_power_injections) == (n_buses, n_time_steps)
+        @test size(results.arc_active_power_flow_from_to) == (n_arcs, n_time_steps)
         @test length(results.converged) == n_time_steps
-        @test !any(results.converged)
 
-        # Optional fields default to nothing.
         @test results.loss_factors === nothing
         @test results.voltage_stability_factors === nothing
         @test results.arc_active_power_losses === nothing
@@ -51,28 +28,9 @@
             make_arc_active_power_losses = true,
         )
 
-        @test results.loss_factors !== nothing
         @test size(results.loss_factors) == (n_buses, n_time_steps)
-        @test all(results.loss_factors .== 0.0)
-
-        @test results.voltage_stability_factors !== nothing
         @test size(results.voltage_stability_factors) == (n_buses, n_time_steps)
-        @test all(results.voltage_stability_factors .== 0.0)
-
-        @test results.arc_active_power_losses !== nothing
         @test size(results.arc_active_power_losses) == (n_arcs, n_time_steps)
-        @test all(results.arc_active_power_losses .== 0.0)
-    end
-
-    @testset "Subtype relationship" begin
-        @test TimePowerFlowData <: AbstractPowerFlowResults
-    end
-
-    @testset "Single time step" begin
-        results = TimePowerFlowData(10, 8, 1)
-        @test size(results.bus_magnitude) == (10, 1)
-        @test size(results.arc_active_power_flow_from_to) == (8, 1)
-        @test length(results.converged) == 1
     end
 end
 
@@ -86,41 +44,14 @@ end
         results = TimeContingencyPowerFlowData(n_buses, n_arcs, n_time_steps, ctg_labels)
         n_ctg = length(ctg_labels)
 
-        # Bus fields have correct 3D dimensions (entity, time_step, contingency).
         @test size(results.bus_magnitude) == (n_buses, n_time_steps, n_ctg)
-        @test size(results.bus_angles) == (n_buses, n_time_steps, n_ctg)
-        @test size(results.bus_type) == (n_buses, n_time_steps, n_ctg)
-
-        # Bus magnitude defaults to ones (flat start).
-        @test all(results.bus_magnitude .== 1.0)
-        # Bus angles default to zeros.
-        @test all(results.bus_angles .== 0.0)
-        # Bus types default to PQ.
-        @test all(results.bus_type .== Ref(PowerSystems.ACBusTypes.PQ))
-
-        # Arc fields have correct 3D dimensions and default to zeros.
-        for field in [
-            :arc_active_power_flow_from_to,
-            :arc_reactive_power_flow_from_to,
-            :arc_active_power_flow_to_from,
-            :arc_reactive_power_flow_to_from,
-            :arc_angle_differences,
-        ]
-            arr = getfield(results, field)
-            @test size(arr) == (n_arcs, n_time_steps, n_ctg)
-            @test all(arr .== 0.0)
-        end
-
-        # Converged is a BitMatrix of (time_steps, contingencies), all false.
+        @test size(results.bus_active_power_injections) == (n_buses, n_time_steps, n_ctg)
+        @test size(results.arc_active_power_flow_from_to) == (n_arcs, n_time_steps, n_ctg)
         @test size(results.converged) == (n_time_steps, n_ctg)
-        @test !any(results.converged)
 
-        # Optional fields default to nothing.
         @test results.loss_factors === nothing
         @test results.voltage_stability_factors === nothing
         @test results.arc_active_power_losses === nothing
-
-        # Network modifications default to nothing for each contingency.
         @test all(isnothing, results.network_modifications)
     end
 
@@ -153,16 +84,11 @@ end
             network_modifications = mods,
         )
 
-        # Access by label.
         @test PowerFlows.get_network_modification(results, "base") === nothing
         @test PowerFlows.get_network_modification(results, "line_1_out") === mod1
         @test PowerFlows.get_network_modification(results, "line_2_out") === mod2
-
-        # Access by index.
         @test PowerFlows.get_network_modification(results, 1) === nothing
         @test PowerFlows.get_network_modification(results, 2) === mod1
-
-        # get_network_modifications returns the full vector.
         @test length(PowerFlows.get_network_modifications(results)) == 3
     end
 
@@ -190,70 +116,38 @@ end
         )
         n_ctg = length(ctg_labels)
 
-        @test results.loss_factors !== nothing
         @test size(results.loss_factors) == (n_buses, n_time_steps, n_ctg)
-        @test all(results.loss_factors .== 0.0)
-
-        @test results.voltage_stability_factors !== nothing
         @test size(results.voltage_stability_factors) == (n_buses, n_time_steps, n_ctg)
-        @test all(results.voltage_stability_factors .== 0.0)
-
-        @test results.arc_active_power_losses !== nothing
         @test size(results.arc_active_power_losses) == (n_arcs, n_time_steps, n_ctg)
-        @test all(results.arc_active_power_losses .== 0.0)
     end
 
-    @testset "Subtype relationship" begin
-        @test TimeContingencyPowerFlowData <: AbstractPowerFlowResults
-    end
-
-    @testset "Mismatched network_modifications length throws" begin
+    @testset "Constructor validation" begin
         bad_mods = Union{Nothing, PNM.NetworkModification}[nothing, nothing]
         @test_throws ArgumentError TimeContingencyPowerFlowData(
-            n_buses,
-            n_arcs,
-            n_time_steps,
-            ctg_labels;
+            n_buses, n_arcs, n_time_steps, ctg_labels;
             network_modifications = bad_mods,
         )
-    end
-
-    @testset "Single contingency" begin
-        results =
-            TimeContingencyPowerFlowData(n_buses, n_arcs, n_time_steps, ["base_case"])
-        @test size(results.bus_magnitude) == (n_buses, n_time_steps, 1)
-        @test size(results.converged) == (n_time_steps, 1)
-        @test PowerFlows.get_n_contingencies(results) == 1
+        @test_throws ArgumentError TimeContingencyPowerFlowData(
+            n_buses, n_arcs, n_time_steps, ["base", "ctg_1", "base"],
+        )
     end
 end
 
-@testset "PowerFlowData contains TimePowerFlowData results" begin
+@testset "PowerFlowData property forwarding" begin
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
     pf = ACPowerFlow()
     data = PowerFlows.PowerFlowData(pf, sys)
 
     @test data.results isa PowerFlows.TimePowerFlowData
     @test data.bus_magnitude === data.results.bus_magnitude
-    @test data.bus_angles === data.results.bus_angles
-    @test data.bus_type === data.results.bus_type
+    @test data.bus_active_power_injections === data.results.bus_active_power_injections
     @test data.converged === data.results.converged
 
-    # Mutation through forwarding works
-    data.bus_magnitude[1, 1] = 0.95
-    @test data.results.bus_magnitude[1, 1] == 0.95
-end
-
-@testset "get_results accessor" begin
-    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
-    pf = ACPowerFlow()
-    data = PowerFlows.PowerFlowData(pf, sys)
-
     r = PowerFlows.get_results(data)
-    @test r isa PowerFlows.TimePowerFlowData
-    @test r.bus_magnitude === data.bus_magnitude
+    @test r === data.results
 end
 
-@testset "Contingency-aware slicing on TimeContingencyPowerFlowData" begin
+@testset "Contingency-aware slicing" begin
     n_buses = 4
     n_arcs = 5
     n_time_steps = 2
@@ -262,19 +156,33 @@ end
     results = PowerFlows.TimeContingencyPowerFlowData(
         n_buses, n_arcs, n_time_steps, labels,
     )
-    # Write a value into contingency 2, time_step 1, bus 3
     results.bus_magnitude[3, 1, 2] = 0.97
 
-    # Slice by contingency index
     slice = PowerFlows.get_contingency_slice(results, :bus_magnitude, 2)
     @test size(slice) == (n_buses, n_time_steps)
     @test slice[3, 1] == 0.97
 
-    # Slice by contingency label
     slice2 = PowerFlows.get_contingency_slice(results, :bus_magnitude, "ctg_1")
-    @test slice2 === slice
+    @test slice2 == slice
 
     # Verify it's a view (mutation reflects back)
     slice[1, 1] = 0.5
     @test results.bus_magnitude[1, 1, 2] == 0.5
+end
+
+@testset "get_contingency_slice validation" begin
+    results = PowerFlows.TimeContingencyPowerFlowData(
+        4, 5, 2, ["base", "ctg_1", "ctg_2"],
+    )
+
+    @test_throws ArgumentError PowerFlows.get_contingency_slice(
+        results, :nonexistent_field, 1)
+    @test_throws ArgumentError PowerFlows.get_contingency_slice(
+        results, :loss_factors, 1)
+    @test_throws ArgumentError PowerFlows.get_contingency_slice(
+        results, :bus_magnitude, 0)
+    @test_throws ArgumentError PowerFlows.get_contingency_slice(
+        results, :bus_magnitude, 4)
+    @test_throws ArgumentError PowerFlows.get_contingency_slice(
+        results, :bus_magnitude, "nonexistent")
 end

--- a/test/test_power_flow_results.jl
+++ b/test/test_power_flow_results.jl
@@ -1,0 +1,77 @@
+@testset "TimePowerFlowData" begin
+    n_buses = 5
+    n_arcs = 4
+    n_time_steps = 3
+
+    @testset "Default construction" begin
+        results = TimePowerFlowData(n_buses, n_arcs, n_time_steps)
+
+        # Bus fields have correct dimensions.
+        @test size(results.bus_magnitude) == (n_buses, n_time_steps)
+        @test size(results.bus_angles) == (n_buses, n_time_steps)
+        @test size(results.bus_type) == (n_buses, n_time_steps)
+
+        # Bus magnitude defaults to ones (flat start).
+        @test all(results.bus_magnitude .== 1.0)
+        # Bus angles default to zeros.
+        @test all(results.bus_angles .== 0.0)
+        # Bus types default to PQ.
+        @test all(results.bus_type .== Ref(PowerSystems.ACBusTypes.PQ))
+
+        # Arc fields have correct dimensions and default to zeros.
+        for field in [
+            :arc_active_power_flow_from_to,
+            :arc_reactive_power_flow_from_to,
+            :arc_active_power_flow_to_from,
+            :arc_reactive_power_flow_to_from,
+            :arc_angle_differences,
+        ]
+            mat = getfield(results, field)
+            @test size(mat) == (n_arcs, n_time_steps)
+            @test all(mat .== 0.0)
+        end
+
+        # Converged defaults to all false.
+        @test length(results.converged) == n_time_steps
+        @test !any(results.converged)
+
+        # Optional fields default to nothing.
+        @test results.loss_factors === nothing
+        @test results.voltage_stability_factors === nothing
+        @test results.arc_active_power_losses === nothing
+    end
+
+    @testset "Optional fields enabled" begin
+        results = TimePowerFlowData(
+            n_buses,
+            n_arcs,
+            n_time_steps;
+            calculate_loss_factors = true,
+            calculate_voltage_stability_factors = true,
+            make_arc_active_power_losses = true,
+        )
+
+        @test results.loss_factors !== nothing
+        @test size(results.loss_factors) == (n_buses, n_time_steps)
+        @test all(results.loss_factors .== 0.0)
+
+        @test results.voltage_stability_factors !== nothing
+        @test size(results.voltage_stability_factors) == (n_buses, n_time_steps)
+        @test all(results.voltage_stability_factors .== 0.0)
+
+        @test results.arc_active_power_losses !== nothing
+        @test size(results.arc_active_power_losses) == (n_arcs, n_time_steps)
+        @test all(results.arc_active_power_losses .== 0.0)
+    end
+
+    @testset "Subtype relationship" begin
+        @test TimePowerFlowData <: AbstractPowerFlowResults
+    end
+
+    @testset "Single time step" begin
+        results = TimePowerFlowData(10, 8, 1)
+        @test size(results.bus_magnitude) == (10, 1)
+        @test size(results.arc_active_power_flow_from_to) == (8, 1)
+        @test length(results.converged) == 1
+    end
+end


### PR DESCRIPTION
I asked Claude to refactor the way to handle the internal PowerFlowData to better manage contingencies. 

This was the prompt 

```
The design idea is to extract the     
  results matrices defined in PowerFlowData into two different structs.                                                    
                                                                                                                           
  1. TimePowerFlowData which essentially retains the existing structure with matrices for all the results and              
  2. TimeContingencyPowerFlowData which now contains a tensor and a proper index to link the contingencies and time steps  of each value. The TimeContingencyPowerFlowData should also have placeholder to store the YbusModifications from each contingency as defined in ../PowerNetworkMatrices to facilitate the calculation of the updated Ybus used for each contingency.

  Make a plan to implement these new structs in a very performant way and make sure all the API for PowerFlowData without  contingencies works properly
  ```

This relies on code from PNM that isn't released yet 