### PR TITLE
Handle removed buses

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PowerFlows"
 uuid = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
-authors = ["Jose Daniel Lara", "Gabriel Konar-Steenberg", "Luke Kiernan"]
 version = "0.16.1"
+authors = ["Jose Daniel Lara", "Gabriel Konar-Steenberg", "Luke Kiernan"]
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -28,7 +28,7 @@ KLU = "^0.6"
 LineSearches = "7.4.0"
 LinearAlgebra = "1"
 Logging = "1"
-PowerNetworkMatrices = "^0.19"
+PowerNetworkMatrices = "^0.20"
 PowerSystems = "5.5"
 SparseArrays = "1"
 StaticArrays = "1.9.13"

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -456,7 +456,14 @@ function make_and_initialize_power_flow_data(
     arc_lossy_admittance_to_from::Union{SparseMatrixCSC{YBUS_ELTYPE, Int}, Nothing} = nothing,
 ) where {M <: PNM.PowerNetworkMatrix, N <: Union{PNM.PowerNetworkMatrix, Nothing}}
     check_unit_setting(sys)
-    n_lccs = length(PSY.get_available_components(PSY.TwoTerminalLCCLine, sys))
+    removed_buses =
+        PNM.get_removed_buses(PNM.get_network_reduction_data(power_network_matrix))
+    n_lccs = count(
+        lcc ->
+            PSY.get_number(PSY.get_from(PSY.get_arc(lcc))) ∉ removed_buses &&
+                PSY.get_number(PSY.get_to(PSY.get_arc(lcc))) ∉ removed_buses,
+        PSY.get_available_components(PSY.TwoTerminalLCCLine, sys),
+    )
     data = PowerFlowData(
         pf,
         power_network_matrix,

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -458,12 +458,11 @@ function make_and_initialize_power_flow_data(
     check_unit_setting(sys)
     removed_buses =
         PNM.get_removed_buses(PNM.get_network_reduction_data(power_network_matrix))
-    n_lccs = count(
+    lcc_filter =
         lcc ->
             PSY.get_number(PSY.get_from(PSY.get_arc(lcc))) ∉ removed_buses &&
-                PSY.get_number(PSY.get_to(PSY.get_arc(lcc))) ∉ removed_buses,
-        PSY.get_available_components(PSY.TwoTerminalLCCLine, sys),
-    )
+                PSY.get_number(PSY.get_to(PSY.get_arc(lcc))) ∉ removed_buses
+    n_lccs = length(PSY.get_available_components(lcc_filter, PSY.TwoTerminalLCCLine, sys))
     data = PowerFlowData(
         pf,
         power_network_matrix,

--- a/src/common.jl
+++ b/src/common.jl
@@ -14,19 +14,20 @@ function _get_injections!(
     bus_reactive_power_injections::Vector{Float64},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
     sys::PSY.System,
 )
     check_unit_setting(sys)
     for source in PSY.get_available_components(PSY.StaticInjection, sys)
+        bus = PSY.get_bus(source)
+        PSY.get_number(bus) in removed_buses && continue
         if contributes_active_power(source) &&
            active_power_contribution_type(source) == PowerContributionType.INJECTION
-            bus = PSY.get_bus(source)
             bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
             bus_active_power_injections[bus_ix] += PSY.get_active_power(source)
         end
         if considers_reactive_power(pf) && contributes_reactive_power(source) &&
            reactive_power_contribution_type(source) == PowerContributionType.INJECTION
-            bus = PSY.get_bus(source)
             bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
             # yet to implement control mode etc. for FACTS devices.
             if source isa PSY.FACTSControlDevice
@@ -51,6 +52,7 @@ function _compute_bus_active_power_range!(
     bus_active_power_range::Matrix{Float64},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
     sys::PSY.System,
     generator_headroom::Union{Dict{Tuple{DataType, String}, Float64}, Nothing} = nothing,
 )
@@ -59,6 +61,7 @@ function _compute_bus_active_power_range!(
         active_power_contribution_type(source) == PowerContributionType.INJECTION ||
             continue
         bus = PSY.get_bus(source)
+        PSY.get_number(bus) in removed_buses && continue
         PSY.get_bustype(bus) ∈ (PSY.ACBusTypes.REF, PSY.ACBusTypes.PV) || continue
         limits = get_active_power_limits_for_power_flow(source)
         range_k = limits.max - PSY.get_active_power(source)
@@ -83,19 +86,20 @@ function _get_withdrawals!(
     bus_reactive_power_constant_impedance_withdrawals::Vector{Float64},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
     sys::PSY.System,
 )
     # constant power withdrawals
     for l in PSY.get_available_components(PSY.StaticInjection, sys)
+        bus = PSY.get_bus(l)
+        PSY.get_number(bus) in removed_buses && continue
         if contributes_active_power(l) &&
            active_power_contribution_type(l) == PowerContributionType.WITHDRAWAL
-            bus = PSY.get_bus(l)
             bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
             bus_active_power_withdrawals[bus_ix] += PSY.get_active_power(l)
         end
         if considers_reactive_power(pf) && contributes_reactive_power(l) &&
            reactive_power_contribution_type(l) == PowerContributionType.WITHDRAWAL
-            bus = PSY.get_bus(l)
             bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
             bus_reactive_power_withdrawals[bus_ix] += PSY.get_reactive_power(l)
         end
@@ -107,6 +111,7 @@ function _get_withdrawals!(
         sys,
     )
         bus = PSY.get_bus(l)
+        PSY.get_number(bus) in removed_buses && continue
         bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
         bus_active_power_withdrawals[bus_ix] += PSY.get_constant_active_power(l)
         bus_reactive_power_withdrawals[bus_ix] += PSY.get_constant_reactive_power(l)
@@ -122,6 +127,7 @@ function _get_withdrawals!(
     # FixedAdmittance components are already included in the Ybus matrix.
     for sa in PSY.get_available_components(PSY.SwitchedAdmittance, sys)
         bus = PSY.get_bus(sa)
+        PSY.get_number(bus) in removed_buses && continue
         bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
         Y = PSY.get_Y(sa) + sum(PSY.get_initial_status(sa) .* PSY.get_Y_increase(sa))
         # Here we implement the switched admittance element as a constant impedance load.
@@ -134,6 +140,7 @@ function _get_withdrawals!(
     end
     for sc in PSY.get_available_components(PSY.SynchronousCondenser, sys)
         bus = PSY.get_bus(sc)
+        PSY.get_number(bus) in removed_buses && continue
         bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
         bus_active_power_withdrawals[bus_ix] += PSY.get_active_power_losses(sc)
         # reactive power handled already:
@@ -146,12 +153,14 @@ function _get_reactive_power_bound!(
     bus_reactive_power_bounds::Vector{Tuple{Float64, Float64}},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
     sys::PSY.System,
 )
     for source in PSY.get_available_components(PSY.StaticInjection, sys)
         isa(source, PSY.ElectricLoad) && continue
         isa(source, PSY.FACTSControlDevice) && continue # FACTS devices.
         bus = PSY.get_bus(source)
+        PSY.get_number(bus) in removed_buses && continue
         bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
         reactive_power_limits = get_reactive_power_limits_for_power_flow(source)
         if !isnothing(reactive_power_limits) && !isinf(reactive_power_limits.min) &&
@@ -395,6 +404,7 @@ function _add_gspf_to_ijv!(
     gsp_factors::Dict{Tuple{DataType, String}, Float64},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
     time_steps_iter::AbstractVector{<:Integer},
 )
     for ((gen_type, gen_name), val) in gsp_factors
@@ -403,6 +413,7 @@ function _add_gspf_to_ijv!(
         isnothing(gen) && throw(ArgumentError("$gen_type $gen_name not found"))
         PSY.get_available(gen) || continue
         bus = PSY.get_bus(gen)
+        PSY.get_number(bus) in removed_buses && continue
         bus_idx = _get_bus_ix(bus_lookup, reverse_bus_search_map, PSY.get_number(bus))
         for time_step in time_steps_iter
             push!(I, bus_idx)
@@ -419,6 +430,7 @@ function make_bus_slack_participation_factors!(
     generator_slack_participation_factors_input::Dict{Tuple{DataType, String}, Float64},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
     time_steps::Int,
     n_buses::Int,
     ::Matrix{PSY.ACBusTypes},
@@ -435,6 +447,7 @@ function make_bus_slack_participation_factors!(
         generator_slack_participation_factors_input,
         bus_lookup,
         reverse_bus_search_map,
+        removed_buses,
         1:time_steps,
     )
 
@@ -454,6 +467,7 @@ function make_bus_slack_participation_factors!(
     },
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
     time_steps::Int,
     n_buses::Int,
     bus_type::Matrix{PSY.ACBusTypes},
@@ -465,6 +479,7 @@ function make_bus_slack_participation_factors!(
             generator_slack_participation_factors_input[1],
             bus_lookup,
             reverse_bus_search_map,
+            removed_buses,
             time_steps,
             n_buses,
             bus_type,
@@ -508,6 +523,7 @@ function make_bus_slack_participation_factors!(
             factors,
             bus_lookup,
             reverse_bus_search_map,
+            removed_buses,
             time_step:time_step,
         )
     end
@@ -522,6 +538,7 @@ function make_bus_slack_participation_factors!(
     ::Nothing,
     ::Dict{Int, Int},
     ::Dict{Int, Int},
+    ::Set{Int},
     time_steps::Int,
     n_buses::Int,
     bus_type::Matrix{PSY.ACBusTypes},

--- a/src/initialize_power_flow_data.jl
+++ b/src/initialize_power_flow_data.jl
@@ -11,6 +11,7 @@ function initialize_power_flow_data!(
     nrd = get_network_reduction_data(data)
     reverse_bus_search_map = PNM.get_reverse_bus_search_map(nrd)
     bus_reduction_map = PNM.get_bus_reduction_map(nrd)
+    removed_buses = PNM.get_removed_buses(nrd)
     bus_lookup = get_bus_lookup(data)
     n_buses = length(bus_lookup)
 
@@ -43,6 +44,7 @@ function initialize_power_flow_data!(
         bus_reactive_power_injections,
         bus_lookup,
         reverse_bus_search_map,
+        removed_buses,
         sys,
     )
     data.bus_active_power_injections[:, 1] .= bus_active_power_injections
@@ -58,6 +60,7 @@ function initialize_power_flow_data!(
             data.bus_active_power_range,
             bus_lookup,
             reverse_bus_search_map,
+            removed_buses,
             sys,
             generator_headroom,
         )
@@ -80,6 +83,7 @@ function initialize_power_flow_data!(
         bus_reactive_power_constant_impedance_withdrawals,
         bus_lookup,
         reverse_bus_search_map,
+        removed_buses,
         sys,
     )
     data.bus_active_power_withdrawals[:, 1] .= bus_active_power_withdrawals
@@ -102,6 +106,7 @@ function initialize_power_flow_data!(
         bus_reactive_power_bounds,
         bus_lookup,
         reverse_bus_search_map,
+        removed_buses,
         sys,
     )
     data.bus_reactive_power_bounds[:, 1] .= bus_reactive_power_bounds
@@ -114,6 +119,7 @@ function initialize_power_flow_data!(
         get_slack_participation_factors(pf),
         bus_lookup,
         reverse_bus_search_map,
+        removed_buses,
         length(get_time_step_map(data)),
         n_buses,
         data.bus_type,
@@ -137,10 +143,10 @@ function initialize_power_flow_data!(
     end
     # LCCs: initialize parameters. For DC power flow, this also writes the fixed flows to
     # data.lcc.arc_active_power_flow_from_to and data.lcc.arc_active_power_flow_to_from.
-    initialize_LCCParameters!(data, sys, bus_lookup, reverse_bus_search_map)
+    initialize_LCCParameters!(data, sys, bus_lookup, reverse_bus_search_map, removed_buses)
     # TODO VSC AC power flow model goes here.
     # LCCs and VSCs, DC only: accumulate net power into bus_hvdc_net_power.
-    lcc_vsc_fixed_injections!(data, sys, bus_lookup, reverse_bus_search_map)
+    lcc_vsc_fixed_injections!(data, sys, bus_lookup, reverse_bus_search_map, removed_buses)
     # generic HVDC lines: calculate fixed flows and save to generic_hvdc_flows.
     initialize_generic_hvdc_flows!(
         data,
@@ -154,6 +160,7 @@ function initialize_power_flow_data!(
         sys,
         bus_lookup,
         reverse_bus_search_map,
+        removed_buses,
     )
     # ZIP Loads, DC only: convert constant current and impedance components to constant
     # powers via assuming V = 1.0 p.u.

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -112,23 +112,22 @@ function initialize_LCC_arcs_and_buses!(
     lccs::Vector{PSY.TwoTerminalLCCLine},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
-    removed_buses::Set{Int},
 )
     lcc_arcs = PSY.get_arc.(lccs)
     nrd = get_network_reduction_data(data)
     for (i, arc) in enumerate(lcc_arcs)
-        from_number = PSY.get_number(PSY.get_from(arc))
-        to_number = PSY.get_number(PSY.get_to(arc))
-        if from_number in removed_buses || to_number in removed_buses
-            error(
-                "LCC line $(PSY.get_name(lccs[i])) connects to a removed bus. " *
-                "LCC lines on removed buses are not supported.",
-            )
-        end
         data.lcc.arcs[i] = PNM.get_arc_tuple(arc, nrd)
         data.lcc.bus_indices[i] = (
-            _get_bus_ix(bus_lookup, reverse_bus_search_map, from_number),
-            _get_bus_ix(bus_lookup, reverse_bus_search_map, to_number),
+            _get_bus_ix(
+                bus_lookup,
+                reverse_bus_search_map,
+                PSY.get_number(PSY.get_from(arc)),
+            ),
+            _get_bus_ix(
+                bus_lookup,
+                reverse_bus_search_map,
+                PSY.get_number(PSY.get_to(arc)),
+            ),
         )
     end
     return
@@ -142,10 +141,16 @@ function initialize_LCCParameters!(
     removed_buses::Set{Int},
 )
     check_unit_setting(sys)
-    lccs = collect(PSY.get_components(PSY.get_available, PSY.TwoTerminalLCCLine, sys))
+    lccs = collect(
+        PSY.get_available_components(
+            x -> x.arc.from.number ∉ removed_buses && x.arc.to.number ∉ removed_buses,
+            PSY.TwoTerminalLCCLine,
+            sys,
+        ),
+    )
     isempty(lccs) && return
 
-    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map, removed_buses)
+    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map)
 
     # for DC power flow calculations, LCC arc flows are known from quantities from setup.
     for (i, lcc_branch) in enumerate(lccs)
@@ -165,7 +170,13 @@ function initialize_LCCParameters!(
     removed_buses::Set{Int},
 )
     check_unit_setting(sys)
-    lccs = collect(PSY.get_components(PSY.get_available, PSY.TwoTerminalLCCLine, sys))
+    lccs = collect(
+        PSY.get_available_components(
+            x -> x.arc.from.number ∉ removed_buses && x.arc.to.number ∉ removed_buses,
+            PSY.TwoTerminalLCCLine,
+            sys,
+        ),
+    )
     isempty(lccs) && return
 
     lcc_setpoint_at_rectifier = get_lcc_setpoint_at_rectifier(data)
@@ -185,7 +196,7 @@ function initialize_LCCParameters!(
     lcc_rectifier_min_alpha = get_lcc_rectifier_min_thyristor_angle(data)
     lcc_inverter_min_gamma = get_lcc_inverter_min_thyristor_angle(data)
 
-    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map, removed_buses)
+    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map)
 
     lcc_arcs = PSY.get_arc.(lccs)
 

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -112,23 +112,23 @@ function initialize_LCC_arcs_and_buses!(
     lccs::Vector{PSY.TwoTerminalLCCLine},
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
 )
     lcc_arcs = PSY.get_arc.(lccs)
-    # TODO error if LCCs are involved in reductions.
     nrd = get_network_reduction_data(data)
     for (i, arc) in enumerate(lcc_arcs)
+        from_number = PSY.get_number(PSY.get_from(arc))
+        to_number = PSY.get_number(PSY.get_to(arc))
+        if from_number in removed_buses || to_number in removed_buses
+            error(
+                "LCC line $(PSY.get_name(lccs[i])) connects to a removed bus. " *
+                "LCC lines on removed buses are not supported.",
+            )
+        end
         data.lcc.arcs[i] = PNM.get_arc_tuple(arc, nrd)
         data.lcc.bus_indices[i] = (
-            _get_bus_ix(
-                bus_lookup,
-                reverse_bus_search_map,
-                PSY.get_number(PSY.get_from(arc)),
-            ),
-            _get_bus_ix(
-                bus_lookup,
-                reverse_bus_search_map,
-                PSY.get_number(PSY.get_to(arc)),
-            ),
+            _get_bus_ix(bus_lookup, reverse_bus_search_map, from_number),
+            _get_bus_ix(bus_lookup, reverse_bus_search_map, to_number),
         )
     end
     return
@@ -139,12 +139,13 @@ function initialize_LCCParameters!(
     sys::PSY.System,
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
 )
     check_unit_setting(sys)
     lccs = collect(PSY.get_components(PSY.get_available, PSY.TwoTerminalLCCLine, sys))
     isempty(lccs) && return
 
-    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map)
+    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map, removed_buses)
 
     # for DC power flow calculations, LCC arc flows are known from quantities from setup.
     for (i, lcc_branch) in enumerate(lccs)
@@ -161,6 +162,7 @@ function initialize_LCCParameters!(
     sys::PSY.System,
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
 )
     check_unit_setting(sys)
     lccs = collect(PSY.get_components(PSY.get_available, PSY.TwoTerminalLCCLine, sys))
@@ -183,7 +185,7 @@ function initialize_LCCParameters!(
     lcc_rectifier_min_alpha = get_lcc_rectifier_min_thyristor_angle(data)
     lcc_inverter_min_gamma = get_lcc_inverter_min_thyristor_angle(data)
 
-    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map)
+    initialize_LCC_arcs_and_buses!(data, lccs, bus_lookup, reverse_bus_search_map, removed_buses)
 
     lcc_arcs = PSY.get_arc.(lccs)
 
@@ -229,20 +231,17 @@ function hvdc_fixed_injections!(
     sys::PSY.System,
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
 )
     for hvdc in PSY.get_available_components(hvdc_type, sys)
         arc = PSY.get_arc(hvdc)
+        from_number = PSY.get_number(PSY.get_from(arc))
+        to_number = PSY.get_number(PSY.get_to(arc))
+        from_number in removed_buses && continue
+        to_number in removed_buses && continue
         (P_net_from, P_net_to) = get_hvdc_injections(hvdc, sys)
-        from_bus_ix = _get_bus_ix(
-            bus_lookup,
-            reverse_bus_search_map,
-            PSY.get_number(PSY.get_from(arc)),
-        )
-        to_bus_ix = _get_bus_ix(
-            bus_lookup,
-            reverse_bus_search_map,
-            PSY.get_number(PSY.get_to(arc)),
-        )
+        from_bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, from_number)
+        to_bus_ix = _get_bus_ix(bus_lookup, reverse_bus_search_map, to_number)
         data.bus_hvdc_net_power[from_bus_ix, :] .+= P_net_from
         data.bus_hvdc_net_power[to_bus_ix, :] .+= P_net_to
     end
@@ -254,6 +253,7 @@ lcc_vsc_fixed_injections!(
     ::PSY.System,
     ::Dict{Int, Int},
     ::Dict{Int, Int},
+    ::Set{Int},
 ) = nothing
 
 lcc_vsc_fixed_injections!(
@@ -261,6 +261,7 @@ lcc_vsc_fixed_injections!(
     sys::PSY.System,
     bus_lookup::Dict{Int, Int},
     reverse_bus_search_map::Dict{Int, Int},
+    removed_buses::Set{Int},
 ) =
     hvdc_fixed_injections!.(
         (data,),
@@ -268,6 +269,7 @@ lcc_vsc_fixed_injections!(
         (sys,),
         (bus_lookup,),
         (reverse_bus_search_map,),
+        (removed_buses,),
     )
 
 function initialize_generic_hvdc_flows!(

--- a/test/test_reduced_dc_power_flow.jl
+++ b/test/test_reduced_dc_power_flow.jl
@@ -111,3 +111,15 @@ end
         unreduced,
     )
 end
+
+@testset "DC PowerFlow with Ward and multiple islands" begin
+    sys = build_system(PSISystems, "2Area 5 Bus System")
+    show_components(ACBus, sys, [:number])
+    ward_reduction = PNM.NetworkReduction[PNM.WardReduction([1, 2, 3, 4])]
+
+    ybus = Ybus(sys; network_reductions = ward_reduction)
+    @show ybus.subnetwork_axes
+    data = PF.PowerFlowData(PF.DCPowerFlow(; network_reductions = ward_reduction), sys)
+    PF.solve_power_flow!(data)
+    @test all(data.converged)
+end


### PR DESCRIPTION
In https://github.com/NREL-Sienna/PowerNetworkMatrices.jl/pull/277 we refactor Ward reduction so that it only applies to a single synchronous region. Buses in other islands are no longer mapped via `reverse_bus_search_map`, but instead are included in `removed_buses`. This PR is to update the handling of these cases so we can build a power flow for a ward reduced system that has multiple islands (e.g. the EI). 