### PR TITLE
fix handling of nonzero ref angle for DC

### DIFF
--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -283,6 +283,12 @@ get_arc_lookup(pfd::ACPowerFlowData) =
 get_arc_axis(pfd::ACPowerFlowData) =
     PNM.get_arc_axis(pfd.power_network_matrix.arc_admittance_from_to)
 
+# used for shifting angles relative to REF bus after DC solve.
+subnetwork_axes(data::PTDFPowerFlowData) = data.aux_network_matrix.subnetwork_axes
+subnetwork_axes(data::vPTDFPowerFlowData) = data.aux_network_matrix.subnetwork_axes
+subnetwork_axes(data::ABAPowerFlowData) = data.power_network_matrix.subnetwork_axes
+subnetwork_axes(data::ACPowerFlowData) = get_aux_network_matrix(data).subnetwork_axes
+
 # so we can initialize things to the correct size inside the below constructor.
 # No `PowerFlowData` instance, so can't call get_arc_axis or similar to get the size.
 arc_count(::AbstractACPowerFlow,

--- a/src/power_flow_setup.jl
+++ b/src/power_flow_setup.jl
@@ -277,6 +277,11 @@ function _dc_power_flow_fallback!(data::ACPowerFlowData, time_step::Int)
     # PNM's KLUWrapper.KLULinSolveCache exposes solve! (in-place) instead of ldiv!.
     PNM.solve!(solver_cache, p_inj)
     data.bus_angles[valid_ix, time_step] .= p_inj
+    # The reduced solve is referenced to 0 at each ref bus, but the AC solve holds each
+    # ref bus fixed at its stored angle: shift the warm start onto the AC reference so
+    # arcs incident to a ref bus with nonzero stored angle don't start with a spurious
+    # angle difference. Only this column — others may hold solved AC states.
+    _shift_angles_to_stored_reference!(data, time_step)
 end
 
 function initialize_power_flow_variables(pf::ACPolarPowerFlow{T},

--- a/src/solve_dc_power_flow.jl
+++ b/src/solve_dc_power_flow.jl
@@ -55,6 +55,35 @@ function _make_dc_scratch(data::PowerFlowData)
     )
 end
 
+_convert_to_range(ix::Integer) = ix:ix
+_convert_to_range(::Colon) = Colon()
+
+# PERF: cache ref-to-bus-indices dict.
+"""
+    _shift_angles_to_stored_reference!(data, time_steps = :)
+
+The DC solve computes angles relative to 0 at each subnetwork's ref bus; if the
+subnetwork's ref bus has nonzero angle, shift the angles accordingly.
+"""
+function _shift_angles_to_stored_reference!(
+    data::Union{PTDFPowerFlowData, vPTDFPowerFlowData, ABAPowerFlowData, ACPowerFlowData},
+    time_steps::Union{Colon, Integer} = Colon(),
+)
+    # normalize a scalar index to a range: in-place broadcasting cannot assign
+    # through the zero-dimensional view that scalar indexing produces.
+    timestep_range = _convert_to_range(time_steps)
+    bus_lookup = get_bus_lookup(data)
+    for (ref_bus, ax) in subnetwork_axes(data)
+        ref_row = bus_lookup[ref_bus]
+        θ_ref = @view data.bus_angles[ref_row, timestep_range]
+        all(iszero, θ_ref) && continue
+        for bus in first(ax)
+            bus == ref_bus && continue
+            @views data.bus_angles[bus_lookup[bus], timestep_range] .+= θ_ref
+        end
+    end
+end
+
 """
     solve_power_flow!(data::PTDFPowerFlowData)
 Evaluates the PTDF power flow and writes the result to the fields of the
@@ -90,6 +119,7 @@ function solve_power_flow!(
     @views p_inj .= power_injections[valid_ix, :]
     solve!(solver_cache, p_inj)
     @views data.bus_angles[valid_ix, :] .= p_inj
+    _shift_angles_to_stored_reference!(data)
     mul!(data.arc_angle_differences, scratch.arc_bus_incidence, data.bus_angles)
     @. data.arc_active_power_losses = scratch.rs * data.arc_active_power_flow_from_to^2
     data.converged .= true
@@ -131,6 +161,7 @@ function solve_power_flow!(
     p_inj = power_injections[valid_ix, :]
     solve!(solver_cache, p_inj)
     data.bus_angles[valid_ix, :] .= p_inj
+    _shift_angles_to_stored_reference!(data)
     _compute_arc_angle_differences_from_data!(data)
     Rs = _get_arc_resistances(data)
     @. data.arc_active_power_losses = Rs * data.arc_active_power_flow_from_to^2
@@ -188,6 +219,7 @@ function solve_power_flow!(
     @views p_inj .= power_injections[valid_ix, :]
     solve!(solver_cache, p_inj)
     @views data.bus_angles[valid_ix, :] .= p_inj
+    _shift_angles_to_stored_reference!(data)
 
     if data.arc_lossy_admittance_from_to !== nothing
         # DC assumption: all bus voltage magnitudes are 1.0 p.u., so V = e^(jθ).

--- a/test/test_nonzero_ref_angle.jl
+++ b/test/test_nonzero_ref_angle.jl
@@ -1,0 +1,89 @@
+# Regression test for DC power flows on systems whose reference bus has a nonzero
+# stored angle (e.g. a case exported from a solved AC/PSS\e case). The reduced DC
+# solve computes angles relative to 0 at the ref bus, but `bus_angles` is initialized
+# from the system data — previously the ref bus row kept its stored angle while all
+# other rows held solved (relative-to-zero) values, so flow extraction `BA' * θ` put a
+# spurious, time-constant flow `θ_stored / x` on every arc incident to the ref bus.
+#
+# The required behavior: flows are invariant to the stored ref bus angle, KCL holds at
+# every bus (including the ref bus), and reported angles are re-referenced so the ref
+# bus honors its stored angle.
+
+# Net flow out of each bus index implied by the arc flows.
+function _net_flow_out(data::PF.PowerFlowData, t::Int)
+    bus_lookup = PF.get_bus_lookup(data)
+    ft = PF.get_arc_active_power_flow_from_to(data)
+    net_out = zeros(length(bus_lookup))
+    for (arc, ix) in PF.get_arc_lookup(data)
+        net_out[bus_lookup[arc[1]]] += ft[ix, t]
+        net_out[bus_lookup[arc[2]]] -= ft[ix, t]
+    end
+    return net_out
+end
+
+@testset "DC power flow with nonzero stored ref bus angle" begin
+    REF_ANGLE = 0.12345  # rad; anything nonzero exercises the bug
+
+    for pf_type in (DCPowerFlow, PTDFDCPowerFlow, vPTDFDCPowerFlow)
+        # Identical systems except for the stored angle at the reference bus.
+        sys_zero = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
+        sys_shifted =
+            PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
+        get_ref_bus(sys) = only(
+            collect(
+                PSY.get_components(
+                    x -> PSY.get_bustype(x) == PSY.ACBusTypes.REF,
+                    PSY.ACBus,
+                    sys,
+                ),
+            ),
+        )
+        PSY.set_angle!(get_ref_bus(sys_zero), 0.0)
+        PSY.set_angle!(get_ref_bus(sys_shifted), REF_ANGLE)
+        ref_bus_number = PSY.get_number(get_ref_bus(sys_shifted))
+
+        data_zero = PowerFlowData(pf_type(; correct_bustypes = true), sys_zero)
+        data_shifted = PowerFlowData(pf_type(; correct_bustypes = true), sys_shifted)
+        solve_power_flow!(data_zero)
+        solve_power_flow!(data_shifted)
+        @test all(PF.get_converged(data_zero))
+        @test all(PF.get_converged(data_shifted))
+
+        # 1. Flows must be invariant to the stored ref bus angle.
+        @test isapprox(
+            PF.get_arc_active_power_flow_from_to(data_shifted),
+            PF.get_arc_active_power_flow_from_to(data_zero);
+            atol = 1e-9,
+        )
+        @test isapprox(
+            PF.get_arc_active_power_flow_to_from(data_shifted),
+            PF.get_arc_active_power_flow_to_from(data_zero);
+            atol = 1e-9,
+        )
+
+        # 2. KCL: the net flow out of every non-ref bus must equal that bus's net
+        # injection. (The ref bus is excluded: its balance equation is the redundant
+        # one, so any system-wide injection imbalance — e.g. the AC-case losses baked
+        # into c_sys14's device setpoints — lands there by design.) Before the fix this
+        # failed at the ref bus's neighbors by O(θ_stored / x).
+        bus_lookup = PF.get_bus_lookup(data_shifted)
+        ref_ix = bus_lookup[ref_bus_number]
+        t = 1
+        net_out = _net_flow_out(data_shifted, t)
+        net_injection = [
+            data_shifted.bus_active_power_injections[ix, t] -
+            PF.get_bus_active_power_total_withdrawals(data_shifted, ix, t)
+            for ix in eachindex(net_out)
+        ]
+        non_ref = setdiff(eachindex(net_out), ref_ix)
+        @test isapprox(net_out[non_ref], net_injection[non_ref]; atol = 1e-8)
+
+        # 3. Reported angles honor the stored reference: the ref bus sits at its stored
+        # angle and every other bus is shifted by exactly that constant, so angle
+        # differences (and hence flows) are unchanged.
+        θ_zero = PF.get_bus_angles(data_zero)
+        θ_shifted = PF.get_bus_angles(data_shifted)
+        @test isapprox(θ_shifted[ref_ix, t], REF_ANGLE; atol = 1e-12)
+        @test isapprox(θ_shifted, θ_zero .+ REF_ANGLE; atol = 1e-9)
+    end
+end


### PR DESCRIPTION
Our DC formulas treat the ref bus angle as zero, but we set it to the system value (not to zero). That then messes with the change-in-angle over the adjacent lines, so we get incorrect flow numbers there.

Found by @m-bossart