### PR TITLE
[DO NOT MERGE] Repro: Windows-only BoundsError in legacy PF loss factors

### DIFF
--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: ['1']
+        julia-version: ['1.11']
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 

--- a/test/test_solve_power_flow.jl
+++ b/test/test_solve_power_flow.jl
@@ -338,6 +338,47 @@ end
     )
 end
 
+# Restored to repro the Windows-only BoundsError tracked in issue #113.
+@testset "Test loss factors for larger grid" begin
+    sys = build_system(MatpowerTestSystems, "matpower_ACTIVSg2000_sys")
+
+    pf_lu = ACPowerFlow{LUACPowerFlow}(; correct_bustypes = true)
+    pf_lu_lf = ACPowerFlow{LUACPowerFlow}(;
+        calculate_loss_factors = true,
+        correct_bustypes = true,
+    )
+    pf_newton = ACPowerFlow{NewtonRaphsonACPowerFlow}(;
+        calculate_loss_factors = true,
+        correct_bustypes = true,
+    )
+
+    data_lu = PowerFlowData(pf_lu_lf, sys)
+    data_newton = PowerFlowData(pf_newton, sys)
+    data_brute_force = PowerFlowData(pf_newton, sys)
+
+    solve_power_flow!(data_lu; pf = pf_lu_lf)
+    solve_power_flow!(data_newton; pf = pf_newton)
+
+    @test all(
+        isapprox.(
+            data_lu.loss_factors,
+            data_newton.loss_factors,
+            rtol = 0,
+            atol = 1e-9,
+        ),
+    )
+
+    bf_loss_factors = penalty_factors_brute_force(data_brute_force, pf_newton)
+    @test all(
+        isapprox.(
+            data_newton.loss_factors,
+            bf_loss_factors,
+            rtol = 0,
+            atol = 1e-4,
+        ),
+    )
+end
+
 @testset "voltage_stability_factors" begin
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
     pf_lu = ACPowerFlow{LUACPowerFlow}(;

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -121,7 +121,10 @@ function _legacy_J(
     j21 = imag(dSbus_dVa[pq, pvpq])
     j22 = imag(dSbus_dVm[pq, pq])
     J = sparse([j11 j12; j21 j22])
-    return J
+    # Convert to Int32-indexed to satisfy PowerFlows._singular_value_decomposition's
+    # signature (J_INDEX_TYPE = Int32). With LinearAlgebra.Diagonal restored above,
+    # `sparse(...)` yields Int64-indexed CSC.
+    return convert(SparseMatrixCSC{Float64, Int32}, J)
 end
 
 # legacy NR implementation - here we do not care about allocations, we use this function only for testing purposes

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -97,10 +97,13 @@ end
 function _legacy_dSbus_dV(
     V::Vector{Complex{Float64}},
     Ybus::SparseMatrixCSC{Complex{Float32}, Int64},
-)::Tuple{SparseMatrixCSC{Complex{Float64}, Int32}, SparseMatrixCSC{Complex{Float64}, Int32}}
-    diagV = SparseArrays.spdiagm(0 => V)
-    diagVnorm = SparseArrays.spdiagm(0 => V ./ abs.(V))
-    diagIbus = SparseArrays.spdiagm(0 => Ybus * V)
+)
+    # Reverted to pre-PR-#93 form (LinearAlgebra.Diagonal instead of
+    # SparseArrays.spdiagm, no return-type annotation) to test whether
+    # that refactor was what masked the Windows BoundsError.
+    diagV = LinearAlgebra.Diagonal(V)
+    diagVnorm = LinearAlgebra.Diagonal(V ./ abs.(V))
+    diagIbus = LinearAlgebra.Diagonal(Ybus * V)
     dSbus_dVm = diagV * conj.(Ybus * diagVnorm) + conj.(diagIbus) * diagVnorm
     dSbus_dVa = 1im * diagV * conj.(diagIbus - Ybus * diagV)
     return dSbus_dVa, dSbus_dVm
@@ -108,8 +111,8 @@ end
 
 # this function is for testing purposes only
 function _legacy_J(
-    dSbus_dVa::SparseMatrixCSC{Complex{Float64}, Int32},
-    dSbus_dVm::SparseMatrixCSC{Complex{Float64}, Int32},
+    dSbus_dVa::AbstractMatrix{<:Complex},
+    dSbus_dVm::AbstractMatrix{<:Complex},
     pvpq::Vector{Int64},
     pq::Vector{Int64},
 )

--- a/test/test_utils/legacy_pf.jl
+++ b/test/test_utils/legacy_pf.jl
@@ -221,8 +221,11 @@ function PowerFlows._newton_power_flow(
                 )
             end
             ref_first = first(ref)
-            dSbus_dVa, dSbus_dVm = _legacy_dSbus_dV(V, Ybus)
-            J = _legacy_J(dSbus_dVa, dSbus_dVm, pvpq, pq)
+            # COMMENTED OUT to reproduce the Windows-only BoundsError on CI.
+            # On Windows, omitting these recomputes triggers a BoundsError
+            # even though the matrix shapes are unchanged.
+            # dSbus_dVa, dSbus_dVm = _legacy_dSbus_dV(V, Ybus)
+            # J = _legacy_J(dSbus_dVa, dSbus_dVm, pvpq, pq)
             dSbus_dV_ref =
                 collect(real.([dSbus_dVa[ref_first, pvpq]; dSbus_dVm[ref_first, pq]]))
             J_t = sparse(transpose(J))


### PR DESCRIPTION
Draft PR to reproduce a Windows-only `BoundsError` originally seen on the `windows-bug` branch of luke-kiernan/PowerFlows.jl (May 2025).

The original branch from a year ago had massive merge conflicts with current `main`, and main's `test/test_utils/legacy_pf.jl` already includes the `_legacy_dSbus_dV` / `_legacy_J` recompute that was the original Windows workaround. So instead, this branch is rebased onto current `main` with a single targeted commit that comments out those two recomputes inside the `get_calculate_loss_factors` block.

**Expected:** Windows job fails with `BoundsError`; macOS and Linux pass.

**Goal:** confirm the bug still reproduces on current `main` + current registered dependency stack before bisecting KLU.jl / SuiteSparse_jll.

Not for merge.