### PR TITLE
Accept narrowly-typed Dicts for ACPowerFlow solver_settings

### DIFF
--- a/src/power_flow_types.jl
+++ b/src/power_flow_types.jl
@@ -215,8 +215,9 @@ function ACPowerFlow{ACSolver}(;
     time_steps::Int = 1,
     time_step_names::Vector{String} = String[],
     correct_bustypes::Bool = false,
-    solver_settings::Dict{Symbol, Any} = Dict{Symbol, Any}(),
+    solver_settings::AbstractDict = Dict{Symbol, Any}(),
 ) where {ACSolver <: ACPowerFlowSolverType}
+    settings = Dict{Symbol, Any}(solver_settings)
     if calculate_loss_factors && ACSolver == LevenbergMarquardtACPowerFlow
         error("Loss factor calculation is not supported by the Levenberg-Marquardt solver.")
     end
@@ -249,7 +250,7 @@ function ACPowerFlow{ACSolver}(;
         time_steps,
         time_step_names,
         correct_bustypes,
-        solver_settings,
+        settings,
     )
 end
 

--- a/test/test_solve_power_flow.jl
+++ b/test/test_solve_power_flow.jl
@@ -866,3 +866,21 @@ end
 @testset "AC arc_angle_differences validation" begin
     foreach(test_ac_arc_angle_differences, AC_SOLVERS_TO_TEST)
 end
+
+@testset "ACPowerFlow solver_settings accepts narrowly-typed Dicts" begin
+    # Regression: previously the kwarg required Dict{Symbol, Any} exactly, so a
+    # plain `Dict(:k => 50)` (inferred as Dict{Symbol, Int64}) was rejected.
+    pf_int = ACPowerFlow(; solver_settings = Dict(:maxIterations => 50))
+    @test pf_int.solver_settings isa Dict{Symbol, Any}
+    @test pf_int.solver_settings[:maxIterations] === 50
+
+    pf_bool = ACPowerFlow(;
+        solver_settings = Dict(:validate_voltage_magnitudes => false),
+    )
+    @test pf_bool.solver_settings[:validate_voltage_magnitudes] === false
+
+    pf_any = ACPowerFlow(;
+        solver_settings = Dict{Symbol, Any}(:maxIterations => 50),
+    )
+    @test pf_any.solver_settings[:maxIterations] === 50
+end


### PR DESCRIPTION
## Summary
- `ACPowerFlow(; solver_settings = Dict(:maxIterations => 50))` previously threw `TypeError: expected Dict{Symbol, Any}, got Dict{Symbol, Int64}` because Julia's typed kwargs perform a strict subtype check and `Dict` is invariant in its value parameter.
- Broaden the kwarg to `AbstractDict` and coerce to `Dict{Symbol, Any}` inside the constructor (via a new local, to keep the inner constructor's argument type stable).
- Existing `Dict{Symbol, Any}(...)` callers continue to work unchanged.

## Test plan
- [x] New regression test (`ACPowerFlow solver_settings accepts narrowly-typed Dicts`) covering `Dict{Symbol, Int}`, `Dict{Symbol, Bool}`, and the existing `Dict{Symbol, Any}` path
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)