### PR TITLE
Share PNM matrices by reference in DC power flow test (deepcopy of KLU cache now disallowed)

### DIFF
--- a/test/test_dc_power_flow.jl
+++ b/test/test_dc_power_flow.jl
@@ -26,8 +26,11 @@ end
     data = PowerFlowData(DCPowerFlow(; correct_bustypes = true), sys)
     power_injections =
         deepcopy(data.bus_active_power_injections - data.bus_active_power_withdrawals)
-    matrix_data = deepcopy(data.power_network_matrix.K)       # LU factorization of ABA
-    aux_network_matrix = deepcopy(data.aux_network_matrix)    # BA matrix
+    # Share the PNM matrices by reference: deepcopying an ABA_Matrix (or its `K`
+    # field) is disallowed because the KLU factorization cache holds raw libklu
+    # pointers. Both are only read below (the `\` solve and the BA transpose).
+    matrix_data = data.power_network_matrix.K                 # LU factorization of ABA
+    aux_network_matrix = data.aux_network_matrix              # BA matrix
 
     valid_ix = setdiff(
         1:length(power_injections),


### PR DESCRIPTION
## Problem

`PowerNetworkMatrices` 0.22.1 makes `deepcopy` of a `KLULinSolveCache` throw by design — the cache holds raw libklu `Symbolic`/`Numeric` pointers, so a bit-copy would alias one factorization across two finalizer-owning caches (a double-free / use-after-free, surfacing as `KLU_INVALID` or `SIGSEGV`).

The `SINGLE PERIOD power flows evaluation: ABA, PTDF, VirtualPTDF` testset in `test/test_dc_power_flow.jl` deepcopied `data.power_network_matrix.K` (the ABA `KLULinSolveCache`). With the new guard this raises an exception **outside** a `@test`, which aborts the entire `ReTest` run (exit 1), so the whole suite fails to complete:

```
deepcopy of a KLULinSolveCache is unsafe and was attempted: the cache holds raw
libklu Symbolic/Numeric pointers that deepcopy would alias by value ...
  [2] deepcopy_internal(::PowerNetworkMatrices.KLUWrapper.KLULinSolveCache{Float64, Int64}, ...)
  [5] macro expansion @ test/test_dc_power_flow.jl:29
```

## Fix

Share the ABA factorization (`K`) and the BA matrix **by reference** instead of deepcopying them. Both are only read afterward:
- `matrix_data \ power_injections[valid_ix]` — a read-only KLU solve (`\(::KLULinSolveCache, B)` copies its RHS internally and does not mutate the factorization)
- `transpose(aux_network_matrix.data) * ref_bus_angles`

so no copy is needed.

This is the only place in the test suite that deepcopies a PNM matrix that carries a KLU cache (`ABA_Matrix` / `VirtualPTDF`). Every other `deepcopy` call in `test/` operates on `System` objects, plain arrays, network-reduction vectors, or the Jacobian's `Jv` (a plain `SparseMatrixCSC`) — none of which hold a `KLULinSolveCache`, so they are left unchanged.

## Verification

- The previously-failing testset now passes: `SINGLE PERIOD power flows evaluation: ABA, PTDF, VirtualPTDF | 9 Pass`.
- **Full suite is green**: `42647` tests pass, **0 failures / 0 errors**, and the `KLULinSolveCache` deepcopy guard does not trip anywhere else.

https://claude.ai/code/session_01KEaQ94Nmn1eJ63xx6QVQxA