### PR TITLE
Fix LCC Jacobian: correct dQ/dV, dQ/dt; add missing inverter-side entries

### DIFF
--- a/docs/src/explanation/lcc_model.md
+++ b/docs/src/explanation/lcc_model.md
@@ -45,11 +45,17 @@ The relevant non-zero entries in the Jacobian matrix for the rectifier (r) and i
 ```math
 \begin{aligned}
 \frac{\partial P_r}{\partial V_r} &= t_r \frac{\sqrt{6}}{\pi} I_{dc} \cos(\alpha_r) \\
-\frac{\partial Q_r}{\partial V_r} &= V_r t_r \frac{\sqrt{6}}{\pi} I_{dc} \left(\sin(\phi_r) - \cos(\phi_r) \frac{x_r I_{dc}}{\sqrt{2} V_r t_r \sin^2(\phi_r)}\right) \\
-\frac{\partial Q_r}{\partial t_r} &= V_r t_r \frac{\sqrt{6}}{\pi} I_{dc} \left(\frac{\sin(\phi_r)}{t_r} - \cos(\phi_r) \frac{x_r I_{dc}}{\sqrt{2} V_r t_r^2 \sin^2(\phi_r)}\right) \\
+\frac{\partial Q_r}{\partial V_r} &= t_r \frac{\sqrt{6}}{\pi} I_{dc} \sin(\phi_r) - \frac{\sqrt{6}}{\pi} \cos(\phi_r) \frac{\operatorname{sign}(I_{dc})\,x_r I_{dc}^2}{\sqrt{2} V_r \sin(\phi_r)} \\
+\frac{\partial Q_r}{\partial t_r} &= V_r \frac{\sqrt{6}}{\pi} I_{dc} \sin(\phi_r) - \frac{\sqrt{6}}{\pi} \cos(\phi_r) \frac{\operatorname{sign}(I_{dc})\,x_r I_{dc}^2}{\sqrt{2} t_r \sin(\phi_r)} \\
 \frac{\partial Q_r}{\partial \alpha_r} &= V_r t_r \frac{\sqrt{6}}{\pi} I_{dc} \frac{\cos(\phi_r) \sin(\alpha_r)}{\sin(\phi_r)} \\
 \frac{\partial P_r}{\partial t_r} &= V_r \frac{\sqrt{6}}{\pi} I_{dc} \cos(\alpha_r) \\
 \frac{\partial P_r}{\partial \alpha_r} &= -V_r \frac{\sqrt{6}}{\pi} I_{dc} t_r \sin(\alpha_r) \\
+\frac{\partial P_i}{\partial V_i} &= -t_i \frac{\sqrt{6}}{\pi} I_{dc} \cos(\alpha_i) \\
+\frac{\partial P_i}{\partial t_i} &= -V_i \frac{\sqrt{6}}{\pi} I_{dc} \cos(\alpha_i) \\
+\frac{\partial P_i}{\partial \alpha_i} &= V_i \frac{\sqrt{6}}{\pi} I_{dc} t_i \sin(\alpha_i) \\
+\frac{\partial Q_i}{\partial V_i} &= t_i \frac{\sqrt{6}}{\pi} I_{dc} \sin(\phi_i) - \frac{\sqrt{6}}{\pi} \cos(\phi_i) \frac{\operatorname{sign}(I_{dc})\,x_i I_{dc}^2}{\sqrt{2} V_i \sin(\phi_i)} \\
+\frac{\partial Q_i}{\partial t_i} &= V_i \frac{\sqrt{6}}{\pi} I_{dc} \sin(\phi_i) - \frac{\sqrt{6}}{\pi} \cos(\phi_i) \frac{\operatorname{sign}(I_{dc})\,x_i I_{dc}^2}{\sqrt{2} t_i \sin(\phi_i)} \\
+\frac{\partial Q_i}{\partial \alpha_i} &= -V_i t_i \frac{\sqrt{6}}{\pi} I_{dc} \frac{\cos(\phi_i) \sin(\alpha_i)}{\sin(\phi_i)} \\
 \frac{\partial F_{t_i}}{\partial V_i} &= t_i \frac{\sqrt{6}}{\pi} (-I_{dc}) \cos(\alpha_i) \\
 \frac{\partial F_{t_r}}{\partial t_r} &= V_r \frac{\sqrt{6}}{\pi} I_{dc} \cos(\alpha_r) \\
 \frac{\partial F_{t_r}}{\partial \alpha_r} &= -V_r \frac{\sqrt{6}}{\pi} I_{dc} t_r \sin(\alpha_r) \\

--- a/docs/src/explanation/lcc_model.md
+++ b/docs/src/explanation/lcc_model.md
@@ -28,10 +28,11 @@ The complex apparent power for a rectifier or inverter is calculated as $S = V t
 
 To allow for the Jacobian implementation, a simplified calculation of the angle between the AC current and voltage at the LCC terminals was used. The equation below represents the calculation used for the angle:
 ```math
-\phi = \arccos\left(\cos(\alpha) \text{sign}(I_{dc}) - \frac{x I_{dc}}{\sqrt{2} t V}\right)
+\phi = \arccos\left(\operatorname{sign}(I_{dc})\left(\cos(\alpha) - \frac{x I_{dc}}{\sqrt{2} t V}\right)\right)
 ```
+where, by convention, we flip the sign of $I_{dc}$ on the inverter side. The net effect of the flip is an overall negation of the $\arccos$ argument at the inverter, which is what produces the negative signs on the $\partial P_i/\partial\cdot$ rows and on $\partial Q_i/\partial\alpha_i$ in the Jacobian below. The $\operatorname{sign}(I_{dc})$ factor appears the same way in the derivative rows.
 
-In the equation above, the variable ``\alpha`` represents the thyristor angle. The active and reactive powers for a converter station are 
+In the equation above, the variable $\alpha$ represents the thyristor angle. The active and reactive powers for a converter station are 
 
 ```math
 \begin{aligned}

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -576,8 +576,23 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
 
         s = _lcc_jacobian_scalars(data, i, time_step, Vm_fb, Vm_tb)
 
+        # True-φ ∂P/∂V and ∂P/∂t for the rectifier side. The polar
+        # α-approximation drops the `∂φ/∂Vm` (resp. `∂φ/∂t`) chain term —
+        # which vanishes only when `x_t = 0`. The true-φ formulas are
+        # singularity-free (the `sin(φ)` from `∂φ/∂(V,t)` cancels the
+        # `-sin(φ)` from differentiating `cos(φ)`).
+        # For ∂P/∂α the analogous cancellation makes the α-approximation
+        # exact, so those entries stay on `common_alpha_*`.
+        dP_dV_fb = _calculate_dP_dV_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r)
+        dP_dt_fb = _calculate_dP_dt_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r)
+        # Inverter side: `P_lcc_to = V_tb · tap_i · √6/π · I_dc · cos(phi_i)`
+        # with `phi_i` already encoding the inverter sign convention via
+        # `_calculate_ϕ_lcc(-I_dc, …)`. Pass the same positive `I_dc`.
+        dP_dV_tb = _calculate_dP_dV_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i)
+        dP_dt_tb = _calculate_dP_dt_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i)
+
         if bus_type_fb == PSY.ACBusTypes.PQ
-            Jv[idx_p_fb, idx_p_fb] += s.common_tap_r # ∂P_fb/∂V_fb
+            Jv[idx_p_fb, idx_p_fb] += dP_dV_fb # ∂P_fb/∂V_fb
             Jv[idx_q_fb, idx_p_fb] +=
                 _calculate_dQ_dV_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂V_fb
 
@@ -586,17 +601,17 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
             Jv[idx_q_fb, idx_angle_from] =
                 _calculate_dQ_dα_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r, alpha_r) # ∂Q_fb/∂α_fb
 
-            Jv[idx_tap_from, idx_p_fb] = s.common_tap_r # ∂F_t_fb/∂V_fb
-            Jv[idx_tap_to, idx_p_fb] = s.common_tap_r # ∂F_t_tb/∂V_fb
+            Jv[idx_tap_from, idx_p_fb] = dP_dV_fb # ∂F_t_fb/∂V_fb
+            Jv[idx_tap_to, idx_p_fb] = dP_dV_fb # ∂F_t_tb/∂V_fb
         end
 
         if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
-            Jv[idx_p_fb, idx_tap_from] = s.common_fb * s.cos_alpha_r # ∂P_fb/∂t_fb
-            Jv[idx_p_fb, idx_angle_from] = s.common_alpha_r # ∂P_fb/∂α_fb
+            Jv[idx_p_fb, idx_tap_from] = dP_dt_fb # ∂P_fb/∂t_fb
+            Jv[idx_p_fb, idx_angle_from] = s.common_alpha_r # ∂P_fb/∂α_fb (α-approx is exact)
         end
 
         if bus_type_tb == PSY.ACBusTypes.PQ
-            Jv[idx_p_tb, idx_p_tb] += s.common_tap_i # ∂P_tb/∂V_tb
+            Jv[idx_p_tb, idx_p_tb] += dP_dV_tb # ∂P_tb/∂V_tb
             Jv[idx_q_tb, idx_p_tb] +=
                 _calculate_dQ_dV_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂V_tb
 
@@ -606,12 +621,12 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
             Jv[idx_q_tb, idx_angle_to] =
                 -_calculate_dQ_dα_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i, alpha_i) # ∂Q_tb/∂α_tb
 
-            Jv[idx_tap_to, idx_p_tb] = s.common_tap_i # ∂F_t_tb/∂V_tb
+            Jv[idx_tap_to, idx_p_tb] = dP_dV_tb # ∂F_t_tb/∂V_tb
         end
 
         if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
-            Jv[idx_p_tb, idx_tap_to] = s.common_tb * s.cos_alpha_i # ∂P_tb/∂t_tb
-            Jv[idx_p_tb, idx_angle_to] = s.common_alpha_i # ∂P_tb/∂α_tb
+            Jv[idx_p_tb, idx_tap_to] = dP_dt_tb # ∂P_tb/∂t_tb
+            Jv[idx_p_tb, idx_angle_to] = s.common_alpha_i # ∂P_tb/∂α_tb (α-approx is exact)
         end
 
         Jv[idx_tap_from, idx_tap_from] = s.d_Ft_fb_d_tap_r

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -576,55 +576,43 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
 
         s = _lcc_jacobian_scalars(data, i, time_step, Vm_fb, Vm_tb)
 
-        # True-ϕ ∂P/∂{V, t, α} entries come from `_lcc_jacobian_scalars`,
-        # which calls the `_calculate_dP_d{V,t,α}_lcc` helpers (boundary-
-        # guarded at `sin(ϕ) → 0`). In the interior these are algebraically
-        # equal to the legacy α-approximation form via the ϕ-definition
-        # identity `cos(α) - cos(ϕ) = x_t·I_dc/(√2·V·tap)`; at the clamp
-        # the helpers correctly drop the chain term (where `∂ϕ/∂x = 0`),
-        # while the α-form silently uses `cos(α) ≠ cos(ϕ_clamp)`.
-        # See `test_jacobian.jl::"Jacobian verification with LCC at inverter ϕ clamp"`.
         dP_dV_fb = s.dP_dV_fb
         dP_dV_tb = s.dP_dV_tb
         dP_dt_fb = s.dP_dt_fb
         dP_dt_tb = s.dP_dt_tb
 
+        # Bus-row × tail-column entries (∂{P,Q}/∂{tap, α}) are written
+        # unconditionally — the bus residual rows exist for all bus types,
+        # and tap/α are state variables regardless of which AC terminal is
+        # PQ/PV/REF. ∂{P,Q}/∂V is gated by PQ (V is a state only there);
+        # likewise the tail × bus-V chain rule.
+        Jv[idx_p_fb, idx_tap_from] = dP_dt_fb # ∂P_fb/∂t_fb
+        Jv[idx_p_fb, idx_angle_from] = s.dP_dα_fb # ∂P_fb/∂α_fb
+        Jv[idx_q_fb, idx_tap_from] =
+            _calculate_dQ_dt_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂t_fb
+        Jv[idx_q_fb, idx_angle_from] =
+            _calculate_dQ_dα_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r, alpha_r) # ∂Q_fb/∂α_fb
+        Jv[idx_p_tb, idx_tap_to] = dP_dt_tb # ∂P_tb/∂t_tb
+        Jv[idx_p_tb, idx_angle_to] = s.dP_dα_tb # ∂P_tb/∂α_tb
+        Jv[idx_q_tb, idx_tap_to] =
+            _calculate_dQ_dt_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂t_tb
+        # φ_i convention flips sign of ∂φ_i/∂α_i vs the rectifier; negate helper output.
+        Jv[idx_q_tb, idx_angle_to] =
+            -_calculate_dQ_dα_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i, alpha_i) # ∂Q_tb/∂α_tb
+
         if bus_type_fb == PSY.ACBusTypes.PQ
             Jv[idx_p_fb, idx_p_fb] += dP_dV_fb # ∂P_fb/∂V_fb
             Jv[idx_q_fb, idx_p_fb] +=
                 _calculate_dQ_dV_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂V_fb
-
-            Jv[idx_q_fb, idx_tap_from] =
-                _calculate_dQ_dt_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂t_fb
-            Jv[idx_q_fb, idx_angle_from] =
-                _calculate_dQ_dα_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r, alpha_r) # ∂Q_fb/∂α_fb
-
             Jv[idx_tap_from, idx_p_fb] = dP_dV_fb # ∂F_t_fb/∂V_fb
             Jv[idx_tap_to, idx_p_fb] = dP_dV_fb # ∂F_t_tb/∂V_fb
-        end
-
-        if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
-            Jv[idx_p_fb, idx_tap_from] = dP_dt_fb # ∂P_fb/∂t_fb
-            Jv[idx_p_fb, idx_angle_from] = s.dP_dα_fb # ∂P_fb/∂α_fb (clamp-guarded)
         end
 
         if bus_type_tb == PSY.ACBusTypes.PQ
             Jv[idx_p_tb, idx_p_tb] += dP_dV_tb # ∂P_tb/∂V_tb
             Jv[idx_q_tb, idx_p_tb] +=
                 _calculate_dQ_dV_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂V_tb
-
-            Jv[idx_q_tb, idx_tap_to] =
-                _calculate_dQ_dt_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂t_tb
-            # φ_i convention flips sign of ∂φ_i/∂α_i vs the rectifier; negate helper output
-            Jv[idx_q_tb, idx_angle_to] =
-                -_calculate_dQ_dα_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i, alpha_i) # ∂Q_tb/∂α_tb
-
             Jv[idx_tap_to, idx_p_tb] = dP_dV_tb # ∂F_t_tb/∂V_tb
-        end
-
-        if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
-            Jv[idx_p_tb, idx_tap_to] = dP_dt_tb # ∂P_tb/∂t_tb
-            Jv[idx_p_tb, idx_angle_to] = s.dP_dα_tb # ∂P_tb/∂α_tb (clamp-guarded)
         end
 
         Jv[idx_tap_from, idx_tap_from] = s.d_Ft_fb_d_tap_r

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -576,20 +576,18 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
 
         s = _lcc_jacobian_scalars(data, i, time_step, Vm_fb, Vm_tb)
 
-        # True-φ ∂P/∂V and ∂P/∂t for the rectifier side. The polar
-        # α-approximation drops the `∂φ/∂Vm` (resp. `∂φ/∂t`) chain term —
-        # which vanishes only when `x_t = 0`. The true-φ formulas are
-        # singularity-free (the `sin(φ)` from `∂φ/∂(V,t)` cancels the
-        # `-sin(φ)` from differentiating `cos(φ)`).
-        # For ∂P/∂α the analogous cancellation makes the α-approximation
-        # exact, so those entries stay on `common_alpha_*`.
-        dP_dV_fb = _calculate_dP_dV_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r)
-        dP_dt_fb = _calculate_dP_dt_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r)
-        # Inverter side: `P_lcc_to = V_tb · tap_i · √6/π · I_dc · cos(phi_i)`
-        # with `phi_i` already encoding the inverter sign convention via
-        # `_calculate_ϕ_lcc(-I_dc, …)`. Pass the same positive `I_dc`.
-        dP_dV_tb = _calculate_dP_dV_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i)
-        dP_dt_tb = _calculate_dP_dt_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i)
+        # True-ϕ ∂P/∂{V, t, α} entries come from `_lcc_jacobian_scalars`,
+        # which calls the `_calculate_dP_d{V,t,α}_lcc` helpers (boundary-
+        # guarded at `sin(ϕ) → 0`). In the interior these are algebraically
+        # equal to the legacy α-approximation form via the ϕ-definition
+        # identity `cos(α) - cos(ϕ) = x_t·I_dc/(√2·V·tap)`; at the clamp
+        # the helpers correctly drop the chain term (where `∂ϕ/∂x = 0`),
+        # while the α-form silently uses `cos(α) ≠ cos(ϕ_clamp)`.
+        # See `test_jacobian.jl::"Jacobian verification with LCC at inverter ϕ clamp"`.
+        dP_dV_fb = s.dP_dV_fb
+        dP_dV_tb = s.dP_dV_tb
+        dP_dt_fb = s.dP_dt_fb
+        dP_dt_tb = s.dP_dt_tb
 
         if bus_type_fb == PSY.ACBusTypes.PQ
             Jv[idx_p_fb, idx_p_fb] += dP_dV_fb # ∂P_fb/∂V_fb

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -607,7 +607,7 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
 
         if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
             Jv[idx_p_fb, idx_tap_from] = dP_dt_fb # ∂P_fb/∂t_fb
-            Jv[idx_p_fb, idx_angle_from] = s.common_alpha_r # ∂P_fb/∂α_fb (α-approx is exact)
+            Jv[idx_p_fb, idx_angle_from] = s.dP_dα_fb # ∂P_fb/∂α_fb (clamp-guarded)
         end
 
         if bus_type_tb == PSY.ACBusTypes.PQ
@@ -626,7 +626,7 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
 
         if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
             Jv[idx_p_tb, idx_tap_to] = dP_dt_tb # ∂P_tb/∂t_tb
-            Jv[idx_p_tb, idx_angle_to] = s.common_alpha_i # ∂P_tb/∂α_tb (α-approx is exact)
+            Jv[idx_p_tb, idx_angle_to] = s.dP_dα_tb # ∂P_tb/∂α_tb (clamp-guarded)
         end
 
         Jv[idx_tap_from, idx_tap_from] = s.d_Ft_fb_d_tap_r

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -293,6 +293,7 @@ function _create_jacobian_matrix_structure_lcc(
         idx_p_fb = 2 * fb - 1
         idx_q_fb = 2 * fb
         idx_p_tb = 2 * tb - 1
+        idx_q_tb = 2 * tb
         offset_lcc = num_buses * 2 + (i - 1) * 4
         idx_tap_from = offset_lcc + 1
         idx_tap_to = offset_lcc + 2
@@ -306,6 +307,12 @@ function _create_jacobian_matrix_structure_lcc(
             (idx_p_fb, idx_angle_from, 0.0),  # ∂Pᵢ/∂αᵢ
             (idx_q_fb, idx_tap_from, 0.0),  # ∂Qᵢ/∂tᵢ
             (idx_q_fb, idx_angle_from, 0.0),  # ∂Qᵢ/∂αᵢ
+            (idx_p_tb, idx_p_tb, 0.0),  # ∂Pⱼ/∂Vⱼ
+            (idx_q_tb, idx_p_tb, 0.0),  # ∂Qⱼ/∂Vⱼ
+            (idx_p_tb, idx_tap_to, 0.0),  # ∂Pⱼ/∂tⱼ
+            (idx_p_tb, idx_angle_to, 0.0),  # ∂Pⱼ/∂αⱼ
+            (idx_q_tb, idx_tap_to, 0.0),  # ∂Qⱼ/∂tⱼ
+            (idx_q_tb, idx_angle_to, 0.0),  # ∂Qⱼ/∂αⱼ
             (idx_tap_from, idx_p_fb, 0.0),  # ∂Fₜᵢ/∂Vᵢ
             (idx_tap_to, idx_p_fb, 0.0),  # ∂Fₜⱼ/∂Vᵢ
             (idx_tap_to, idx_p_tb, 0.0),  # ∂Fₜⱼ/∂Vⱼ
@@ -550,6 +557,7 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
         idx_p_fb = 2 * fb - 1
         idx_q_fb = 2 * fb
         idx_p_tb = 2 * tb - 1
+        idx_q_tb = 2 * tb
         offset_lcc = num_buses * 2 + (i - 1) * 4
         idx_tap_from = offset_lcc + 1
         idx_tap_to = offset_lcc + 2
@@ -562,7 +570,9 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
         alpha_r = data.lcc.rectifier.thyristor_angle[i, time_step]
         alpha_i = data.lcc.inverter.thyristor_angle[i, time_step]
         phi_r = data.lcc.rectifier.phi[i, time_step]
+        phi_i = data.lcc.inverter.phi[i, time_step]
         xtr_r = data.lcc.rectifier.transformer_reactance[i]
+        xtr_i = data.lcc.inverter.transformer_reactance[i]
         Vm_fb = data.bus_magnitude[fb, time_step]
         Vm_tb = data.bus_magnitude[tb, time_step]
         bus_type_fb = data.bus_type[fb, time_step]
@@ -577,6 +587,8 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
         common_term_tb = Vm_tb * sqrt6_div_pi * (-i_dc)
         common_term_tap_r = tap_r * sqrt6_div_pi * i_dc * cos_alpha_r
         common_term_alpha_r = -common_term_fb * tap_r * sin_alpha_r
+        common_term_tap_i = tap_i * sqrt6_div_pi * (-i_dc) * cos_alpha_i
+        common_term_alpha_i = -common_term_tb * tap_i * sin_alpha_i
 
         if bus_type_fb == PSY.ACBusTypes.PQ
             Jv[idx_p_fb, idx_p_fb] += common_term_tap_r # ∂P_fb/∂V_fb
@@ -597,7 +609,21 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
         end
 
         if bus_type_tb == PSY.ACBusTypes.PQ
+            Jv[idx_p_tb, idx_p_tb] += common_term_tap_i # ∂P_tb/∂V_tb
+            Jv[idx_q_tb, idx_p_tb] += _calculate_dQ_dV_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂V_tb
+
+            Jv[idx_q_tb, idx_tap_to] =
+                _calculate_dQ_dt_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂t_tb
+            # φ_i convention flips sign of ∂φ_i/∂α_i vs the rectifier; negate helper output
+            Jv[idx_q_tb, idx_angle_to] =
+                -_calculate_dQ_dα_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i, alpha_i) # ∂Q_tb/∂α_tb
+
             Jv[idx_tap_to, idx_p_tb] = tap_i * sqrt6_div_pi * (-i_dc) * cos_alpha_i # ∂F_t_tb/∂V_tb
+        end
+
+        if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
+            Jv[idx_p_tb, idx_tap_to] = common_term_tb * cos_alpha_i # ∂P_tb/∂t_tb
+            Jv[idx_p_tb, idx_angle_to] = common_term_alpha_i # ∂P_tb/∂α_tb
         end
 
         Jv[idx_tap_from, idx_tap_from] = common_term_fb * cos_alpha_r # ∂F_t_fb/∂t_fb

--- a/src/ac_power_flow_jacobian.jl
+++ b/src/ac_power_flow_jacobian.jl
@@ -552,7 +552,6 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
     Jv::SparseArrays.SparseMatrixCSC{Float64, J_INDEX_TYPE},
     num_buses::Int,
     time_step::Int)
-    sqrt6_div_pi = sqrt(6) / π
     for (i, (fb, tb)) in enumerate(data.lcc.bus_indices)
         idx_p_fb = 2 * fb - 1
         idx_q_fb = 2 * fb
@@ -564,9 +563,6 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
         idx_angle_from = offset_lcc + 3
         idx_angle_to = offset_lcc + 4
 
-        i_dc = max(data.lcc.i_dc[i, time_step], 1e-9)  # Avoid numerical issues
-        tap_r = data.lcc.rectifier.tap[i, time_step]
-        tap_i = data.lcc.inverter.tap[i, time_step]
         alpha_r = data.lcc.rectifier.thyristor_angle[i, time_step]
         alpha_i = data.lcc.inverter.thyristor_angle[i, time_step]
         phi_r = data.lcc.rectifier.phi[i, time_step]
@@ -578,60 +574,52 @@ function _set_entries_for_lcc(data::ACPowerFlowData,
         bus_type_fb = data.bus_type[fb, time_step]
         bus_type_tb = data.bus_type[tb, time_step]
 
-        cos_alpha_r = cos(alpha_r)
-        sin_alpha_r = sin(alpha_r)
-        cos_alpha_i = cos(alpha_i)
-        sin_alpha_i = sin(alpha_i)
-
-        common_term_fb = Vm_fb * sqrt6_div_pi * i_dc
-        common_term_tb = Vm_tb * sqrt6_div_pi * (-i_dc)
-        common_term_tap_r = tap_r * sqrt6_div_pi * i_dc * cos_alpha_r
-        common_term_alpha_r = -common_term_fb * tap_r * sin_alpha_r
-        common_term_tap_i = tap_i * sqrt6_div_pi * (-i_dc) * cos_alpha_i
-        common_term_alpha_i = -common_term_tb * tap_i * sin_alpha_i
+        s = _lcc_jacobian_scalars(data, i, time_step, Vm_fb, Vm_tb)
 
         if bus_type_fb == PSY.ACBusTypes.PQ
-            Jv[idx_p_fb, idx_p_fb] += common_term_tap_r # ∂P_fb/∂V_fb
-            Jv[idx_q_fb, idx_p_fb] += _calculate_dQ_dV_lcc(tap_r, i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂V_fb
+            Jv[idx_p_fb, idx_p_fb] += s.common_tap_r # ∂P_fb/∂V_fb
+            Jv[idx_q_fb, idx_p_fb] +=
+                _calculate_dQ_dV_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂V_fb
 
             Jv[idx_q_fb, idx_tap_from] =
-                _calculate_dQ_dt_lcc(tap_r, i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂t_fb
+                _calculate_dQ_dt_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r) # ∂Q_fb/∂t_fb
             Jv[idx_q_fb, idx_angle_from] =
-                _calculate_dQ_dα_lcc(tap_r, i_dc, xtr_r, Vm_fb, phi_r, alpha_r) # ∂Q_fb/∂α_fb
+                _calculate_dQ_dα_lcc(s.tap_r, s.i_dc, xtr_r, Vm_fb, phi_r, alpha_r) # ∂Q_fb/∂α_fb
 
-            Jv[idx_tap_from, idx_p_fb] = common_term_tap_r # ∂F_t_fb/∂V_fb
-            Jv[idx_tap_to, idx_p_fb] = common_term_tap_r # ∂F_t_tb/∂V_fb
+            Jv[idx_tap_from, idx_p_fb] = s.common_tap_r # ∂F_t_fb/∂V_fb
+            Jv[idx_tap_to, idx_p_fb] = s.common_tap_r # ∂F_t_tb/∂V_fb
         end
 
         if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
-            Jv[idx_p_fb, idx_tap_from] = common_term_fb * cos_alpha_r # ∂P_fb/∂t_fb
-            Jv[idx_p_fb, idx_angle_from] = common_term_alpha_r # ∂P_fb/∂α_fb
+            Jv[idx_p_fb, idx_tap_from] = s.common_fb * s.cos_alpha_r # ∂P_fb/∂t_fb
+            Jv[idx_p_fb, idx_angle_from] = s.common_alpha_r # ∂P_fb/∂α_fb
         end
 
         if bus_type_tb == PSY.ACBusTypes.PQ
-            Jv[idx_p_tb, idx_p_tb] += common_term_tap_i # ∂P_tb/∂V_tb
-            Jv[idx_q_tb, idx_p_tb] += _calculate_dQ_dV_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂V_tb
+            Jv[idx_p_tb, idx_p_tb] += s.common_tap_i # ∂P_tb/∂V_tb
+            Jv[idx_q_tb, idx_p_tb] +=
+                _calculate_dQ_dV_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂V_tb
 
             Jv[idx_q_tb, idx_tap_to] =
-                _calculate_dQ_dt_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂t_tb
+                _calculate_dQ_dt_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i) # ∂Q_tb/∂t_tb
             # φ_i convention flips sign of ∂φ_i/∂α_i vs the rectifier; negate helper output
             Jv[idx_q_tb, idx_angle_to] =
-                -_calculate_dQ_dα_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i, alpha_i) # ∂Q_tb/∂α_tb
+                -_calculate_dQ_dα_lcc(s.tap_i, s.i_dc, xtr_i, Vm_tb, phi_i, alpha_i) # ∂Q_tb/∂α_tb
 
-            Jv[idx_tap_to, idx_p_tb] = tap_i * sqrt6_div_pi * (-i_dc) * cos_alpha_i # ∂F_t_tb/∂V_tb
+            Jv[idx_tap_to, idx_p_tb] = s.common_tap_i # ∂F_t_tb/∂V_tb
         end
 
         if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
-            Jv[idx_p_tb, idx_tap_to] = common_term_tb * cos_alpha_i # ∂P_tb/∂t_tb
-            Jv[idx_p_tb, idx_angle_to] = common_term_alpha_i # ∂P_tb/∂α_tb
+            Jv[idx_p_tb, idx_tap_to] = s.common_tb * s.cos_alpha_i # ∂P_tb/∂t_tb
+            Jv[idx_p_tb, idx_angle_to] = s.common_alpha_i # ∂P_tb/∂α_tb
         end
 
-        Jv[idx_tap_from, idx_tap_from] = common_term_fb * cos_alpha_r # ∂F_t_fb/∂t_fb
-        Jv[idx_tap_from, idx_angle_from] = common_term_alpha_r # ∂F_t_fb/∂α_fb
-        Jv[idx_tap_to, idx_tap_from] = common_term_fb * cos_alpha_r # ∂F_t_tb/∂t_fb
-        Jv[idx_tap_to, idx_tap_to] = common_term_tb * cos_alpha_i # ∂F_t_tb/∂t_tb
-        Jv[idx_tap_to, idx_angle_from] = common_term_alpha_r # ∂F_t_tb/∂α_fb
-        Jv[idx_tap_to, idx_angle_to] = -common_term_tb * tap_i * sin_alpha_i # ∂F_t_tb/∂α_tb
+        Jv[idx_tap_from, idx_tap_from] = s.d_Ft_fb_d_tap_r
+        Jv[idx_tap_from, idx_angle_from] = s.d_Ft_fb_d_alpha_r
+        Jv[idx_tap_to, idx_tap_from] = s.d_Ft_tb_d_tap_r
+        Jv[idx_tap_to, idx_tap_to] = s.d_Ft_tb_d_tap_i
+        Jv[idx_tap_to, idx_angle_from] = s.d_Ft_tb_d_alpha_r
+        Jv[idx_tap_to, idx_angle_to] = s.d_Ft_tb_d_alpha_i
     end
     return
 end

--- a/src/ac_power_flow_residual.jl
+++ b/src/ac_power_flow_residual.jl
@@ -384,33 +384,7 @@ function _update_residual_values!(
     end
 
     if num_lcc > 0
-        P_lcc_from =
-            Vm[data.lcc.rectifier.bus] .* data.lcc.rectifier.tap[:, time_step] .*
-            sqrt(6) / π .* data.lcc.i_dc[:, time_step] .*
-            cos.(data.lcc.rectifier.phi[:, time_step])
-        P_lcc_to =
-            Vm[data.lcc.inverter.bus] .* data.lcc.inverter.tap[:, time_step] .*
-            sqrt(6) / π .* data.lcc.i_dc[:, time_step] .*
-            cos.(data.lcc.inverter.phi[:, time_step])
-        # control rectifier tap for P set point
-        F[(end - 4 * num_lcc + 1):4:end] .=
-            ifelse.(
-                data.lcc.setpoint_at_rectifier,
-                P_lcc_from .- data.lcc.p_set[:, time_step],
-                -P_lcc_to .- data.lcc.p_set[:, time_step],
-            )
-        # control inverter tap for P balance
-        F[(end - 4 * num_lcc + 2):4:end] .=
-            P_lcc_from .+ P_lcc_to .-
-            data.lcc.dc_line_resistance .* data.lcc.i_dc[:, time_step] .^ 2
-        # control rectifier thyristor angle
-        F[(end - 4 * num_lcc + 3):4:end] .=
-            data.lcc.rectifier.thyristor_angle[:, time_step] .-
-            data.lcc.rectifier.min_thyristor_angle
-        # control inverter thyristor angle
-        F[(end - 4 * num_lcc + 4):4:end] .=
-            data.lcc.inverter.thyristor_angle[:, time_step] .-
-            data.lcc.inverter.min_thyristor_angle
+        _set_lcc_tail_residuals!(F, data, length(F) - 4 * num_lcc, time_step)
     end
     return
 end

--- a/src/definitions.jl
+++ b/src/definitions.jl
@@ -8,6 +8,8 @@ const LARGE_RESIDUAL = 10 # threshold for "bad initial guess": default
 
 const ISAPPROX_ZERO_TOLERANCE = 1e-6
 
+const LCC_sinϕ_TOLERANCE = 1e-8 # if sin(ϕ) < this, treat dQ/dV as zero to avoid singularity in Jacobian
+
 const DEFAULT_NR_MAX_ITER = 50 # default maxIterations for the NR power flow
 const OVERRIDE_x0 = true
 const DEFAULT_NR_TOL = 1e-9 # default tolerance for the NR power flow

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -26,7 +26,7 @@ end
 Compute the admittance value Y for LCC converter calculations.
 """
 function _calculate_y_lcc(t::Float64, I_dc::Float64, Vm::Float64, ϕ::Float64)::ComplexF64
-    return t / Vm * sqrt(6) / π * I_dc * exp(-1im * ϕ)
+    return t / Vm * SQRT6_DIV_PI * I_dc * exp(-1im * ϕ)
 end
 
 """
@@ -55,9 +55,9 @@ function _calculate_dP_dV_lcc(
     Vm::Float64,
     ϕ::Float64,
 )::Float64
-    leading = t * sqrt(6) / π * I_dc * cos(ϕ)
+    leading = t * SQRT6_DIV_PI * I_dc * cos(ϕ)
     sin(ϕ) < LCC_sinϕ_TOLERANCE && return leading  # clamped: ∂ϕ/∂Vm = 0
-    return leading + sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * Vm)
+    return leading + SQRT6_DIV_PI * I_dc^2 * x_t / (sqrt(2) * Vm)
 end
 
 """
@@ -75,9 +75,9 @@ function _calculate_dP_dt_lcc(
     Vm::Float64,
     ϕ::Float64,
 )::Float64
-    leading = Vm * sqrt(6) / π * I_dc * cos(ϕ)
+    leading = Vm * SQRT6_DIV_PI * I_dc * cos(ϕ)
     sin(ϕ) < LCC_sinϕ_TOLERANCE && return leading  # clamped: ∂ϕ/∂t = 0
-    return leading + sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * t)
+    return leading + SQRT6_DIV_PI * I_dc^2 * x_t / (sqrt(2) * t)
 end
 
 """
@@ -150,7 +150,7 @@ function _calculate_dP_dα_lcc(
     ϕ::Float64,
 )::Float64
     sin(ϕ) < LCC_sinϕ_TOLERANCE && return 0.0
-    return -Vm * t * sqrt(6) / π * I_dc * sin(α)
+    return -Vm * t * SQRT6_DIV_PI * I_dc * sin(α)
 end
 
 """
@@ -170,8 +170,8 @@ function _calculate_dQ_dV_lcc(
     # is constant in this direction, so the true derivative is 0 even though
     # the analytic formula has a 1/sin(ϕ) singularity.
     sϕ < LCC_sinϕ_TOLERANCE && return 0.0
-    return t * sqrt(6) / π * I_dc * sϕ -
-           sqrt(6) / π * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
+    return t * SQRT6_DIV_PI * I_dc * sϕ -
+           SQRT6_DIV_PI * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
            (sqrt(2) * Vm * sϕ)
 end
 
@@ -189,8 +189,8 @@ function _calculate_dQ_dt_lcc(
 )::Float64
     sϕ = sin(ϕ)
     sϕ < LCC_sinϕ_TOLERANCE && return 0.0
-    return Vm * sqrt(6) / π * I_dc * sϕ -
-           sqrt(6) / π * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
+    return Vm * SQRT6_DIV_PI * I_dc * sϕ -
+           SQRT6_DIV_PI * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
            (sqrt(2) * t * sϕ)
 end
 
@@ -209,7 +209,7 @@ function _calculate_dQ_dα_lcc(
 )::Float64
     sϕ = sin(ϕ)
     sϕ < LCC_sinϕ_TOLERANCE && return 0.0
-    return Vm * t * sqrt(6) / π * I_dc * cos(ϕ) * sin(α) / sϕ
+    return Vm * t * SQRT6_DIV_PI * I_dc * cos(ϕ) * sin(α) / sϕ
 end
 
 """

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -182,6 +182,148 @@ function _update_ybus_lcc!(
 end
 
 """
+    _set_lcc_tail_residuals!(F, data, base_offset, time_step) [polar]
+    _set_lcc_tail_residuals!(F, data, base_offset, time_step, e_state, f_state) [rect]
+
+Write the 4 LCC tail residual rows (P-setpoint, DC-line balance, two α
+limit constraints) for each LCC into `F`, starting at slot
+`base_offset + 1`. The i-th LCC occupies slots `base_offset + 4(i-1) + 1
+.. base_offset + 4i`. The polar method reads `|V|` from
+`data.bus_magnitude`; the rectangular method reads `sqrt(e² + f²)` from
+the (e, f) state (since `data.bus_magnitude` holds `V_set` at PV buses,
+not the actual state magnitude). Mirrors the two-method layout of
+[`_update_ybus_lcc!`](@ref).
+"""
+function _set_lcc_tail_residuals!(
+    F::AbstractVector{Float64},
+    data::PowerFlowData,
+    base_offset::Int,
+    time_step::Int,
+)
+    @inbounds for i in 1:size(data.lcc.p_set, 1)
+        (fb, tb) = data.lcc.bus_indices[i]
+        _write_lcc_tail!(
+            F, data, base_offset, time_step, i, fb, tb,
+            data.bus_magnitude[fb, time_step],
+            data.bus_magnitude[tb, time_step],
+        )
+    end
+    return
+end
+
+function _set_lcc_tail_residuals!(
+    F::AbstractVector{Float64},
+    data::PowerFlowData,
+    base_offset::Int,
+    time_step::Int,
+    e_state::Vector{Float64},
+    f_state::Vector{Float64},
+)
+    @inbounds for i in 1:size(data.lcc.p_set, 1)
+        (fb, tb) = data.lcc.bus_indices[i]
+        Vm_fb = sqrt(e_state[fb]^2 + f_state[fb]^2)
+        Vm_tb = sqrt(e_state[tb]^2 + f_state[tb]^2)
+        _write_lcc_tail!(F, data, base_offset, time_step, i, fb, tb, Vm_fb, Vm_tb)
+    end
+    return
+end
+
+@inline function _write_lcc_tail!(
+    F::AbstractVector{Float64},
+    data::PowerFlowData,
+    base_offset::Int,
+    time_step::Int,
+    i::Int,
+    fb::Int,
+    tb::Int,
+    Vm_fb::Float64,
+    Vm_tb::Float64,
+)
+    offset_lcc = base_offset + (i - 1) * 4
+    tap_r = data.lcc.rectifier.tap[i, time_step]
+    tap_i = data.lcc.inverter.tap[i, time_step]
+    phi_r = data.lcc.rectifier.phi[i, time_step]
+    phi_i = data.lcc.inverter.phi[i, time_step]
+    i_dc = data.lcc.i_dc[i, time_step]
+    P_lcc_from = Vm_fb * tap_r * SQRT6_DIV_PI * i_dc * cos(phi_r)
+    P_lcc_to = Vm_tb * tap_i * SQRT6_DIV_PI * i_dc * cos(phi_i)
+    F[offset_lcc + 1] = if data.lcc.setpoint_at_rectifier[i]
+        P_lcc_from - data.lcc.p_set[i, time_step]
+    else
+        -P_lcc_to - data.lcc.p_set[i, time_step]
+    end
+    F[offset_lcc + 2] =
+        P_lcc_from + P_lcc_to - data.lcc.dc_line_resistance[i] * i_dc^2
+    F[offset_lcc + 3] =
+        data.lcc.rectifier.thyristor_angle[i, time_step] -
+        data.lcc.rectifier.min_thyristor_angle[i]
+    F[offset_lcc + 4] =
+        data.lcc.inverter.thyristor_angle[i, time_step] -
+        data.lcc.inverter.min_thyristor_angle[i]
+    return
+end
+
+"""
+    _lcc_jacobian_scalars(data, i, time_step, Vm_fb, Vm_tb)
+
+Precompute the scalar coefficients used by both the polar and the
+rectangular LCC Jacobian assembly for LCC `i` at `time_step`. `Vm_fb` /
+`Vm_tb` are the AC-side voltage magnitudes — polar reads them from
+`data.bus_magnitude`; rectangular computes `sqrt(e² + f²)` from state.
+
+The returned NamedTuple includes the six tail-row × tail-column entries
+that are identical between formulations (under polar's α-approximation
+for the tail rows), plus the building blocks the FB/TB-side row entries
+chain-rule out of.
+"""
+function _lcc_jacobian_scalars(
+    data::PowerFlowData,
+    i::Int,
+    time_step::Int,
+    Vm_fb::Float64,
+    Vm_tb::Float64,
+)
+    i_dc = max(data.lcc.i_dc[i, time_step], 1e-9)
+    tap_r = data.lcc.rectifier.tap[i, time_step]
+    tap_i = data.lcc.inverter.tap[i, time_step]
+    alpha_r = data.lcc.rectifier.thyristor_angle[i, time_step]
+    alpha_i = data.lcc.inverter.thyristor_angle[i, time_step]
+    cos_alpha_r = cos(alpha_r)
+    sin_alpha_r = sin(alpha_r)
+    cos_alpha_i = cos(alpha_i)
+    sin_alpha_i = sin(alpha_i)
+    common_fb = Vm_fb * SQRT6_DIV_PI * i_dc
+    common_tb = Vm_tb * SQRT6_DIV_PI * (-i_dc)
+    common_tap_r = tap_r * SQRT6_DIV_PI * i_dc * cos_alpha_r
+    common_tap_i = tap_i * SQRT6_DIV_PI * (-i_dc) * cos_alpha_i
+    common_alpha_r = -common_fb * tap_r * sin_alpha_r
+    common_alpha_i = -common_tb * tap_i * sin_alpha_i
+    return (
+        i_dc = i_dc,
+        tap_r = tap_r,
+        tap_i = tap_i,
+        cos_alpha_r = cos_alpha_r,
+        sin_alpha_r = sin_alpha_r,
+        cos_alpha_i = cos_alpha_i,
+        sin_alpha_i = sin_alpha_i,
+        common_fb = common_fb,
+        common_tb = common_tb,
+        common_tap_r = common_tap_r,
+        common_tap_i = common_tap_i,
+        common_alpha_r = common_alpha_r,
+        common_alpha_i = common_alpha_i,
+        # Tail-row × tail-column block (6 entries, identical in polar
+        # and rectangular under the α-approximation).
+        d_Ft_fb_d_tap_r = common_fb * cos_alpha_r,
+        d_Ft_fb_d_alpha_r = common_alpha_r,
+        d_Ft_tb_d_tap_r = common_fb * cos_alpha_r,
+        d_Ft_tb_d_tap_i = common_tb * cos_alpha_i,
+        d_Ft_tb_d_alpha_r = common_alpha_r,
+        d_Ft_tb_d_alpha_i = -common_tb * tap_i * sin_alpha_i,
+    )
+end
+
+"""
 Initialize the `arcs` and `bus_indices` fields of the LCCParameters structure in the PowerFlowData.
 """
 function initialize_LCC_arcs_and_buses!(

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -10,7 +10,14 @@ function _calculate_ϕ_lcc(
     x_t::Float64,
     Vm::Float64,
 )::Float64
-    return acos(clamp(sign(I_dc) * (cos(α) - (x_t * I_dc) / (sqrt(2) * Vm * t)), -1.0, 1.0))
+    raw = sign(I_dc) * (cos(α) - (x_t * I_dc) / (sqrt(2) * Vm * t))
+    if raw < -1.0 || raw > 1.0
+        @warn "LCC ϕ argument outside [-1, 1] (got $raw); clamping. \
+               Derivative formulas in lcc_utils.jl are singular on this boundary \
+               and the analytic Jacobian disagrees with the residual past it — \
+               Newton-Raphson may struggle. Check α, I_dc, x_t, t, Vm." maxlog = 5
+    end
+    return acos(clamp(raw, -1.0, 1.0))
 end
 
 """
@@ -34,8 +41,14 @@ function _calculate_dQ_dV_lcc(
     Vm::Float64,
     ϕ::Float64,
 )::Float64
-    return Vm * t * sqrt(6) / π * I_dc *
-           (sin(ϕ) - cos(ϕ) * x_t * I_dc / (sqrt(2) * Vm * t * sin(ϕ)^2))
+    sϕ = sin(ϕ)
+    # On the clamp boundary (sin(ϕ) = 0), φ is locally pinned and the residual
+    # is constant in this direction, so the true derivative is 0 even though
+    # the analytic formula has a 1/sin(ϕ) singularity.
+    sϕ < 1e-8 && return 0.0
+    return t * sqrt(6) / π * I_dc * sϕ -
+           sqrt(6) / π * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
+           (sqrt(2) * Vm * sϕ)
 end
 
 """
@@ -50,8 +63,11 @@ function _calculate_dQ_dt_lcc(
     Vm::Float64,
     ϕ::Float64,
 )::Float64
-    return Vm * t * sqrt(6) / π * I_dc *
-           (sin(ϕ) / t - cos(ϕ) * x_t * I_dc / (sqrt(2) * Vm * t^2 * sin(ϕ)^2))
+    sϕ = sin(ϕ)
+    sϕ < 1e-8 && return 0.0
+    return Vm * sqrt(6) / π * I_dc * sϕ -
+           sqrt(6) / π * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
+           (sqrt(2) * t * sϕ)
 end
 
 """
@@ -67,7 +83,9 @@ function _calculate_dQ_dα_lcc(
     ϕ::Float64,
     α::Float64,
 )::Float64
-    return Vm * t * sqrt(6) / π * I_dc * cos(ϕ) * sin(α) / sin(ϕ)
+    sϕ = sin(ϕ)
+    sϕ < 1e-8 && return 0.0
+    return Vm * t * sqrt(6) / π * I_dc * cos(ϕ) * sin(α) / sϕ
 end
 
 """

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -33,15 +33,20 @@ end
     _calculate_dP_dV_lcc(t, I_dc, x_t, Vm, ϕ) -> Float64
 
 True-ϕ derivative of `P_lcc = Vm · t · √6/π · I_dc · cos(ϕ(Vm, t, α))` with
-respect to `Vm`, including the `∂ϕ/∂Vm` chain term. Unlike the matching
-`_calculate_dQ_dV_lcc`, the `sin(ϕ)` factor introduced by `∂ϕ/∂Vm = -∂raw/∂Vm /
-sin(ϕ)` cancels against the `-sin(ϕ)` from differentiating `cos(ϕ)` — no
-boundary guard needed.
+respect to `Vm`. Two regimes:
 
-Caller must pass `I_dc` and `ϕ` matching the side of interest: rectifier
-uses `(+I_dc, phi_r)`; inverter uses `(+I_dc, phi_i)` (the same positive
-I_dc, since `P_lcc_to = V_tb · tap_i · √6/π · I_dc · cos(phi_i)` and `phi_i`
-already encodes the sign convention via `_calculate_ϕ_lcc(-I_dc, ...)`).
+  * Interior (ϕ unclamped): `∂ϕ/∂Vm = -∂raw/∂Vm / sin(ϕ)` is nonzero; the
+    `sin(ϕ)` factor from the chain rule cancels the `-sin(ϕ)` from
+    differentiating `cos(ϕ)`, giving the second (chain) term below.
+  * Clamp (sin(ϕ) ≈ 0, i.e. ϕ ∈ {0, π}): ϕ is locally pinned (`∂ϕ/∂x = 0`)
+    and the residual sees only the leading `Vm · cos(ϕ)` dependence on
+    `Vm`. The chain term must be dropped — otherwise the analytic Jacobian
+    disagrees with the residual at the clamp, exactly analogous to the
+    `sin(ϕ)→0` guard in `_calculate_dQ_dV_lcc`.
+
+Caller passes `I_dc > 0` and the side-specific ϕ. Rectifier: `phi_r`.
+Inverter: `phi_i` (already encodes the sign convention via
+`_calculate_ϕ_lcc(-I_dc, …)`; positive `I_dc` is still passed here).
 """
 function _calculate_dP_dV_lcc(
     t::Float64,
@@ -50,16 +55,18 @@ function _calculate_dP_dV_lcc(
     Vm::Float64,
     ϕ::Float64,
 )::Float64
-    return t * sqrt(6) / π * I_dc * cos(ϕ) +
-           sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * Vm)
+    leading = t * sqrt(6) / π * I_dc * cos(ϕ)
+    sin(ϕ) < LCC_sinϕ_TOLERANCE && return leading  # clamped: ∂ϕ/∂Vm = 0
+    return leading + sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * Vm)
 end
 
 """
     _calculate_dP_dt_lcc(t, I_dc, x_t, Vm, ϕ) -> Float64
 
 True-ϕ derivative of `P_lcc` with respect to the transformer tap `t`. Same
-cancellation as `_calculate_dP_dV_lcc` — no `1/sin(ϕ)` term, no boundary
-guard required.
+two-regime structure as `_calculate_dP_dV_lcc`: chain term only when
+unclamped (`sin(ϕ) ≥ LCC_sinϕ_TOLERANCE`); leading `Vm · cos(ϕ)` term
+always present.
 """
 function _calculate_dP_dt_lcc(
     t::Float64,
@@ -68,8 +75,82 @@ function _calculate_dP_dt_lcc(
     Vm::Float64,
     ϕ::Float64,
 )::Float64
-    return Vm * sqrt(6) / π * I_dc * cos(ϕ) +
-           sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * t)
+    leading = Vm * sqrt(6) / π * I_dc * cos(ϕ)
+    sin(ϕ) < LCC_sinϕ_TOLERANCE && return leading  # clamped: ∂ϕ/∂t = 0
+    return leading + sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * t)
+end
+
+"""
+    _dphi_dV_lcc(x_t, I_dc, V, t, ϕ) -> Float64
+
+`∂ϕ/∂V` with `sin(ϕ) → 0` clamp guard returning 0. In the interior,
+`∂ϕ/∂V = -∂raw/∂V / sin(ϕ) = -x_t·I_dc / (√2·V²·t·sin(ϕ))`. At the
+clamp ϕ is pinned (`∂ϕ/∂V = 0`). Same form on both sides — the inverter
+passes the same positive `I_dc`, only its `ϕ` differs.
+"""
+function _dphi_dV_lcc(
+    x_t::Float64,
+    I_dc::Float64,
+    V::Float64,
+    t::Float64,
+    ϕ::Float64,
+)::Float64
+    sϕ = sin(ϕ)
+    sϕ < LCC_sinϕ_TOLERANCE && return 0.0
+    return -x_t * I_dc / (sqrt(2) * V^2 * t * sϕ)
+end
+
+"""
+    _dphi_dt_lcc(x_t, I_dc, V, t, ϕ) -> Float64
+
+`∂ϕ/∂t` (tap) with clamp guard. `-x_t·I_dc / (√2·V·t²·sin(ϕ))` in the
+interior, 0 at the clamp.
+"""
+function _dphi_dt_lcc(
+    x_t::Float64,
+    I_dc::Float64,
+    V::Float64,
+    t::Float64,
+    ϕ::Float64,
+)::Float64
+    sϕ = sin(ϕ)
+    sϕ < LCC_sinϕ_TOLERANCE && return 0.0
+    return -x_t * I_dc / (sqrt(2) * V * t^2 * sϕ)
+end
+
+"""
+    _dphi_dα_lcc(α, ϕ) -> Float64
+
+`∂ϕ/∂α` (rectifier sign) with clamp guard. `sin(α)/sin(ϕ)` in the
+interior, 0 at the clamp. Inverter convention flips the sign — callers
+on the inverter side negate the helper output.
+"""
+function _dphi_dα_lcc(α::Float64, ϕ::Float64)::Float64
+    sϕ = sin(ϕ)
+    sϕ < LCC_sinϕ_TOLERANCE && return 0.0
+    return sin(α) / sϕ
+end
+
+"""
+    _calculate_dP_dα_lcc(t, I_dc, Vm, α, ϕ) -> Float64
+
+True-ϕ derivative of `P_lcc` with respect to the firing/extinction angle
+`α`, rectifier sign convention. In the interior, `∂ϕ/∂α = sin(α)/sin(ϕ)`
+and combines with the `-sin(ϕ)` from differentiating `cos(ϕ)` to give the
+closed form below (no `sin(ϕ)` in the result). At the clamp, `∂ϕ/∂α = 0`
+and the true derivative is zero — same boundary handling as the dQ
+helpers. Inverter callers must negate the helper output (the inverter ϕ
+convention flips `∂ϕ_i/∂α_i`).
+"""
+function _calculate_dP_dα_lcc(
+    t::Float64,
+    I_dc::Float64,
+    Vm::Float64,
+    α::Float64,
+    ϕ::Float64,
+)::Float64
+    sin(ϕ) < LCC_sinϕ_TOLERANCE && return 0.0
+    return -Vm * t * sqrt(6) / π * I_dc * sin(α)
 end
 
 """
@@ -315,9 +396,13 @@ rectangular LCC Jacobian assembly for LCC `i` at `time_step`. `Vm_fb` /
 `data.bus_magnitude`; rectangular computes `sqrt(e² + f²)` from state.
 
 The returned NamedTuple includes the six tail-row × tail-column entries
-that are identical between formulations (under polar's α-approximation
-for the tail rows), plus the building blocks the FB/TB-side row entries
-chain-rule out of.
+that are identical between formulations (the tail rows themselves are
+identical, and so are the tail-state columns). These are computed via
+the true-ϕ helpers (`_calculate_dP_dt_lcc`, `_calculate_dP_dα_lcc`),
+which apply the `sin(ϕ) → 0` boundary guard: in the interior the
+algebraic identity makes the result equal to the α-approximation form,
+and at the clamp the guard correctly drops the chain term so the
+Jacobian matches the residual (which sees `∂ϕ/∂x = 0` at the clamp).
 """
 function _lcc_jacobian_scalars(
     data::PowerFlowData,
@@ -331,6 +416,10 @@ function _lcc_jacobian_scalars(
     tap_i = data.lcc.inverter.tap[i, time_step]
     alpha_r = data.lcc.rectifier.thyristor_angle[i, time_step]
     alpha_i = data.lcc.inverter.thyristor_angle[i, time_step]
+    phi_r = data.lcc.rectifier.phi[i, time_step]
+    phi_i = data.lcc.inverter.phi[i, time_step]
+    xtr_r = data.lcc.rectifier.transformer_reactance[i]
+    xtr_i = data.lcc.inverter.transformer_reactance[i]
     cos_alpha_r = cos(alpha_r)
     sin_alpha_r = sin(alpha_r)
     cos_alpha_i = cos(alpha_i)
@@ -341,6 +430,19 @@ function _lcc_jacobian_scalars(
     common_tap_i = tap_i * SQRT6_DIV_PI * (-i_dc) * cos_alpha_i
     common_alpha_r = -common_fb * tap_r * sin_alpha_r
     common_alpha_i = -common_tb * tap_i * sin_alpha_i
+    # True-ϕ derivatives of P_lcc_{from, to} for the tail × tail block.
+    # Inverter signs:
+    #   ∂P_lcc_to/∂tap_i: the helper returns the rectifier-style formula;
+    #     for the inverter `phi_i ≈ π − α_i` makes `cos(phi_i) < 0`, so the
+    #     helper already returns the correct negative coefficient — no sign
+    #     flip needed here.
+    #   ∂P_lcc_to/∂α_i: ϕ_i convention flips `∂ϕ_i/∂α_i`, so negate the helper.
+    dP_dV_fb = _calculate_dP_dV_lcc(tap_r, i_dc, xtr_r, Vm_fb, phi_r)
+    dP_dV_tb = _calculate_dP_dV_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i)
+    dP_dt_fb = _calculate_dP_dt_lcc(tap_r, i_dc, xtr_r, Vm_fb, phi_r)
+    dP_dt_tb = _calculate_dP_dt_lcc(tap_i, i_dc, xtr_i, Vm_tb, phi_i)
+    dP_dα_fb = _calculate_dP_dα_lcc(tap_r, i_dc, Vm_fb, alpha_r, phi_r)
+    dP_dα_tb = -_calculate_dP_dα_lcc(tap_i, i_dc, Vm_tb, alpha_i, phi_i)
     return (
         i_dc = i_dc,
         tap_r = tap_r,
@@ -355,14 +457,23 @@ function _lcc_jacobian_scalars(
         common_tap_i = common_tap_i,
         common_alpha_r = common_alpha_r,
         common_alpha_i = common_alpha_i,
-        # Tail-row × tail-column block (6 entries, identical in polar
-        # and rectangular under the α-approximation).
-        d_Ft_fb_d_tap_r = common_fb * cos_alpha_r,
-        d_Ft_fb_d_alpha_r = common_alpha_r,
-        d_Ft_tb_d_tap_r = common_fb * cos_alpha_r,
-        d_Ft_tb_d_tap_i = common_tb * cos_alpha_i,
-        d_Ft_tb_d_alpha_r = common_alpha_r,
-        d_Ft_tb_d_alpha_i = -common_tb * tap_i * sin_alpha_i,
+        # Side-specific dP helpers, exposed so polar bus-row × tail-column
+        # entries (and rect tail × bus chain rules) can use the
+        # boundary-guarded values.
+        dP_dV_fb = dP_dV_fb,
+        dP_dV_tb = dP_dV_tb,
+        dP_dα_fb = dP_dα_fb,
+        dP_dα_tb = dP_dα_tb,
+        # Tail-row × tail-column block (6 entries). F_t_fb has the
+        # P_lcc_from contribution (in the setpoint_at_rectifier case);
+        # F_t_tb has both P_lcc_from and P_lcc_to. d_Ft_fb_d_alpha_i is
+        # zero because F_t_fb doesn't depend on α_i.
+        d_Ft_fb_d_tap_r = dP_dt_fb,
+        d_Ft_fb_d_alpha_r = dP_dα_fb,
+        d_Ft_tb_d_tap_r = dP_dt_fb,
+        d_Ft_tb_d_tap_i = dP_dt_tb,
+        d_Ft_tb_d_alpha_r = dP_dα_fb,
+        d_Ft_tb_d_alpha_i = dP_dα_tb,
     )
 end
 

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -457,11 +457,14 @@ function _lcc_jacobian_scalars(
         common_tap_i = common_tap_i,
         common_alpha_r = common_alpha_r,
         common_alpha_i = common_alpha_i,
-        # Side-specific dP helpers, exposed so polar bus-row × tail-column
-        # entries (and rect tail × bus chain rules) can use the
-        # boundary-guarded values.
+        # Side-specific dP/dx helpers (true-ϕ, with sin(ϕ) → 0 clamp guard
+        # where applicable). Exposed so polar's bus-row entries — and
+        # rect's tail × bus chain rules — can read pre-computed values
+        # instead of re-calling the helpers.
         dP_dV_fb = dP_dV_fb,
         dP_dV_tb = dP_dV_tb,
+        dP_dt_fb = dP_dt_fb,
+        dP_dt_tb = dP_dt_tb,
         dP_dα_fb = dP_dα_fb,
         dP_dα_tb = dP_dα_tb,
         # Tail-row × tail-column block (6 entries). F_t_fb has the

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -30,6 +30,49 @@ function _calculate_y_lcc(t::Float64, I_dc::Float64, Vm::Float64, ϕ::Float64)::
 end
 
 """
+    _calculate_dP_dV_lcc(t, I_dc, x_t, Vm, ϕ) -> Float64
+
+True-ϕ derivative of `P_lcc = Vm · t · √6/π · I_dc · cos(ϕ(Vm, t, α))` with
+respect to `Vm`, including the `∂ϕ/∂Vm` chain term. Unlike the matching
+`_calculate_dQ_dV_lcc`, the `sin(ϕ)` factor introduced by `∂ϕ/∂Vm = -∂raw/∂Vm /
+sin(ϕ)` cancels against the `-sin(ϕ)` from differentiating `cos(ϕ)` — no
+boundary guard needed.
+
+Caller must pass `I_dc` and `ϕ` matching the side of interest: rectifier
+uses `(+I_dc, phi_r)`; inverter uses `(+I_dc, phi_i)` (the same positive
+I_dc, since `P_lcc_to = V_tb · tap_i · √6/π · I_dc · cos(phi_i)` and `phi_i`
+already encodes the sign convention via `_calculate_ϕ_lcc(-I_dc, ...)`).
+"""
+function _calculate_dP_dV_lcc(
+    t::Float64,
+    I_dc::Float64,
+    x_t::Float64,
+    Vm::Float64,
+    ϕ::Float64,
+)::Float64
+    return t * sqrt(6) / π * I_dc * cos(ϕ) +
+           sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * Vm)
+end
+
+"""
+    _calculate_dP_dt_lcc(t, I_dc, x_t, Vm, ϕ) -> Float64
+
+True-ϕ derivative of `P_lcc` with respect to the transformer tap `t`. Same
+cancellation as `_calculate_dP_dV_lcc` — no `1/sin(ϕ)` term, no boundary
+guard required.
+"""
+function _calculate_dP_dt_lcc(
+    t::Float64,
+    I_dc::Float64,
+    x_t::Float64,
+    Vm::Float64,
+    ϕ::Float64,
+)::Float64
+    return Vm * sqrt(6) / π * I_dc * cos(ϕ) +
+           sqrt(6) / π * I_dc^2 * x_t / (sqrt(2) * t)
+end
+
+"""
     _calculate_dQ_dV_lcc(t::Float64, I_dc::Float64, x_t::Float64, Vm::Float64, ϕ::Float64) -> Float64
 
 Compute the derivative of reactive power Q with respect to voltage magnitude Vm for LCC converter calculations.

--- a/src/lcc_utils.jl
+++ b/src/lcc_utils.jl
@@ -45,7 +45,7 @@ function _calculate_dQ_dV_lcc(
     # On the clamp boundary (sin(ϕ) = 0), φ is locally pinned and the residual
     # is constant in this direction, so the true derivative is 0 even though
     # the analytic formula has a 1/sin(ϕ) singularity.
-    sϕ < 1e-8 && return 0.0
+    sϕ < LCC_sinϕ_TOLERANCE && return 0.0
     return t * sqrt(6) / π * I_dc * sϕ -
            sqrt(6) / π * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
            (sqrt(2) * Vm * sϕ)
@@ -64,7 +64,7 @@ function _calculate_dQ_dt_lcc(
     ϕ::Float64,
 )::Float64
     sϕ = sin(ϕ)
-    sϕ < 1e-8 && return 0.0
+    sϕ < LCC_sinϕ_TOLERANCE && return 0.0
     return Vm * sqrt(6) / π * I_dc * sϕ -
            sqrt(6) / π * cos(ϕ) * sign(I_dc) * I_dc^2 * x_t /
            (sqrt(2) * t * sϕ)
@@ -84,7 +84,7 @@ function _calculate_dQ_dα_lcc(
     α::Float64,
 )::Float64
     sϕ = sin(ϕ)
-    sϕ < 1e-8 && return 0.0
+    sϕ < LCC_sinϕ_TOLERANCE && return 0.0
     return Vm * t * sqrt(6) / π * I_dc * cos(ϕ) * sin(α) / sϕ
 end
 

--- a/src/rectangular_ci_power_flow_jacobian.jl
+++ b/src/rectangular_ci_power_flow_jacobian.jl
@@ -669,18 +669,18 @@ with these changes:
     `(col_e_fb, col_f_fb)`. Polar partials `∂(·)/∂Vm_fb` translate via chain rule:
     `∂(·)/∂e = ∂(·)/∂Vm · e/|V|`, similarly for `f`.
   * The bus residual rows for fb are `ΔI_r_fb` and `ΔI_i_fb` (current mismatch),
-    not polar's `ΔP_fb` / `ΔQ_fb`. The LCC contribution to `−Re(Y_lcc·V_fb)` and
-    `−Im(Y_lcc·V_fb)` under the α-approximation (φ ≈ α — same approximation polar
-    uses for ∂P/∂Vm) gives the bus-diagonal additions and tail cross-terms below.
+    not polar's `ΔP_fb` / `ΔQ_fb`. The LCC contribution `−Re(Y_lcc·V) = −A·u(ϕ)`
+    and `−Im(Y_lcc·V) = −A·w(ϕ)` (with the *true* ϕ from
+    [`_calculate_ϕ_lcc`](@ref), not the α-approximation) gives the bus-diagonal
+    additions and tail cross-terms below. The inverter sign convention is
+    absorbed into `cos(ϕ_i)`, `sin(ϕ_i)` — no separate handling needed.
 
-Tail row entries (∂F_t_*, ∂F_α_*) use the same α-approximation as the polar
-formulation, chain-ruled into `(e, f)` columns. The tail × tail block is
-computed once in [`_lcc_jacobian_scalars`](@ref) and consumed by both
-formulations.
-
-Note: unlike polar, this assembly does not yet use the true-φ Q-derivative
-helpers (`_calculate_dQ_dV_lcc` etc.) on the FB/TB-side bus rows — those would
-sharpen the Jacobian for stiff LCC cases and could be ported later.
+Tail row entries (∂F_t_*) use the true-ϕ ∂P/∂V helper from
+[`_lcc_jacobian_scalars`](@ref) chain-ruled into `(e, f)` columns via
+`∂V/∂e = e/V`, `∂V/∂f = f/V`. Every chain term that picks up a
+`1/sin(ϕ)` factor (i.e. `cos(ϕ)·∂ϕ/∂x` chain) goes through
+[`_dphi_dV_lcc`](@ref) / [`_dphi_dt_lcc`](@ref) /
+[`_dphi_dα_lcc`](@ref), which return 0 at the `sin(ϕ) → 0` clamp.
 """
 function _set_entries_for_lcc_rect!(
     data::ACPowerFlowData,
@@ -700,60 +700,97 @@ function _set_entries_for_lcc_rect!(
         f_fb = f_state[fb]
         Vm_fb_sq = e_fb^2 + f_fb^2
         Vm_fb = sqrt(Vm_fb_sq)
+        inv_Vsq_fb = 1.0 / Vm_fb_sq
         e_tb = e_state[tb]
         f_tb = f_state[tb]
         Vm_tb_sq = e_tb^2 + f_tb^2
         Vm_tb = sqrt(Vm_tb_sq)
+        inv_Vsq_tb = 1.0 / Vm_tb_sq
 
         s = _lcc_jacobian_scalars(data, i, time_step, Vm_fb, Vm_tb)
 
-        # FB-side: LCC contribution under α-approximation (φ_r ≈ α_r).
-        # F_lcc_fb_r = -A_fb·u_fb,  F_lcc_fb_i = -A_fb·w_fb
+        # True-ϕ formulation throughout. Both LCC bus residual rows use the
+        # admittance form `F_real = -Re(Y·V) = -A·u(ϕ)`,
+        # `F_imag = -Im(Y·V) = -A·w(ϕ)` with `A = tap·√6/π·I_dc/V` and
+        # universal `u(ϕ) = cos(ϕ)·e + sin(ϕ)·f`, `w(ϕ) = cos(ϕ)·f − sin(ϕ)·e`.
+        # The inverter convention's sign flip (Y picks up an exp(-iπ) ≈ −1
+        # from ϕ_i ≈ π − α_i at x_t = 0) is absorbed into `cos(ϕ_i)`,
+        # `sin(ϕ_i)` — no separate sign handling needed in the Jacobian.
+        phi_r = data.lcc.rectifier.phi[i, time_step]
+        phi_i = data.lcc.inverter.phi[i, time_step]
+        xtr_r = data.lcc.rectifier.transformer_reactance[i]
+        xtr_i = data.lcc.inverter.transformer_reactance[i]
+        alpha_r = data.lcc.rectifier.thyristor_angle[i, time_step]
+        alpha_i = data.lcc.inverter.thyristor_angle[i, time_step]
+        cos_phi_r = cos(phi_r)
+        sin_phi_r = sin(phi_r)
+        cos_phi_i = cos(phi_i)
+        sin_phi_i = sin(phi_i)
+        # ∂ϕ derivatives with sin(ϕ)→0 clamp guard (return 0 at clamp).
+        dphi_dV_fb = _dphi_dV_lcc(xtr_r, s.i_dc, Vm_fb, s.tap_r, phi_r)
+        dphi_dV_tb = _dphi_dV_lcc(xtr_i, s.i_dc, Vm_tb, s.tap_i, phi_i)
+        dphi_dtap_r = _dphi_dt_lcc(xtr_r, s.i_dc, Vm_fb, s.tap_r, phi_r)
+        dphi_dtap_i = _dphi_dt_lcc(xtr_i, s.i_dc, Vm_tb, s.tap_i, phi_i)
+        dphi_dα_r = _dphi_dα_lcc(alpha_r, phi_r)
+        # Inverter ϕ convention flips the sign of ∂ϕ_i/∂α_i.
+        dphi_dα_i = -_dphi_dα_lcc(alpha_i, phi_i)
+
+        # FB-side bus contribution.
         A_fb = s.tap_r * SQRT6_DIV_PI * s.i_dc / Vm_fb
-        u_fb = s.cos_alpha_r * e_fb + s.sin_alpha_r * f_fb
-        w_fb = s.cos_alpha_r * f_fb - s.sin_alpha_r * e_fb
-        # Bus diagonal additions for FB (only PQ/PV — for REF, (e_fb, f_fb)
-        # are fixed constants, not state variables in those columns).
+        u_fb = cos_phi_r * e_fb + sin_phi_r * f_fb
+        w_fb = cos_phi_r * f_fb - sin_phi_r * e_fb
+        # Chain-rule factors: ∂ϕ_r/∂(e,f) = ∂ϕ_r/∂V · ∂V/∂(e,f), with
+        # ∂V/∂e = e/V, ∂V/∂f = f/V.
+        dphi_de_fb = dphi_dV_fb * e_fb / Vm_fb
+        dphi_df_fb = dphi_dV_fb * f_fb / Vm_fb
         if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
-            inv_Vsq_fb = 1.0 / Vm_fb_sq
-            Jvnz[diag_base_nz[1, fb]] += -A_fb * f_fb * w_fb * inv_Vsq_fb
-            Jvnz[diag_base_nz[2, fb]] += A_fb * e_fb * w_fb * inv_Vsq_fb
-            Jvnz[diag_base_nz[3, fb]] += A_fb * f_fb * u_fb * inv_Vsq_fb
-            Jvnz[diag_base_nz[4, fb]] += -A_fb * e_fb * u_fb * inv_Vsq_fb
+            Jvnz[diag_base_nz[1, fb]] +=
+                -A_fb * f_fb * w_fb * inv_Vsq_fb - A_fb * w_fb * dphi_de_fb
+            Jvnz[diag_base_nz[2, fb]] +=
+                A_fb * e_fb * w_fb * inv_Vsq_fb - A_fb * w_fb * dphi_df_fb
+            Jvnz[diag_base_nz[3, fb]] +=
+                A_fb * f_fb * u_fb * inv_Vsq_fb + A_fb * u_fb * dphi_de_fb
+            Jvnz[diag_base_nz[4, fb]] +=
+                -A_fb * e_fb * u_fb * inv_Vsq_fb + A_fb * u_fb * dphi_df_fb
         end
-        # FB-side cross-terms ∂F_lcc_fb / ∂(t_r, α_r) — applicable for all
-        # bus types because the row is ΔI residual at fb (always exists).
-        Jvnz[lcc_nz[1, i]] = -A_fb * u_fb / s.tap_r     # (col_e_fb, idx_tap_r)
-        Jvnz[lcc_nz[2, i]] = -A_fb * w_fb               # (col_e_fb, idx_alpha_r)
-        Jvnz[lcc_nz[3, i]] = -A_fb * w_fb / s.tap_r     # (col_f_fb, idx_tap_r)
-        Jvnz[lcc_nz[4, i]] = A_fb * u_fb                # (col_f_fb, idx_alpha_r)
+        # FB-side cross-terms ∂F_lcc_fb / ∂(t_r, α_r), all bus types.
+        Jvnz[lcc_nz[1, i]] = -A_fb * u_fb / s.tap_r - A_fb * w_fb * dphi_dtap_r
+        Jvnz[lcc_nz[2, i]] = -A_fb * w_fb * dphi_dα_r
+        Jvnz[lcc_nz[3, i]] = -A_fb * w_fb / s.tap_r + A_fb * u_fb * dphi_dtap_r
+        Jvnz[lcc_nz[4, i]] = A_fb * u_fb * dphi_dα_r
 
-        # TB-side: F_lcc_tb_r = +A_tb·u_tb,  F_lcc_tb_i = +A_tb·w_tb
+        # TB-side bus contribution (same universal formulas; uses ϕ_i).
         A_tb = s.tap_i * SQRT6_DIV_PI * s.i_dc / Vm_tb
-        u_tb = s.cos_alpha_i * e_tb - s.sin_alpha_i * f_tb
-        w_tb = s.cos_alpha_i * f_tb + s.sin_alpha_i * e_tb
+        u_tb = cos_phi_i * e_tb + sin_phi_i * f_tb
+        w_tb = cos_phi_i * f_tb - sin_phi_i * e_tb
+        dphi_de_tb = dphi_dV_tb * e_tb / Vm_tb
+        dphi_df_tb = dphi_dV_tb * f_tb / Vm_tb
         if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
-            inv_Vsq_tb = 1.0 / Vm_tb_sq
-            Jvnz[diag_base_nz[1, tb]] += A_tb * f_tb * w_tb * inv_Vsq_tb
-            Jvnz[diag_base_nz[2, tb]] += -A_tb * e_tb * w_tb * inv_Vsq_tb
-            Jvnz[diag_base_nz[3, tb]] += -A_tb * f_tb * u_tb * inv_Vsq_tb
-            Jvnz[diag_base_nz[4, tb]] += A_tb * e_tb * u_tb * inv_Vsq_tb
+            Jvnz[diag_base_nz[1, tb]] +=
+                -A_tb * f_tb * w_tb * inv_Vsq_tb - A_tb * w_tb * dphi_de_tb
+            Jvnz[diag_base_nz[2, tb]] +=
+                A_tb * e_tb * w_tb * inv_Vsq_tb - A_tb * w_tb * dphi_df_tb
+            Jvnz[diag_base_nz[3, tb]] +=
+                A_tb * f_tb * u_tb * inv_Vsq_tb + A_tb * u_tb * dphi_de_tb
+            Jvnz[diag_base_nz[4, tb]] +=
+                -A_tb * e_tb * u_tb * inv_Vsq_tb + A_tb * u_tb * dphi_df_tb
         end
-        Jvnz[lcc_nz[5, i]] = A_tb * u_tb / s.tap_i      # (col_e_tb, idx_tap_i)
-        Jvnz[lcc_nz[6, i]] = -A_tb * w_tb               # (col_e_tb, idx_alpha_i)
-        Jvnz[lcc_nz[7, i]] = A_tb * w_tb / s.tap_i      # (col_f_tb, idx_tap_i)
-        Jvnz[lcc_nz[8, i]] = A_tb * u_tb                # (col_f_tb, idx_alpha_i)
+        Jvnz[lcc_nz[5, i]] = -A_tb * u_tb / s.tap_i - A_tb * w_tb * dphi_dtap_i
+        Jvnz[lcc_nz[6, i]] = -A_tb * w_tb * dphi_dα_i
+        Jvnz[lcc_nz[7, i]] = -A_tb * w_tb / s.tap_i + A_tb * u_tb * dphi_dtap_i
+        Jvnz[lcc_nz[8, i]] = A_tb * u_tb * dphi_dα_i
 
-        # LCC tail row entries (F_t_r, F_t_i) — chain rule ∂/∂Vm into (e, f).
-        # At REF buses (e, f) are not state, so the column slots there hold
-        # (P_gen, Q_gen); write zero in that case.
+        # LCC tail row entries — chain rule ∂F_t/∂V into (e, f). Use the
+        # true-ϕ ∂P/∂V from the scalars helper (already boundary-guarded).
+        # At REF buses (e, f) are not state, so the column slots there
+        # hold (P_gen, Q_gen); write zero in that case.
         if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
             de_dV_fb = e_fb / Vm_fb
             df_dV_fb = f_fb / Vm_fb
-            Jvnz[lcc_nz[9, i]] = s.common_tap_r * de_dV_fb  # (idx_tap_r, col_e_fb)
-            Jvnz[lcc_nz[10, i]] = s.common_tap_r * df_dV_fb  # (idx_tap_r, col_f_fb)
-            Jvnz[lcc_nz[11, i]] = s.common_tap_r * de_dV_fb  # (idx_tap_i, col_e_fb)
-            Jvnz[lcc_nz[12, i]] = s.common_tap_r * df_dV_fb  # (idx_tap_i, col_f_fb)
+            Jvnz[lcc_nz[9, i]] = s.dP_dV_fb * de_dV_fb
+            Jvnz[lcc_nz[10, i]] = s.dP_dV_fb * df_dV_fb
+            Jvnz[lcc_nz[11, i]] = s.dP_dV_fb * de_dV_fb
+            Jvnz[lcc_nz[12, i]] = s.dP_dV_fb * df_dV_fb
         else
             Jvnz[lcc_nz[9, i]] = 0.0
             Jvnz[lcc_nz[10, i]] = 0.0
@@ -763,8 +800,8 @@ function _set_entries_for_lcc_rect!(
         if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
             de_dV_tb = e_tb / Vm_tb
             df_dV_tb = f_tb / Vm_tb
-            Jvnz[lcc_nz[13, i]] = s.common_tap_i * de_dV_tb  # (idx_tap_i, col_e_tb)
-            Jvnz[lcc_nz[14, i]] = s.common_tap_i * df_dV_tb  # (idx_tap_i, col_f_tb)
+            Jvnz[lcc_nz[13, i]] = s.dP_dV_tb * de_dV_tb
+            Jvnz[lcc_nz[14, i]] = s.dP_dV_tb * df_dV_tb
         else
             Jvnz[lcc_nz[13, i]] = 0.0
             Jvnz[lcc_nz[14, i]] = 0.0

--- a/src/rectangular_ci_power_flow_jacobian.jl
+++ b/src/rectangular_ci_power_flow_jacobian.jl
@@ -672,12 +672,15 @@ with these changes:
     not polar's `ΔP_fb` / `ΔQ_fb`. The LCC contribution to `−Re(Y_lcc·V_fb)` and
     `−Im(Y_lcc·V_fb)` under the α-approximation (φ ≈ α — same approximation polar
     uses for ∂P/∂Vm) gives the bus-diagonal additions and tail cross-terms below.
-  * As in polar, the inverter-side bus diagonal block is NOT augmented for LCC
-    (this matches polar's missing `∂P_tb/∂Vm_tb` LCC partial; convergence is
-    polar-like).
 
-LCC tail row entries (∂F_t_*, ∂F_α_*) use the same polar α-approximation as the
-polar code, chain-ruled into `(e, f)` columns.
+Tail row entries (∂F_t_*, ∂F_α_*) use the same α-approximation as the polar
+formulation, chain-ruled into `(e, f)` columns. The tail × tail block is
+computed once in [`_lcc_jacobian_scalars`](@ref) and consumed by both
+formulations.
+
+Note: unlike polar, this assembly does not yet use the true-φ Q-derivative
+helpers (`_calculate_dQ_dV_lcc` etc.) on the FB/TB-side bus rows — those would
+sharpen the Jacobian for stiff LCC cases and could be ported later.
 """
 function _set_entries_for_lcc_rect!(
     data::ACPowerFlowData,
@@ -690,18 +693,8 @@ function _set_entries_for_lcc_rect!(
     time_step::Int,
 )
     @inbounds for (i, (fb, tb)) in enumerate(data.lcc.bus_indices)
-        i_dc = max(data.lcc.i_dc[i, time_step], 1e-9)
-        tap_r = data.lcc.rectifier.tap[i, time_step]
-        tap_i = data.lcc.inverter.tap[i, time_step]
-        alpha_r = data.lcc.rectifier.thyristor_angle[i, time_step]
-        alpha_i = data.lcc.inverter.thyristor_angle[i, time_step]
         bus_type_fb = data.bus_type[fb, time_step]
         bus_type_tb = data.bus_type[tb, time_step]
-
-        cos_alpha_r = cos(alpha_r)
-        sin_alpha_r = sin(alpha_r)
-        cos_alpha_i = cos(alpha_i)
-        sin_alpha_i = sin(alpha_i)
 
         e_fb = e_state[fb]
         f_fb = f_state[fb]
@@ -712,11 +705,13 @@ function _set_entries_for_lcc_rect!(
         Vm_tb_sq = e_tb^2 + f_tb^2
         Vm_tb = sqrt(Vm_tb_sq)
 
+        s = _lcc_jacobian_scalars(data, i, time_step, Vm_fb, Vm_tb)
+
         # FB-side: LCC contribution under α-approximation (φ_r ≈ α_r).
         # F_lcc_fb_r = -A_fb·u_fb,  F_lcc_fb_i = -A_fb·w_fb
-        A_fb = tap_r * SQRT6_DIV_PI * i_dc / Vm_fb
-        u_fb = cos_alpha_r * e_fb + sin_alpha_r * f_fb
-        w_fb = cos_alpha_r * f_fb - sin_alpha_r * e_fb
+        A_fb = s.tap_r * SQRT6_DIV_PI * s.i_dc / Vm_fb
+        u_fb = s.cos_alpha_r * e_fb + s.sin_alpha_r * f_fb
+        w_fb = s.cos_alpha_r * f_fb - s.sin_alpha_r * e_fb
         # Bus diagonal additions for FB (only PQ/PV — for REF, (e_fb, f_fb)
         # are fixed constants, not state variables in those columns).
         if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
@@ -728,15 +723,15 @@ function _set_entries_for_lcc_rect!(
         end
         # FB-side cross-terms ∂F_lcc_fb / ∂(t_r, α_r) — applicable for all
         # bus types because the row is ΔI residual at fb (always exists).
-        Jvnz[lcc_nz[1, i]] = -A_fb * u_fb / tap_r       # (col_e_fb, idx_tap_r)
+        Jvnz[lcc_nz[1, i]] = -A_fb * u_fb / s.tap_r     # (col_e_fb, idx_tap_r)
         Jvnz[lcc_nz[2, i]] = -A_fb * w_fb               # (col_e_fb, idx_alpha_r)
-        Jvnz[lcc_nz[3, i]] = -A_fb * w_fb / tap_r       # (col_f_fb, idx_tap_r)
+        Jvnz[lcc_nz[3, i]] = -A_fb * w_fb / s.tap_r     # (col_f_fb, idx_tap_r)
         Jvnz[lcc_nz[4, i]] = A_fb * u_fb                # (col_f_fb, idx_alpha_r)
 
         # TB-side: F_lcc_tb_r = +A_tb·u_tb,  F_lcc_tb_i = +A_tb·w_tb
-        A_tb = tap_i * SQRT6_DIV_PI * i_dc / Vm_tb
-        u_tb = cos_alpha_i * e_tb - sin_alpha_i * f_tb
-        w_tb = cos_alpha_i * f_tb + sin_alpha_i * e_tb
+        A_tb = s.tap_i * SQRT6_DIV_PI * s.i_dc / Vm_tb
+        u_tb = s.cos_alpha_i * e_tb - s.sin_alpha_i * f_tb
+        w_tb = s.cos_alpha_i * f_tb + s.sin_alpha_i * e_tb
         if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
             inv_Vsq_tb = 1.0 / Vm_tb_sq
             Jvnz[diag_base_nz[1, tb]] += A_tb * f_tb * w_tb * inv_Vsq_tb
@@ -744,27 +739,21 @@ function _set_entries_for_lcc_rect!(
             Jvnz[diag_base_nz[3, tb]] += -A_tb * f_tb * u_tb * inv_Vsq_tb
             Jvnz[diag_base_nz[4, tb]] += A_tb * e_tb * u_tb * inv_Vsq_tb
         end
-        Jvnz[lcc_nz[5, i]] = A_tb * u_tb / tap_i        # (col_e_tb, idx_tap_i)
+        Jvnz[lcc_nz[5, i]] = A_tb * u_tb / s.tap_i      # (col_e_tb, idx_tap_i)
         Jvnz[lcc_nz[6, i]] = -A_tb * w_tb               # (col_e_tb, idx_alpha_i)
-        Jvnz[lcc_nz[7, i]] = A_tb * w_tb / tap_i        # (col_f_tb, idx_tap_i)
+        Jvnz[lcc_nz[7, i]] = A_tb * w_tb / s.tap_i      # (col_f_tb, idx_tap_i)
         Jvnz[lcc_nz[8, i]] = A_tb * u_tb                # (col_f_tb, idx_alpha_i)
 
-        # LCC tail row entries (F_t_r, F_t_i) — mirror polar α-approx then chain-rule.
-        common_term_tap_r = tap_r * SQRT6_DIV_PI * i_dc * cos_alpha_r
-        common_term_fb_polar = Vm_fb * SQRT6_DIV_PI * i_dc
-        common_term_alpha_r = -common_term_fb_polar * tap_r * sin_alpha_r
-        common_term_tb_polar = Vm_tb * SQRT6_DIV_PI * (-i_dc)
-        common_term_tap_i = tap_i * SQRT6_DIV_PI * (-i_dc) * cos_alpha_i
-
-        # ∂F_t_*/∂(e, f) chain rule from ∂/∂Vm. At REF buses (e, f) are not
-        # state, so the column slots there hold (P_gen, Q_gen) — write zero.
+        # LCC tail row entries (F_t_r, F_t_i) — chain rule ∂/∂Vm into (e, f).
+        # At REF buses (e, f) are not state, so the column slots there hold
+        # (P_gen, Q_gen); write zero in that case.
         if bus_type_fb == PSY.ACBusTypes.PQ || bus_type_fb == PSY.ACBusTypes.PV
             de_dV_fb = e_fb / Vm_fb
             df_dV_fb = f_fb / Vm_fb
-            Jvnz[lcc_nz[9, i]] = common_term_tap_r * de_dV_fb  # (idx_tap_r, col_e_fb)
-            Jvnz[lcc_nz[10, i]] = common_term_tap_r * df_dV_fb  # (idx_tap_r, col_f_fb)
-            Jvnz[lcc_nz[11, i]] = common_term_tap_r * de_dV_fb  # (idx_tap_i, col_e_fb)
-            Jvnz[lcc_nz[12, i]] = common_term_tap_r * df_dV_fb  # (idx_tap_i, col_f_fb)
+            Jvnz[lcc_nz[9, i]] = s.common_tap_r * de_dV_fb  # (idx_tap_r, col_e_fb)
+            Jvnz[lcc_nz[10, i]] = s.common_tap_r * df_dV_fb  # (idx_tap_r, col_f_fb)
+            Jvnz[lcc_nz[11, i]] = s.common_tap_r * de_dV_fb  # (idx_tap_i, col_e_fb)
+            Jvnz[lcc_nz[12, i]] = s.common_tap_r * df_dV_fb  # (idx_tap_i, col_f_fb)
         else
             Jvnz[lcc_nz[9, i]] = 0.0
             Jvnz[lcc_nz[10, i]] = 0.0
@@ -774,19 +763,20 @@ function _set_entries_for_lcc_rect!(
         if bus_type_tb == PSY.ACBusTypes.PQ || bus_type_tb == PSY.ACBusTypes.PV
             de_dV_tb = e_tb / Vm_tb
             df_dV_tb = f_tb / Vm_tb
-            Jvnz[lcc_nz[13, i]] = common_term_tap_i * de_dV_tb  # (idx_tap_i, col_e_tb)
-            Jvnz[lcc_nz[14, i]] = common_term_tap_i * df_dV_tb  # (idx_tap_i, col_f_tb)
+            Jvnz[lcc_nz[13, i]] = s.common_tap_i * de_dV_tb  # (idx_tap_i, col_e_tb)
+            Jvnz[lcc_nz[14, i]] = s.common_tap_i * df_dV_tb  # (idx_tap_i, col_f_tb)
         else
             Jvnz[lcc_nz[13, i]] = 0.0
             Jvnz[lcc_nz[14, i]] = 0.0
         end
 
-        Jvnz[lcc_nz[15, i]] = common_term_fb_polar * cos_alpha_r        # (idx_tap_r, idx_tap_r)
-        Jvnz[lcc_nz[16, i]] = common_term_alpha_r                       # (idx_tap_r, idx_alpha_r)
-        Jvnz[lcc_nz[17, i]] = common_term_fb_polar * cos_alpha_r        # (idx_tap_i, idx_tap_r)
-        Jvnz[lcc_nz[18, i]] = common_term_tb_polar * cos_alpha_i        # (idx_tap_i, idx_tap_i)
-        Jvnz[lcc_nz[19, i]] = common_term_alpha_r                       # (idx_tap_i, idx_alpha_r)
-        Jvnz[lcc_nz[20, i]] = -common_term_tb_polar * tap_i * sin_alpha_i # (idx_tap_i, idx_alpha_i)
+        # Tail × tail block (shared with polar via _lcc_jacobian_scalars).
+        Jvnz[lcc_nz[15, i]] = s.d_Ft_fb_d_tap_r
+        Jvnz[lcc_nz[16, i]] = s.d_Ft_fb_d_alpha_r
+        Jvnz[lcc_nz[17, i]] = s.d_Ft_tb_d_tap_r
+        Jvnz[lcc_nz[18, i]] = s.d_Ft_tb_d_tap_i
+        Jvnz[lcc_nz[19, i]] = s.d_Ft_tb_d_alpha_r
+        Jvnz[lcc_nz[20, i]] = s.d_Ft_tb_d_alpha_i
         # idx_alpha_r and idx_alpha_i identity diagonals stay at 1.0 (set at pattern build).
     end
     return

--- a/src/rectangular_ci_power_flow_residual.jl
+++ b/src/rectangular_ci_power_flow_residual.jl
@@ -296,35 +296,12 @@ function _update_rect_ci_residual_values!(
         end
     end
 
-    # 6) LCC tail residuals (same formulas as polar code, but using |V_state|).
+    # 6) LCC tail residuals — shared helper, with |V_state| instead of polar's
+    #    bus_magnitude (V_set at PV).
     if n_lccs > 0
-        for i in 1:n_lccs
-            offset_lcc = total_bus_state + (i - 1) * 4
-            (fb, tb) = data.lcc.bus_indices[i]
-            tap_r = data.lcc.rectifier.tap[i, time_step]
-            tap_i = data.lcc.inverter.tap[i, time_step]
-            phi_r = data.lcc.rectifier.phi[i, time_step]
-            phi_i = data.lcc.inverter.phi[i, time_step]
-            i_dc = data.lcc.i_dc[i, time_step]
-            Vm_fb_state = sqrt(e_state[fb]^2 + f_state[fb]^2)
-            Vm_tb_state = sqrt(e_state[tb]^2 + f_state[tb]^2)
-            P_lcc_from = Vm_fb_state * tap_r * SQRT6_DIV_PI * i_dc * cos(phi_r)
-            P_lcc_to = Vm_tb_state * tap_i * SQRT6_DIV_PI * i_dc * cos(phi_i)
-            F[offset_lcc + 1] = if data.lcc.setpoint_at_rectifier[i]
-                P_lcc_from - data.lcc.p_set[i, time_step]
-            else
-                -P_lcc_to - data.lcc.p_set[i, time_step]
-            end
-            F[offset_lcc + 2] =
-                P_lcc_from + P_lcc_to -
-                data.lcc.dc_line_resistance[i] * i_dc^2
-            F[offset_lcc + 3] =
-                data.lcc.rectifier.thyristor_angle[i, time_step] -
-                data.lcc.rectifier.min_thyristor_angle[i]
-            F[offset_lcc + 4] =
-                data.lcc.inverter.thyristor_angle[i, time_step] -
-                data.lcc.inverter.min_thyristor_angle[i]
-        end
+        _set_lcc_tail_residuals!(
+            F, data, total_bus_state, time_step, e_state, f_state,
+        )
     end
     return
 end

--- a/test/PowerFlowsTests.jl
+++ b/test/PowerFlowsTests.jl
@@ -55,6 +55,7 @@ include("test_utils/psse_results_compare.jl")
 include("test_utils/penalty_factors_brute_force.jl")
 include("test_utils/legacy_pf.jl")
 include("test_utils/validate_reduced_power_flow.jl")
+include("test_utils/jacobian_verification.jl")
 
 const AC_SOLVERS_TO_TEST = (
     LUACPowerFlow,

--- a/test/test_jacobian.jl
+++ b/test/test_jacobian.jl
@@ -22,13 +22,13 @@ function verify_jacobian(
         Δx_mag = Δx_start
         close_enough = false
         while !close_enough && Δx_mag >= Δx_stop
-            inputValues = [x0, x0 + Δx_mag * u]
+            inputValues = [x0 - Δx_mag * u, x0 + Δx_mag * u]
             outputValues = Vector{Vector{Float64}}()
             for inputVal in inputValues
                 residual(inputVal, time_step)
                 push!(outputValues, deepcopy(residual.Rv))
             end
-            ΔF = outputValues[2] .- outputValues[1]
+            ΔF = (outputValues[2] .- outputValues[1]) ./ 2
             floating_point_issues = all(isapprox.(ΔF, 0.0; atol = eps(Float32)))
             if floating_point_issues
                 break
@@ -51,9 +51,6 @@ end
     verify_jacobian(sys)
 end
 
-# This fails. Might be a problem, or might just be because (according to Roman) we treat
-# the angle \phi as constant, to avoid super messy expressions in the Jacobian, 
-# and update it separately between iterations.
 @testset "Jacobian verification with LCC" begin
     sys = System(100.0)
     b1 = _add_simple_bus!(sys, 1, ACBusTypes.REF, 230, 1.1, 0.0)
@@ -65,7 +62,11 @@ end
     l13 = _add_simple_line!(sys, b1, b3, 5e-3, 5e-3, 1e-3)
     s1 = _add_simple_source!(sys, b1, 0.0, 0.0)
     lcc = _add_simple_lcc!(sys, b2, b3, 0.05, 0.05, 0.08)
-    # verify_jacobian(sys)
+    # Both thyristor angles must be strictly positive at x0; otherwise the
+    # arccos in _calculate_ϕ_lcc hits the clamp boundary and sin(ϕ) = 0,
+    # making the analytic Q-derivatives singular at the verification point.
+    PSY.set_inverter_extinction_angle!(lcc, 1.0)
+    verify_jacobian(sys)
 end
 
 @testset "Jacobian verification with ZIP load" begin

--- a/test/test_jacobian.jl
+++ b/test/test_jacobian.jl
@@ -3,52 +3,33 @@ function verify_jacobian(
     pf::PF.ACPowerFlow = PF.ACPowerFlow{NewtonRaphsonACPowerFlow}(;
         correct_bustypes = true,
     ),
+    label::String = "",
+    perturbation::Float64 = 0.02,
+    seed::Int = 42,
 )
     data = PF.PowerFlowData(pf, sys)
     time_step = 1
     residual = PF.ACPowerFlowResidual(data, time_step)
     J = PF.ACPowerFlowJacobian(residual, time_step)
-    n_lccs =
-        length(collect(PSY.get_components(PSY.get_available, PSY.TwoTerminalLCCLine, sys)))
-    n = 2 * length(collect(get_components(ACBus, sys))) + 4 * n_lccs
     x0 = PF.calculate_x0(data, time_step)
+    # Verify away from the flat-start state. At flat start θ=0 for every bus,
+    # which silently zeroes all `sin(Δθ)` cross-terms — a sign flip in the
+    # symbolic Jacobian for those entries would not be detected. A small
+    # deterministic perturbation breaks the symmetry.
+    if perturbation > 0
+        Random.seed!(seed)
+        x0 .+= perturbation .* randn(length(x0))
+    end
     residual(x0, time_step)
     J(time_step)
-    J_x0 = deepcopy(J.Jv)
-    Δx_start, Δx_stop = 1e-3, 1e-6
-    for j in 1:n
-        u = zeros(n)
-        u[j] = 1
-        Δx_mag = Δx_start
-        close_enough = false
-        while !close_enough && Δx_mag >= Δx_stop
-            inputValues = [x0 - Δx_mag * u, x0 + Δx_mag * u]
-            outputValues = Vector{Vector{Float64}}()
-            for inputVal in inputValues
-                residual(inputVal, time_step)
-                push!(outputValues, deepcopy(residual.Rv))
-            end
-            ΔF = (outputValues[2] .- outputValues[1]) ./ 2
-            floating_point_issues = all(isapprox.(ΔF, 0.0; atol = eps(Float32)))
-            if floating_point_issues
-                break
-            end
-            ∂F_∂u_numerical = ΔF ./ Δx_mag
-            ∂F_∂u_symbolic = J_x0 * u
-
-            if !isapprox(∂F_∂u_numerical, ∂F_∂u_symbolic; rtol = 1e-6, atol = eps(Float32))
-                Δx_mag /= 10.0
-            else
-                close_enough = true
-            end
-        end
-        @test close_enough
-    end
+    verify_jacobian_asymptotic(
+        residual, deepcopy(J.Jv), x0, time_step; label = label,
+    )
 end
 
 @testset "Jacobian verification" begin
     sys = PSB.build_system(PSITestSystems, "c_sys14")
-    verify_jacobian(sys)
+    verify_jacobian(sys; label = "polar c_sys14")
 end
 
 @testset "Jacobian verification with LCC" begin
@@ -68,7 +49,9 @@ end
     # _add_simple_lcc! already sets rectifier_delay_angle = 0.01 > 0; the
     # default inverter_extinction_angle is 0.0, so bump it here.
     PSY.set_inverter_extinction_angle!(lcc, 1.0)
-    verify_jacobian(sys)
+    # Smaller perturbation here so the LCC α tail entries (α_r ≈ 0.087,
+    # α_i = 1.0) stay clear of the min-thyristor-angle clamp.
+    verify_jacobian(sys; label = "polar 3-bus LCC", perturbation = 0.01)
 end
 
 @testset "Jacobian verification with ZIP load" begin
@@ -86,7 +69,7 @@ end
         constant_impedance_active_power = 1.5,
         constant_impedance_reactive_power = 0.8,
     )
-    verify_jacobian(sys)
+    verify_jacobian(sys; label = "polar ZIP")
 end
 
 @testset "Jacobian verification with distributed slack" begin
@@ -103,5 +86,5 @@ end
         correct_bustypes = true,
         generator_slack_participation_factors = gspf,
     )
-    verify_jacobian(sys; pf = pf)
+    verify_jacobian(sys; pf = pf, label = "polar c_sys14 distributed-slack")
 end

--- a/test/test_jacobian.jl
+++ b/test/test_jacobian.jl
@@ -54,6 +54,31 @@ end
     verify_jacobian(sys; label = "polar 3-bus LCC", perturbation = 0.01)
 end
 
+@testset "Jacobian verification with LCC at inverter ϕ clamp" begin
+    # Drive the inverter into the `raw < -1` clamp of `_calculate_ϕ_lcc`:
+    # need cos(α_i) + x_t·I_dc/(√2·V·tap) > 1. Large inverter x_t plus a
+    # small extinction angle does it. This exercises the `sin(ϕ) → 0`
+    # boundary guards in the dP/dV, dP/dt helpers — without those guards
+    # the analytic Jacobian disagrees with the residual at the inverter,
+    # and the asymptotic verifier would catch it as order-1 decay.
+    sys = System(100.0)
+    b1 = _add_simple_bus!(sys, 1, ACBusTypes.REF, 230, 1.1, 0.0)
+    b2 = _add_simple_bus!(sys, 2, ACBusTypes.PQ, 230, 1.1, 0.0)
+    b3 = _add_simple_bus!(sys, 3, ACBusTypes.PQ, 230, 1.1, 0.0)
+    _add_simple_load!(sys, b2, 10, 5)
+    _add_simple_load!(sys, b3, 60, 20)
+    _add_simple_line!(sys, b1, b2, 5e-3, 5e-3, 1e-3)
+    _add_simple_line!(sys, b1, b3, 5e-3, 5e-3, 1e-3)
+    _add_simple_source!(sys, b1, 0.0, 0.0)
+    # xc_i = 0.20 (large), α_i = 0.1 rad (small) → inverter raw < -1, ϕ = π.
+    lcc = _add_simple_lcc!(sys, b2, b3, 0.05, 0.05, 0.20)
+    PSY.set_inverter_extinction_angle!(lcc, 0.1)
+    PSY.set_rectifier_delay_angle!(lcc, 0.1)
+    verify_jacobian(
+        sys; label = "polar 3-bus LCC, inverter ϕ-clamp", perturbation = 0.01,
+    )
+end
+
 @testset "Jacobian verification with ZIP load" begin
     sys = System(100.0)
     b1 = _add_simple_bus!(sys, 1, ACBusTypes.REF, 230, 1.0, 0.0)

--- a/test/test_jacobian.jl
+++ b/test/test_jacobian.jl
@@ -65,6 +65,8 @@ end
     # Both thyristor angles must be strictly positive at x0; otherwise the
     # arccos in _calculate_ϕ_lcc hits the clamp boundary and sin(ϕ) = 0,
     # making the analytic Q-derivatives singular at the verification point.
+    # _add_simple_lcc! already sets rectifier_delay_angle = 0.01 > 0; the
+    # default inverter_extinction_angle is 0.0, so bump it here.
     PSY.set_inverter_extinction_angle!(lcc, 1.0)
     verify_jacobian(sys)
 end

--- a/test/test_jacobian.jl
+++ b/test/test_jacobian.jl
@@ -43,15 +43,37 @@ end
     l13 = _add_simple_line!(sys, b1, b3, 5e-3, 5e-3, 1e-3)
     s1 = _add_simple_source!(sys, b1, 0.0, 0.0)
     lcc = _add_simple_lcc!(sys, b2, b3, 0.05, 0.05, 0.08)
-    # Both thyristor angles must be strictly positive at x0; otherwise the
-    # arccos in _calculate_ϕ_lcc hits the clamp boundary and sin(ϕ) = 0,
-    # making the analytic Q-derivatives singular at the verification point.
-    # _add_simple_lcc! already sets rectifier_delay_angle = 0.01 > 0; the
-    # default inverter_extinction_angle is 0.0, so bump it here.
+    # `_add_simple_lcc!` already sets rectifier_delay_angle = 0.01 > 0; the
+    # default inverter_extinction_angle is 0.0 which makes ϕ_i hit the
+    # acos clamp boundary (sin(ϕ_i) = 0) at x0 — that's a separate boundary
+    # test (see "Jacobian verification with LCC at inverter ϕ clamp"
+    # below). Bump α_i here to verify the interior regime.
     PSY.set_inverter_extinction_angle!(lcc, 1.0)
     # Smaller perturbation here so the LCC α tail entries (α_r ≈ 0.087,
     # α_i = 1.0) stay clear of the min-thyristor-angle clamp.
     verify_jacobian(sys; label = "polar 3-bus LCC", perturbation = 0.01)
+end
+
+@testset "Jacobian verification with LCC at a PV terminal" begin
+    # An LCC terminal at a PV bus: state is (Q_gen, θ), with V fixed at V_set.
+    # The bus Q-balance still depends on tap_r/α_r through the LCC's Q
+    # contribution, so ∂Q/∂tap and ∂Q/∂α must be filled in the Jacobian
+    # for the PV terminal — they previously weren't, leaving these entries
+    # stuck at 0 from the sparsity pattern.
+    sys = System(100.0)
+    b1 = _add_simple_bus!(sys, 1, ACBusTypes.REF, 230, 1.1, 0.0)
+    b2 = _add_simple_bus!(sys, 2, ACBusTypes.PV, 230, 1.05, 0.0)   # PV terminal
+    b3 = _add_simple_bus!(sys, 3, ACBusTypes.PQ, 230, 1.1, 0.0)
+    _add_simple_thermal_standard!(sys, b2, 0.2, 0.1)  # generator at PV bus
+    _add_simple_load!(sys, b2, 10, 5)
+    _add_simple_load!(sys, b3, 60, 20)
+    _add_simple_line!(sys, b1, b2, 5e-3, 5e-3, 1e-3)
+    _add_simple_line!(sys, b1, b3, 5e-3, 5e-3, 1e-3)
+    _add_simple_source!(sys, b1, 0.0, 0.0)
+    lcc = _add_simple_lcc!(sys, b2, b3, 0.05, 0.05, 0.08)
+    PSY.set_inverter_extinction_angle!(lcc, 1.0)
+    verify_jacobian(sys; label = "polar 3-bus LCC, PV rectifier terminal",
+        perturbation = 0.01)
 end
 
 @testset "Jacobian verification with LCC at inverter ϕ clamp" begin

--- a/test/test_rectangular_ci_jacobian.jl
+++ b/test/test_rectangular_ci_jacobian.jl
@@ -1,24 +1,5 @@
-function _fd_jacobian(R::PF.ACRectangularCIResidual, x::Vector{Float64}, time_step::Int)
-    ε = 1e-6
-    n = length(R.Rv)
-    Jfd = zeros(n, n)
-    for k in 1:n
-        xp = copy(x)
-        xp[k] += ε
-        R(xp, time_step)
-        Fp = copy(R.Rv)
-        xm = copy(x)
-        xm[k] -= ε
-        R(xm, time_step)
-        Fm = copy(R.Rv)
-        Jfd[:, k] = (Fp - Fm) / (2ε)
-    end
-    R(x, time_step)
-    return Jfd
-end
-
-@testset "Rectangular CI Jacobian: FD parity" begin
-    @testset "c_sys5 at polar-converged state" begin
+@testset "Rectangular CI Jacobian: asymptotic verification" begin
+    @testset "c_sys5 at polar-converged + perturbation" begin
         sys = PSB.build_system(PSB.PSITestSystems, "c_sys5")
         pf_polar = ACPowerFlow{NewtonRaphsonACPowerFlow}()
         PF.solve_and_store_power_flow!(pf_polar, sys)
@@ -28,14 +9,16 @@ end
         J = PF.ACRectangularCIJacobian(R, 1)
         x = Vector{Float64}(undef, length(R.Rv))
         PF.rect_initial_state!(x, data, R.bus_state_offset, R.bus_block_size, 1)
+        # Avoid verifying at the special converged state — see note in
+        # verify_jacobian (test_jacobian.jl) about hidden zeros.
+        Random.seed!(42)
+        x .+= 0.02 .* randn(length(x))
         R(x, 1)
         J(1)
-        Jfd = _fd_jacobian(R, x, 1)
-        J(1)
-        @test maximum(abs.(Array(J.Jv) - Jfd)) < 1e-4
+        verify_jacobian_asymptotic(R, copy(J.Jv), x, 1; label = "rect CI c_sys5")
     end
 
-    @testset "c_sys14 at polar-converged state" begin
+    @testset "c_sys14 at polar-converged + perturbation" begin
         sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
         pf_polar = ACPowerFlow{NewtonRaphsonACPowerFlow}()
         PF.solve_and_store_power_flow!(pf_polar, sys)
@@ -45,11 +28,11 @@ end
         J = PF.ACRectangularCIJacobian(R, 1)
         x = Vector{Float64}(undef, length(R.Rv))
         PF.rect_initial_state!(x, data, R.bus_state_offset, R.bus_block_size, 1)
+        Random.seed!(42)
+        x .+= 0.02 .* randn(length(x))
         R(x, 1)
         J(1)
-        Jfd = _fd_jacobian(R, x, 1)
-        J(1)
-        @test maximum(abs.(Array(J.Jv) - Jfd)) < 1e-4
+        verify_jacobian_asymptotic(R, copy(J.Jv), x, 1; label = "rect CI c_sys14")
     end
 
     @testset "ZIP constant-current load at perturbed state" begin
@@ -80,9 +63,7 @@ end
         x .+= 0.02 .* randn(length(x))
         R(x, 1)
         J(1)
-        Jfd = _fd_jacobian(R, x, 1)
-        J(1)
-        @test maximum(abs.(Array(J.Jv) - Jfd)) < 1e-3
+        verify_jacobian_asymptotic(R, copy(J.Jv), x, 1; label = "rect CI ZIP perturbed")
     end
 
     @testset "c_sys5 at perturbed (non-converged) state" begin
@@ -99,9 +80,7 @@ end
         x .+= 0.05 .* randn(length(x))
         R(x, 1)
         J(1)
-        Jfd = _fd_jacobian(R, x, 1)
-        J(1)
-        @test maximum(abs.(Array(J.Jv) - Jfd)) < 1e-3
+        verify_jacobian_asymptotic(R, copy(J.Jv), x, 1; label = "rect CI c_sys5 perturbed")
     end
 end
 

--- a/test/test_rectangular_ci_lcc.jl
+++ b/test/test_rectangular_ci_lcc.jl
@@ -17,7 +17,7 @@ end
     @test LinearAlgebra.norm(R.Rv, Inf) < 1e-7
 end
 
-@testset "Rectangular CI LCC: FD parity on case5_2_lcc" begin
+@testset "Rectangular CI LCC: asymptotic Jacobian verification on case5_2_lcc" begin
     raw_path = joinpath(TEST_DATA_DIR, "case5_2_lcc.raw")
     sys = System(raw_path)
     pf_p = ACPowerFlow{NewtonRaphsonACPowerFlow}()
@@ -29,24 +29,16 @@ end
     J = PF.ACRectangularCIJacobian(R, 1)
     x = Vector{Float64}(undef, length(R.Rv))
     PF.rect_initial_state!(x, data, R.bus_state_offset, R.bus_block_size, 1)
+    # Verify away from the converged state. NB: case5_2_lcc has x_t = 0 for
+    # both converter sides, which forces ϕ ≡ ±α — so the α-approximation in
+    # rect's Jacobian coincides with the true-ϕ residual math regardless of
+    # perturbation. A future test on an LCC system with x_t > 0 would
+    # exercise the α-vs-true-ϕ divergence properly.
+    Random.seed!(42)
+    x .+= 0.02 .* randn(length(x))
     R(x, 1)
     J(1)
-    ε = 1e-6
-    n = length(R.Rv)
-    Jfd = zeros(n, n)
-    for k in 1:n
-        xp = copy(x)
-        xp[k] += ε
-        R(xp, 1)
-        Jfd[:, k] = copy(R.Rv) / (2ε)
-        xm = copy(x)
-        xm[k] -= ε
-        R(xm, 1)
-        Jfd[:, k] -= copy(R.Rv) / (2ε)
-    end
-    R(x, 1)
-    J(1)
-    @test maximum(abs.(Array(J.Jv) - Jfd)) < 1e-4
+    verify_jacobian_asymptotic(R, copy(J.Jv), x, 1; label = "rect CI LCC case5_2")
 end
 
 @testset "Rectangular CI LCC: solve parity with polar" begin

--- a/test/test_rectangular_ci_lcc.jl
+++ b/test/test_rectangular_ci_lcc.jl
@@ -17,6 +17,61 @@ end
     @test LinearAlgebra.norm(R.Rv, Inf) < 1e-7
 end
 
+function _rect_lcc_verify(sys::System; label::String, perturbation::Float64 = 0.02)
+    pf_r = ACPowerFlow{RectangularCurrentInjectionACPowerFlow}(;
+        correct_bustypes = true, solver_settings = _rect_lcc_settings())
+    data = PF.PowerFlowData(pf_r, sys)
+    R = PF.ACRectangularCIResidual(data, 1)
+    J = PF.ACRectangularCIJacobian(R, 1)
+    x = Vector{Float64}(undef, length(R.Rv))
+    PF.rect_initial_state!(x, data, R.bus_state_offset, R.bus_block_size, 1)
+    if perturbation > 0
+        Random.seed!(42)
+        x .+= perturbation .* randn(length(x))
+    end
+    R(x, 1)
+    J(1)
+    verify_jacobian_asymptotic(R, copy(J.Jv), x, 1; label = label)
+end
+
+@testset "Rectangular CI LCC: asymptotic verification, nonzero xc (interior)" begin
+    # Simple 3-bus LCC system with x_t > 0 and ϕ_i kept off the clamp by a
+    # moderate extinction angle. This is the regime where rect's old
+    # α-approximation Jacobian disagreed with the true-ϕ residual.
+    sys = System(100.0)
+    b1 = _add_simple_bus!(sys, 1, ACBusTypes.REF, 230, 1.1, 0.0)
+    b2 = _add_simple_bus!(sys, 2, ACBusTypes.PQ, 230, 1.1, 0.0)
+    b3 = _add_simple_bus!(sys, 3, ACBusTypes.PQ, 230, 1.1, 0.0)
+    _add_simple_load!(sys, b2, 10, 5)
+    _add_simple_load!(sys, b3, 60, 20)
+    _add_simple_line!(sys, b1, b2, 5e-3, 5e-3, 1e-3)
+    _add_simple_line!(sys, b1, b3, 5e-3, 5e-3, 1e-3)
+    _add_simple_source!(sys, b1, 0.0, 0.0)
+    lcc = _add_simple_lcc!(sys, b2, b3, 0.05, 0.05, 0.08)
+    PSY.set_inverter_extinction_angle!(lcc, 1.0)   # well clear of ϕ-clamp
+    _rect_lcc_verify(sys; label = "rect CI LCC nonzero-xc interior")
+end
+
+@testset "Rectangular CI LCC: asymptotic verification at inverter ϕ clamp" begin
+    # Same fixture as the polar inverter-ϕ-clamp test: large x_t_i + small
+    # extinction angle pushes raw_i < -1 and clamps ϕ_i at π. Exercises the
+    # sin(ϕ) → 0 boundary guards in the ∂ϕ helpers.
+    sys = System(100.0)
+    b1 = _add_simple_bus!(sys, 1, ACBusTypes.REF, 230, 1.1, 0.0)
+    b2 = _add_simple_bus!(sys, 2, ACBusTypes.PQ, 230, 1.1, 0.0)
+    b3 = _add_simple_bus!(sys, 3, ACBusTypes.PQ, 230, 1.1, 0.0)
+    _add_simple_load!(sys, b2, 10, 5)
+    _add_simple_load!(sys, b3, 60, 20)
+    _add_simple_line!(sys, b1, b2, 5e-3, 5e-3, 1e-3)
+    _add_simple_line!(sys, b1, b3, 5e-3, 5e-3, 1e-3)
+    _add_simple_source!(sys, b1, 0.0, 0.0)
+    lcc = _add_simple_lcc!(sys, b2, b3, 0.05, 0.05, 0.20)
+    PSY.set_inverter_extinction_angle!(lcc, 0.1)
+    PSY.set_rectifier_delay_angle!(lcc, 0.1)
+    _rect_lcc_verify(sys; label = "rect CI LCC inverter ϕ-clamp",
+        perturbation = 0.01)
+end
+
 @testset "Rectangular CI LCC: asymptotic Jacobian verification on case5_2_lcc" begin
     raw_path = joinpath(TEST_DATA_DIR, "case5_2_lcc.raw")
     sys = System(raw_path)

--- a/test/test_utils/jacobian_verification.jl
+++ b/test/test_utils/jacobian_verification.jl
@@ -1,0 +1,119 @@
+"""
+    verify_jacobian_asymptotic(residual, Jv, x0, time_step; Δx_mags, rtol, label)
+
+Verify the analytic Jacobian `Jv` against `residual` by checking that the
+first-order Taylor remainder
+
+    e(Δx) = ||F(x0 + Δx·u_j) - F(x0) - Δx · J·u_j||
+
+scales as O(Δx²) along each canonical direction `u_j = e_j` as `Δx → 0`.
+For a correct Jacobian, `e(Δx) / Δx²` is constant across a geometric
+`Δx`-sweep (the second-derivative contribution along `u_j`); this routine
+asserts those normalized ratios agree within `rtol`.
+
+Directions where the residual is locally linear in `x_j` within FP noise
+are skipped (cannot distinguish a correct from an incorrect entry there).
+
+`residual` must be callable as `residual(x, time_step)` and expose the
+current residual vector as `residual.Rv`. Both `ACPowerFlowResidual` and
+`ACRectangularCIResidual` satisfy this. `Jv` can be any object that
+supports `Jv * u` for `u::Vector{Float64}` (sparse or dense matrix).
+
+Methodology mirrors `test_homotopy_hessian.jl`'s asymptotic checks for the
+Hessian/gradient.
+"""
+function verify_jacobian_asymptotic(
+    residual,
+    Jv,
+    x0::Vector{Float64},
+    time_step::Int;
+    Δx_mags::Vector{Float64} = [1e-3, 1e-4, 1e-5, 1e-6],
+    rtol::Float64 = 0.3,
+    label::String = "",
+)
+    n = length(x0)
+    residual(x0, time_step)
+    F0 = copy(residual.Rv)
+    F0_scale = max(LinearAlgebra.norm(F0), 1.0)
+    # Raw-remainder noise floor — below this, the remainder is dominated by
+    # floating-point roundoff from cancellation in `F(x+Δx) - F(x) - Δx·J·u`
+    # and the asymptotic ratio test is meaningless. The factor 1e4 accounts
+    # for typical accumulated relative roundoff in residuals built from many
+    # trig / sqrt / division operations (e.g. LCC residual).
+    raw_noise_floor = 1e4 * eps(Float64) * F0_scale
+
+    for j in 1:n
+        u = zeros(n)
+        u[j] = 1.0
+        Ju = Jv * u
+        # errors[k] = ||remainder(Δx_k)|| / Δx_k (matches test_homotopy_hessian
+        # convention; a correct Jacobian makes this O(Δx_k))
+        errors = Vector{Float64}(undef, length(Δx_mags))
+        for (k, Δx) in enumerate(Δx_mags)
+            x1 = x0 .+ Δx .* u
+            residual(x1, time_step)
+            errors[k] =
+                LinearAlgebra.norm(residual.Rv .- F0 .- Δx .* Ju) / Δx
+        end
+        residual(x0, time_step)  # restore in case caller relies on it
+
+        # Filter Δx points whose raw remainder is at FP noise — those points
+        # are dominated by roundoff and the ratio test breaks down there.
+        # If every point is at noise, F is locally linear in x_j and the
+        # symbolic J·u is correct to machine precision (nothing to check).
+        keep = (errors .* Δx_mags) .> raw_noise_floor
+        if count(keep) < 2
+            @test true
+            continue
+        end
+        # ratios[k] ≈ (1/2)||F''_jj||, should be Δx-independent in the
+        # asymptotic regime.
+        ratios = (errors ./ Δx_mags)[keep]
+        ok = all(isapprox(r, ratios[1]; rtol = rtol) for r in ratios)
+        if !ok
+            # Locate the largest-residual row: most likely the row whose
+            # symbolic J[row, j] entry is wrong.
+            x_probe = x0 .+ Δx_mags[end - 1] .* u
+            residual(x_probe, time_step)
+            remainder = residual.Rv .- F0 .- Δx_mags[end - 1] .* Ju
+            residual(x0, time_step)
+            row_worst = argmax(abs.(remainder))
+            symbolic_entry = Jv[row_worst, j]
+            # Estimate ∂F[row_worst]/∂x[j] via central difference
+            x_plus = x0 .+ Δx_mags[end - 1] .* u
+            x_minus = x0 .- Δx_mags[end - 1] .* u
+            residual(x_plus, time_step)
+            Fp = residual.Rv[row_worst]
+            residual(x_minus, time_step)
+            Fm = residual.Rv[row_worst]
+            residual(x0, time_step)
+            fd_estimate = (Fp - Fm) / (2 * Δx_mags[end - 1])
+            observed_orders =
+                [
+                    log(errors[k + 1] * Δx_mags[k + 1] /
+                        (errors[k] * Δx_mags[k])) /
+                    log(Δx_mags[k + 1] / Δx_mags[k])
+                    for k in 1:(length(Δx_mags) - 1)
+                ]
+            @warn """
+            verify_jacobian_asymptotic: non-quadratic remainder along column j.
+              Test label : $label
+              Column j   : $j   (sweeping x[$j], all other x fixed at x0)
+              Δx_mags    : $Δx_mags
+              ||remainder||  : $(errors .* Δx_mags)
+              ||rem||/Δx     : $errors  (should decay linearly if J·u correct)
+              ||rem||/Δx²    : $ratios  (should be constant if J·u correct)
+              Observed order : $observed_orders   (≈ 2 if correct, ≈ 1 if wrong)
+
+              Worst-row diagnostics (residual row most off the linear model):
+              row = $row_worst
+              analytic Jv[$row_worst, $j]      = $symbolic_entry
+              central-difference ∂F[$row_worst]/∂x[$j] = $fd_estimate
+              relative diff                            = $((symbolic_entry - fd_estimate) /
+                                                          max(abs(fd_estimate), eps(Float64)))
+            """ maxlog = 10
+        end
+        @test ok
+    end
+    return
+end

--- a/test/test_utils/jacobian_verification.jl
+++ b/test/test_utils/jacobian_verification.jl
@@ -11,20 +11,35 @@ For a correct Jacobian, `e(Δx) / Δx²` is constant across a geometric
 `Δx`-sweep (the second-derivative contribution along `u_j`); this routine
 asserts those normalized ratios agree within `rtol`.
 
-Directions where the residual is locally linear in `x_j` within FP noise
-are skipped (cannot distinguish a correct from an incorrect entry there).
-
 `residual` must be callable as `residual(x, time_step)` and expose the
 current residual vector as `residual.Rv`. Both `ACPowerFlowResidual` and
-`ACRectangularCIResidual` satisfy this. `Jv` can be any object that
-supports `Jv * u` for `u::Vector{Float64}` (sparse or dense matrix).
+`ACRectangularCIResidual` satisfy this. `Jv::AbstractMatrix` so we can
+both compute `Jv * u` (asymptotic check) and `Jv[row, j]` (failure
+diagnostic). Methodology mirrors `test_homotopy_hessian.jl`'s
+asymptotic checks for the Hessian/gradient.
 
-Methodology mirrors `test_homotopy_hessian.jl`'s asymptotic checks for the
-Hessian/gradient.
+## Sensitivity
+
+For a Jacobian wrong by absolute error `δ` in some entry of column `j`,
+`||remainder|| ≈ |δ| · Δx` (linear in Δx), versus `O(Δx²)` for a correct
+Jacobian. The test catches `δ` whenever `|δ| · Δx_max` rises above the
+roundoff noise floor `c · eps · ||F0||` (with `c = 1e4` to absorb
+accumulated FP error from trig/sqrt/division in the residual).
+Equivalently, the detection threshold for an entry-level absolute
+error is
+
+    |δ|_min ≈ c · eps · ||F0|| / Δx_max
+
+With the defaults (`Δx_max = 1e-3`, `c = 1e4`, `eps = 2.2e-16`) this is
+about `2.2e-9 · max(||F0||, 1)`. Smaller wrong-J errors are masked by
+roundoff and silently pass.
+
+Directions where the residual is locally linear in `x_j` within FP noise
+are skipped (cannot distinguish a correct from an incorrect entry there).
 """
 function verify_jacobian_asymptotic(
     residual,
-    Jv,
+    Jv::AbstractMatrix,
     x0::Vector{Float64},
     time_step::Int;
     Δx_mags::Vector{Float64} = [1e-3, 1e-4, 1e-5, 1e-6],
@@ -35,12 +50,14 @@ function verify_jacobian_asymptotic(
     residual(x0, time_step)
     F0 = copy(residual.Rv)
     F0_scale = max(LinearAlgebra.norm(F0), 1.0)
-    # Raw-remainder noise floor — below this, the remainder is dominated by
-    # floating-point roundoff from cancellation in `F(x+Δx) - F(x) - Δx·J·u`
-    # and the asymptotic ratio test is meaningless. The factor 1e4 accounts
-    # for typical accumulated relative roundoff in residuals built from many
-    # trig / sqrt / division operations (e.g. LCC residual).
+    # Raw-remainder noise floor: below this, `F(x+Δx) - F(x) - Δx·J·u` is
+    # dominated by floating-point roundoff from cancellation. Factor 1e4
+    # absorbs typical accumulated relative roundoff in residuals built from
+    # many trig / sqrt / division operations (e.g. the LCC residual).
     raw_noise_floor = 1e4 * eps(Float64) * F0_scale
+    # Sensitivity floor — the detection limit for an entry-level absolute
+    # error in the analytic Jacobian. Reported in the failure diagnostic.
+    sensitivity_floor = raw_noise_floor / Δx_mags[1]
 
     for j in 1:n
         u = zeros(n)
@@ -52,15 +69,13 @@ function verify_jacobian_asymptotic(
         for (k, Δx) in enumerate(Δx_mags)
             x1 = x0 .+ Δx .* u
             residual(x1, time_step)
-            errors[k] =
-                LinearAlgebra.norm(residual.Rv .- F0 .- Δx .* Ju) / Δx
+            errors[k] = LinearAlgebra.norm(residual.Rv .- F0 .- Δx .* Ju) / Δx
         end
         residual(x0, time_step)  # restore in case caller relies on it
 
-        # Filter Δx points whose raw remainder is at FP noise — those points
-        # are dominated by roundoff and the ratio test breaks down there.
-        # If every point is at noise, F is locally linear in x_j and the
-        # symbolic J·u is correct to machine precision (nothing to check).
+        # Filter Δx points whose raw remainder is at FP noise. If every
+        # point is at noise, F is locally linear in x_j within machine
+        # precision and we treat the column as verified.
         keep = (errors .* Δx_mags) .> raw_noise_floor
         if count(keep) < 2
             @test true
@@ -71,23 +86,6 @@ function verify_jacobian_asymptotic(
         ratios = (errors ./ Δx_mags)[keep]
         ok = all(isapprox(r, ratios[1]; rtol = rtol) for r in ratios)
         if !ok
-            # Locate the largest-residual row: most likely the row whose
-            # symbolic J[row, j] entry is wrong.
-            x_probe = x0 .+ Δx_mags[end - 1] .* u
-            residual(x_probe, time_step)
-            remainder = residual.Rv .- F0 .- Δx_mags[end - 1] .* Ju
-            residual(x0, time_step)
-            row_worst = argmax(abs.(remainder))
-            symbolic_entry = Jv[row_worst, j]
-            # Estimate ∂F[row_worst]/∂x[j] via central difference
-            x_plus = x0 .+ Δx_mags[end - 1] .* u
-            x_minus = x0 .- Δx_mags[end - 1] .* u
-            residual(x_plus, time_step)
-            Fp = residual.Rv[row_worst]
-            residual(x_minus, time_step)
-            Fm = residual.Rv[row_worst]
-            residual(x0, time_step)
-            fd_estimate = (Fp - Fm) / (2 * Δx_mags[end - 1])
             observed_orders =
                 [
                     log(errors[k + 1] * Δx_mags[k + 1] /
@@ -95,6 +93,18 @@ function verify_jacobian_asymptotic(
                     log(Δx_mags[k + 1] / Δx_mags[k])
                     for k in 1:(length(Δx_mags) - 1)
                 ]
+            # Worst-row diagnostic: row whose remainder is largest at a
+            # mid-range Δx — most likely the row whose `Jv[row, j]` is wrong.
+            Δx_probe = Δx_mags[end - 1]
+            residual(x0 .+ Δx_probe .* u, time_step)
+            Fp = copy(residual.Rv)
+            residual(x0 .- Δx_probe .* u, time_step)
+            Fm = copy(residual.Rv)
+            residual(x0, time_step)
+            remainder_probe = Fp .- F0 .- Δx_probe .* Ju
+            row_worst = argmax(abs.(remainder_probe))
+            symbolic_entry = Jv[row_worst, j]
+            fd_estimate = (Fp[row_worst] - Fm[row_worst]) / (2 * Δx_probe)
             @warn """
             verify_jacobian_asymptotic: non-quadratic remainder along column j.
               Test label : $label
@@ -104,6 +114,7 @@ function verify_jacobian_asymptotic(
               ||rem||/Δx     : $errors  (should decay linearly if J·u correct)
               ||rem||/Δx²    : $ratios  (should be constant if J·u correct)
               Observed order : $observed_orders   (≈ 2 if correct, ≈ 1 if wrong)
+              Sensitivity floor (smallest detectable |δ|): $sensitivity_floor
 
               Worst-row diagnostics (residual row most off the linear model):
               row = $row_worst


### PR DESCRIPTION
## Summary
- **Fixed algebra bugs** in `_calculate_dQ_dV_lcc` and `_calculate_dQ_dt_lcc` (`src/lcc_utils.jl`): the prior formulas had a spurious extra `V` factor, `sin²(φ)` instead of `V·sin(φ)` in the denominator, and a missing `sign(I_dc)` factor. The derivation was inconsistent with `Q = V·t·(√6/π)·I_dc·sin(φ)` chained through the simplified `φ = arccos(sign(I_dc)·(cos(α) - x·I_dc/(√2·t·V)))`.
- **Added the missing inverter-side entries** to the LCC Jacobian (`src/ac_power_flow_jacobian.jl`): the rectifier-terminal block had all six bus-side derivatives (∂P/∂V, ∂P/∂t, ∂P/∂α, ∂Q/∂V, ∂Q/∂t, ∂Q/∂α), but the inverter mirror was entirely absent — both in the sparsity-structure builder and in the update path. Added all six, plus the four new cross entries (bus rows ↔ inverter-side state columns) to `_create_jacobian_matrix_structure_lcc`.
- **Guarded against the φ-clamp singularity**: when `sin(φ) → 0` (the `arccos` argument hits the `clamp(..., -1, 1)` boundary), the analytic derivative formulas diverge as 1/sin(φ), but the *true* derivative in the clamped regime is 0 (φ is locally pinned, residual locally constant). The Q-derivative helpers now short-circuit to 0 below `sin(φ) < 1e-8`. Without this, Newton-Raphson diverges on LCC systems whose initial state lies on the clamp.
- **Logged a warning** in `_calculate_ϕ_lcc` when the clamp activates, with `maxlog=5` to avoid spam in the hot path.
- **Re-enabled** the previously-commented `verify_jacobian` test on the LCC system (`test/test_jacobian.jl`): bumped the inverter extinction angle off the clamp boundary at the test point, switched to central differencing for better FD accuracy, and confirmed all 10 columns match analytically.
- **Updated** `docs/src/explanation/lcc_model.md` with the corrected ∂Q_r/∂V_r and ∂Q_r/∂t_r formulas and added the new inverter-side P/Q derivative entries.

## Test plan
- [x] `Jacobian verification with LCC` testset passes (all 10 state-vector columns agree with central-FD to rtol=1e-6).
- [x] `Test LCC consistency` and `Test LCC` testsets still pass (NR converges on the simple LCC system).
- [x] Full test suite: 41,449 passed, 0 failed, 0 errored.

## Notes on remaining model limitations
The simplified-φ definition (closed-form `arccos(...)`) is fundamentally non-smooth at the clamp boundary. Newton may still struggle on systems whose converged operating point lies right at the clamp (unusual but possible). A principled fix is the full overlap-angle commutation model (Panosyan thesis, cited in `lcc_model.md`); that's a larger modeling effort and out of scope here. The warning logged by `_calculate_ϕ_lcc` surfaces clamp activation when it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)