### PR TITLE
Add per-iteration Jacobian eigenvalue diagnostics and fold bail-out

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PowerFlows"
 uuid = "94fada2c-fd9a-4e89-8d82-81405f5cb4f6"
-version = "0.20.1"
+version = "0.21.0"
 authors = ["Jose Daniel Lara", "Gabriel Konar-Steenberg", "Luke Kiernan"]
 
 [deps]
@@ -40,7 +40,7 @@ KrylovKit = "0.9, 0.10"
 LineSearches = "7"
 LinearAlgebra = "1"
 Logging = "1"
-PowerNetworkMatrices = "^0.23"
+PowerNetworkMatrices = "^0.24"
 PowerSystems = "^5.10"
 SparseArrays = "1"
 StaticArrays = "^1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InfrastructureSystems = "2cd47ed4-ca9b-11e9-27f2-ab636a7671f1"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -23,6 +24,11 @@ Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
 [extensions]
 PowerFlowsPardisoExt = "Pardiso"
 
+# Until the condest!/rcond! re-export lands in a tagged PowerNetworkMatrices
+# release, pull it from the branch so the solver diagnostics resolve on CI.
+[sources]
+PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl", rev = "lk/expose-klu-condest"}
+
 [compat]
 DataFrames = "1"
 Pardiso = "1"
@@ -30,6 +36,7 @@ DataStructures = "0.19"
 Dates = "1"
 InfrastructureSystems = "3"
 JSON3 = "1"
+KrylovKit = "0.9, 0.10"
 LineSearches = "7"
 LinearAlgebra = "1"
 Logging = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,6 +25,7 @@ pages = OrderedDict(
         "Evaluation Models vs. Solver Algorithms" => "explanation/models-and-solvers.md",
         "Mixed Current-Power Balance Formulation" => "explanation/mixed_cpb_formulation.md",
         "Levenberg-Marquardt vs Gauss-Seidel" => "explanation/lm_vs_gauss_seidel.md",
+        "Folds, Voltage Collapse, and Solver Diagnostics" => "explanation/folds_and_diagnostics.md",
         "LCC Model Implementation" => "explanation/lcc_model.md",
     ],
     "Reference" => Any[

--- a/docs/src/explanation/folds_and_diagnostics.md
+++ b/docs/src/explanation/folds_and_diagnostics.md
@@ -1,0 +1,123 @@
+# Folds, Voltage Collapse, and Solver Diagnostics
+
+An AC power flow can fail to converge because of a poor starting point — a
+*numerical* difficulty, addressed by robust solvers such as
+[`TrustRegionACPowerFlow`](@ref), [`LevenbergMarquardtACPowerFlow`](@ref), or
+[`RobustHomotopyPowerFlow`](@ref) — or because the requested operating point
+**has no solution**, a *physical* limit no solver can overcome. The second case
+is a **fold**. This page explains the term and the per-iteration diagnostics
+that recognize it.
+
+## What is a fold?
+
+Write the power flow equations as $F(x; p) = 0$, where $x$ collects the bus
+voltage states and $p$ is a scalar that *stresses* the system — typically total
+load. At light loading there is a well-behaved high-voltage solution and a
+second, lower-voltage one; as $p$ increases the two drift toward each other.
+Plotting a bus voltage magnitude against $p$ traces the **PV (nose) curve**:
+
+```text
+ |V|
+  │   ── high-voltage (operable) branch
+  │ ╱                       ╲
+  │╱                          ● ← fold / nose: the two branches meet
+  │                         ╱     (maximum loadability p*)
+  │   ── low-voltage branch
+  └────────────────────────────── p (loading)
+                            p*
+```
+
+At the **fold** (the nose, loading $p^*$) the two solutions coalesce and, for
+$p > p^*$, vanish: no (real) power flow solution exists. Mathematically this is
+a **saddle-node bifurcation**, whose defining feature is that the Jacobian
+$J = \partial F / \partial x$ becomes **singular** — its smallest eigenvalue
+passes through zero. The fold is the classical static **voltage-collapse** limit.
+
+## Why a fold breaks the solver
+
+Newton-type methods solve a linear system with $J$ at every iteration. Near the
+fold $J$ becomes ill-conditioned and finally singular: the step
+$\Delta x = -J^{-1} F$ blows up and the iteration diverges, or the solver
+crosses onto the **low-voltage branch** and "converges" to a physically
+meaningless solution. Both look like ordinary non-convergence, but more
+iterations or a more robust solver cannot help — the operating point is
+infeasible. Recognizing the fold lets you report *"past the loadability
+limit"* instead of returning a bad root or burning the iteration budget.
+
+## How PowerFlows.jl detects a fold
+
+The smallest-magnitude eigenvalue of the Jacobian is the standard proximity
+indicator: it tends to zero at the fold, and its real part changes sign when an
+iterate crosses onto the other branch.
+
+PowerFlows.jl computes this eigenvalue on the bus-voltage **Schur complement**
+$S$ of the Jacobian — the bus block left after projecting out the LCC/HVDC
+converter states (with no converters, $S = J$). $S$ is never formed or
+factorized: inverse iteration (KrylovKit) finds the largest-magnitude
+eigenvalue $\mu$ of $S^{-1}$ through a factorization of the *full* $J$ — each
+Arnoldi matvec is one back-solve — and reports $\lambda_{\min}(S) = 1/\mu$. The
+per-iteration cost is one numeric refactorization of $J$ plus the eigensolve,
+shared by the log line and the bail-out. (LM keeps a small dedicated KLU factor
+of $J$, since its solver factorizes the augmented least-squares system
+instead.) Because $J$ is non-symmetric, $\lambda_{\min}$ may be complex; the
+fold signal is the sign of its real part.
+
+Two opt-in settings expose this. Both are off by default and add cost only when
+enabled.
+
+### `log_solver_diagnostics` — observe the approach
+
+A constructor keyword on the formulation. Each iteration emits an `@info` line
+with $\lVert F\rVert_\infty$ (and the bus/equation where it is attained), the
+condition estimate $\hat\kappa(J)$, $\lambda_{\min}(S)$, and the residual
+contraction ratio. Watching $\lambda_{\min}(S)$ shrink toward zero is a direct
+view of an iterate nearing a fold.
+
+```julia
+pf = ACPolarPowerFlow{NewtonRaphsonACPowerFlow}(; log_solver_diagnostics = true)
+solve_power_flow(pf, sys)
+# [ Info: NR iter 3: ‖F‖_∞ = 0.04211 at bus 8 (Q), κ̂(J) = 1830.0,
+#         λ_min(S) = 0.5217 (|λ_min| = 0.5217), contraction = 0.231
+```
+
+$\hat\kappa(J)$ is available only on the KLU backend; other backends print
+`n/a`. Pin `:linear_solver => "KLU"` in `solver_settings` if you need it on
+platforms whose default is AppleAccelerate.
+
+### `stop_at_fold` — abort at the fold
+
+Passed through `solver_settings`. The solver stops as soon as it sees a fold
+signature — the real part of $\lambda_{\min}(S)$ flips sign between iterations,
+the Jacobian is outright singular, or the eigenvalue is indeterminate
+(non-converged or non-finite, treated conservatively as a fold) — and returns
+*not converged* with a warning, rather than continuing toward divergence or the
+low-voltage branch.
+
+```julia
+pf = ACPolarPowerFlow{NewtonRaphsonACPowerFlow}(;
+    solver_settings = Dict{Symbol, Any}(:stop_at_fold => true))
+data = PowerFlowData(pf, sys)
+converged = solve_power_flow!(data)   # false at a fold, with a voltage-collapse warning
+```
+
+`stop_at_fold` is supported by [`NewtonRaphsonACPowerFlow`](@ref),
+[`TrustRegionACPowerFlow`](@ref), and [`LevenbergMarquardtACPowerFlow`](@ref),
+on every AC formulation (polar, rectangular-CI, and mixed-CPB, with or without
+HVDC).
+
+## Caveats
+
+  - The sign-flip test is a **practical signature, not a rigorous bifurcation
+    test**: it stops a solve wandering into a collapse region; it does not
+    certify the exact loadability limit.
+  - The per-iteration cost is justified on hard or near-collapse cases — not
+    something to leave on for routine, well-conditioned solves.
+  - A `stop_at_fold` abort returns `false` like any other non-convergence; the
+    distinguishing detail is the fold/voltage-collapse warning in the log.
+
+## See also
+
+[`NewtonRaphsonACPowerFlow`](@ref), [`TrustRegionACPowerFlow`](@ref),
+[`LevenbergMarquardtACPowerFlow`](@ref), [`RobustHomotopyPowerFlow`](@ref),
+[Evaluation Models vs. Solver Algorithms](@ref),
+[How to choose an AC formulation and solver](@ref choose-ac-formulation-and-solver).

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -238,6 +238,7 @@ get_computed_gspf(pfd::PowerFlowData) = pfd.computed_generator_slack_participati
 get_calculate_loss_factors(pfd::PowerFlowData) = get_calculate_loss_factors(pfd.pf)
 get_calculate_voltage_stability_factors(pfd::PowerFlowData) =
     get_calculate_voltage_stability_factors(pfd.pf)
+get_log_solver_diagnostics(pfd::PowerFlowData) = get_log_solver_diagnostics(pfd.pf)
 get_network_reductions(pfd::PowerFlowData) = get_network_reductions(pfd.pf)
 """
     get_time_steps(pfd::PowerFlowData)

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -40,6 +40,7 @@ import SparseArrays
 import InfrastructureSystems as IS
 import PowerNetworkMatrices as PNM
 import PowerNetworkMatrices: YBUS_ELTYPE
+import KrylovKit
 import SparseArrays:
     SparseMatrixCSC, SparseVector, sparse, sparsevec, AbstractSparseMatrix, spzeros
 import StaticArrays: MVector
@@ -71,6 +72,7 @@ include("mixed_cpb_setup.jl")
 include("mixed_cpb_power_flow_residual.jl")
 include("mixed_cpb_power_flow_jacobian.jl")
 include("solve_ac_power_flow.jl")
+include("residual_condition_diagnostics.jl")
 include("power_flow_setup.jl")
 include("power_flow_method.jl")
 include("levenberg-marquardt.jl")

--- a/src/levenberg-marquardt.jl
+++ b/src/levenberg-marquardt.jl
@@ -133,6 +133,7 @@ function _newton_power_flow(
     λ_0::Float64 = DEFAULT_λ_0,
     marquardt_scaling::Union{Bool, Nothing} = nothing,
     x0::Union{Vector{Float64}, Nothing} = nothing,
+    stop_at_fold::Bool = false,
     _ignored...,
 )
     init_kwargs = if isnothing(x0)
@@ -153,7 +154,7 @@ function _newton_power_flow(
             residual,
             J,
             ws;
-            tol, maxIterations, λ_0,
+            tol, maxIterations, λ_0, stop_at_fold,
         )
     end
     # x0 was mutated in place to the converged state by _run_power_flow_method
@@ -173,6 +174,7 @@ function _run_power_flow_method(
     maxIterations::Int = DEFAULT_NR_MAX_ITER,
     tol::Float64 = DEFAULT_NR_TOL,
     λ_0::Float64 = DEFAULT_λ_0,
+    stop_at_fold::Bool = false,
     _ignored...,
 )
     μ::Float64 = λ_0
@@ -182,23 +184,23 @@ function _run_power_flow_method(
     resSize = dot(residual.Rv, residual.Rv)
     linf = norm(residual.Rv, Inf)
     @debug "initially: sum of squares $(siground(resSize)), L ∞ norm $(siground(linf)), λ = $λ"
-    monitor = get_log_solver_diagnostics(J.data)
-    prev_F::Float64 = NaN  # previous ‖F‖∞, for the contraction ratio
-    # LM factorizes the augmented [J; √λ·D], not J itself, so the diagnostic keeps
-    # its own factor of J (symbolic done once here, refreshed each iteration). Only
-    # allocated when diagnostics are on. LM exposes no linear-solver backend choice,
-    # so we use KLU here: it's available on every platform and yields κ̂ for free.
-    diag_cache = monitor ? make_linear_solver_cache(PNM.KLUSolver(), J.Jv) : nothing
-    if monitor
-        symbolic_factor!(diag_cache, J.Jv)
-    end
+    monitor, diag_state = setup_solver_diagnostics(J, stop_at_fold)
+    # LM factorizes the augmented [J; √λ·D], not J, so the diagnostic keeps its own
+    # KLU factor of J (symbolic once here, refreshed each iteration by the hook).
+    diag_cache =
+        isnothing(diag_state) ? nothing :
+        make_linear_solver_cache(PNM.KLUSolver(), J.Jv)
+    isnothing(diag_state) || symbolic_factor!(diag_cache, J.Jv)
     while i < maxIterations && !converged && isfinite(λ) && μ < DEFAULT_μ_MAX
         λ, μ = update_damping_factor!(x, residual, J, μ, time_step, ws)
-        if monitor
-            numeric_refactor!(diag_cache, J.Jv)
-            prev_F = _log_solver_diagnostics(
-                "LM iter $i", residual, J.data, time_step,
-                diag_cache, size(J.Jv, 1), prev_F)
+        if !isnothing(diag_state)
+            # One-iterate lag: update_damping_factor! evaluated J at the pre-step
+            # iterate but residual.Rv is already post-step, so κ̂/λ_min describe the
+            # linearization J while the reported ‖F‖∞ is after the step. Not realigned.
+            run_solver_diagnostics!(
+                diag_state, "LM iter $i", residual, J, time_step,
+                diag_cache, monitor, stop_at_fold) &&
+                return false, i
         end
         converged = isfinite(λ) && norm(residual.Rv, Inf) < tol
         i += 1

--- a/src/levenberg-marquardt.jl
+++ b/src/levenberg-marquardt.jl
@@ -182,8 +182,24 @@ function _run_power_flow_method(
     resSize = dot(residual.Rv, residual.Rv)
     linf = norm(residual.Rv, Inf)
     @debug "initially: sum of squares $(siground(resSize)), L ∞ norm $(siground(linf)), λ = $λ"
+    monitor = get_log_solver_diagnostics(J.data)
+    prev_F::Float64 = NaN  # previous ‖F‖∞, for the contraction ratio
+    # LM factorizes the augmented [J; √λ·D], not J itself, so the diagnostic keeps
+    # its own factor of J (symbolic done once here, refreshed each iteration). Only
+    # allocated when diagnostics are on. LM exposes no linear-solver backend choice,
+    # so we use KLU here: it's available on every platform and yields κ̂ for free.
+    diag_cache = monitor ? make_linear_solver_cache(PNM.KLUSolver(), J.Jv) : nothing
+    if monitor
+        symbolic_factor!(diag_cache, J.Jv)
+    end
     while i < maxIterations && !converged && isfinite(λ) && μ < DEFAULT_μ_MAX
         λ, μ = update_damping_factor!(x, residual, J, μ, time_step, ws)
+        if monitor
+            numeric_refactor!(diag_cache, J.Jv)
+            prev_F = _log_solver_diagnostics(
+                "LM iter $i", residual, J.data, time_step,
+                diag_cache, size(J.Jv, 1), prev_F)
+        end
         converged = isfinite(λ) && norm(residual.Rv, Inf) < tol
         i += 1
     end

--- a/src/linear_solver_backend.jl
+++ b/src/linear_solver_backend.jl
@@ -62,6 +62,11 @@ solve!(c::PNM.AAFactorCache, b::StridedVecOrMat{Float64}) =
 transpose solve)."""
 tsolve!(c::PNM.KLULinSolveCache, b::StridedVecOrMat{Float64}) = PNM.tsolve!(c, b)
 
+"""1-norm condition-number estimate of the cached factorization. KLU-only
+(libklu's `klu_condest`); AppleAccelerate exposes no condition estimate. Used by
+the per-iteration solver diagnostics ([`_log_solver_diagnostics`](@ref))."""
+condest!(c::PNM.KLULinSolveCache) = PNM.condest!(c)
+
 # --- Backend resolution and construction ---
 
 """Resolve the active linear-solver backend tag.

--- a/src/linear_solver_backend.jl
+++ b/src/linear_solver_backend.jl
@@ -64,7 +64,7 @@ tsolve!(c::PNM.KLULinSolveCache, b::StridedVecOrMat{Float64}) = PNM.tsolve!(c, b
 
 """1-norm condition-number estimate of the cached factorization. KLU-only
 (libklu's `klu_condest`); AppleAccelerate exposes no condition estimate. Used by
-the per-iteration solver diagnostics ([`_log_solver_diagnostics`](@ref))."""
+the per-iteration solver diagnostics ([`run_solver_diagnostics!`](@ref))."""
 condest!(c::PNM.KLULinSolveCache) = PNM.condest!(c)
 
 # --- Backend resolution and construction ---

--- a/src/power_flow_method.jl
+++ b/src/power_flow_method.jl
@@ -652,11 +652,15 @@ function _run_power_flow_method(time_step::Int,
     validate_voltage_magnitudes::Bool = DEFAULT_VALIDATE_VOLTAGES,
     vm_validation_range::MinMax = DEFAULT_VALIDATION_RANGE,
     iwamoto::Bool = false,
+    bail_on_eig_sign_switch::Bool = false,
     _ignored...,  # absorb unknown keys from caller without error
 )
     validate_vms = validate_voltage_magnitudes
     i, converged = 1, false
     consecutive_reverts = 0
+    monitor = get_log_solver_diagnostics(J.data)
+    eig_sign = EigvalSign.UNSEEN  # sign of real(λ_min) last iter, for the fold bail-out
+    prev_F::Float64 = NaN  # previous ‖F‖∞, for the contraction ratio
     while i < maxIterations && !converged
         if iwamoto
             made_progress = _iwamoto_step(
@@ -694,6 +698,23 @@ function _run_power_flow_method(time_step::Int,
             vm_validation_range,
             i,
         )
+        if monitor || bail_on_eig_sign_switch
+            # Refresh the factor on the current J (reuses the cached symbolic;
+            # no second matrix) so κ̂/λ_min match the reported residual. Shared by
+            # the diagnostic log line and the fold bail-out below.
+            numeric_refactor!(linSolveCache, J.Jv)
+        end
+        if monitor
+            prev_F = _log_solver_diagnostics(
+                "NR iter $i", residual, J.data, time_step,
+                linSolveCache, size(J.Jv, 1), prev_F)
+        end
+        if bail_on_eig_sign_switch
+            switched, eig_sign = detect_eig_sign_switch(
+                eig_sign, "NR iter $i", J.data, time_step,
+                linSolveCache, size(J.Jv, 1))
+            switched && return false, i
+        end
         converged = norm(residual.Rv, Inf) < tol
         if !converged
             i += 1
@@ -728,6 +749,7 @@ function _run_power_flow_method(time_step::Int,
     iwamoto_fallback::Bool = DEFAULT_IWAMOTO_FALLBACK,
     validate_voltage_magnitudes::Bool = DEFAULT_VALIDATE_VOLTAGES,
     vm_validation_range::MinMax = DEFAULT_VALIDATION_RANGE,
+    bail_on_eig_sign_switch::Bool = false,
     _ignored...,  # absorb unknown keys from caller without error
 )
     validate_vms = validate_voltage_magnitudes
@@ -752,6 +774,9 @@ function _run_power_flow_method(time_step::Int,
     linf = norm(residual.Rv, Inf)
     @debug "initially: sum of squares $(siground(residualSize)), L ∞ norm $(siground(linf)), Δ $(siground(delta))"
 
+    monitor = get_log_solver_diagnostics(J.data)
+    eig_sign = EigvalSign.UNSEEN  # sign of real(λ_min) last iter, for the fold bail-out
+    prev_F::Float64 = NaN  # previous ‖F‖∞, for the contraction ratio
     while i < maxIterations && !converged
         delta = _trust_region_step(
             time_step,
@@ -771,6 +796,23 @@ function _run_power_flow_method(time_step::Int,
             vm_validation_range,
             i,
         )
+        if monitor || bail_on_eig_sign_switch
+            # Refresh the factor on the current J (reuses the cached symbolic;
+            # no second matrix) so κ̂/λ_min match the reported residual. Shared by
+            # the diagnostic log line and the fold bail-out below.
+            numeric_refactor!(linSolveCache, J.Jv)
+        end
+        if monitor
+            prev_F = _log_solver_diagnostics(
+                "TR iter $i", residual, J.data, time_step,
+                linSolveCache, size(J.Jv, 1), prev_F)
+        end
+        if bail_on_eig_sign_switch
+            switched, eig_sign = detect_eig_sign_switch(
+                eig_sign, "TR iter $i", J.data, time_step,
+                linSolveCache, size(J.Jv, 1))
+            switched && return false, i
+        end
         converged = norm(residual.Rv, Inf) < tol
         if !converged
             i += 1
@@ -859,6 +901,8 @@ function _newton_power_flow(
     eta::Float64 = DEFAULT_TRUST_REGION_ETA,
     autoscale::Bool = DEFAULT_AUTOSCALE,
     iwamoto_fallback::Bool = DEFAULT_IWAMOTO_FALLBACK,
+    # NR and TR: fold / voltage-collapse bail-out (any backend; κ̂ is KLU-only)
+    bail_on_eig_sign_switch::Bool = false,
     # initialize_power_flow_variables
     x0::Union{Vector{Float64}, Nothing} = nothing,
     # linear solver backend, resolved by `PNM.resolve_linear_solver`. Canonical names:
@@ -903,6 +947,7 @@ function _newton_power_flow(
             eta,
             autoscale,
             iwamoto_fallback,
+            bail_on_eig_sign_switch,
         )
         x_final = stateVector.x
     end

--- a/src/power_flow_method.jl
+++ b/src/power_flow_method.jl
@@ -652,15 +652,13 @@ function _run_power_flow_method(time_step::Int,
     validate_voltage_magnitudes::Bool = DEFAULT_VALIDATE_VOLTAGES,
     vm_validation_range::MinMax = DEFAULT_VALIDATION_RANGE,
     iwamoto::Bool = false,
-    bail_on_eig_sign_switch::Bool = false,
+    stop_at_fold::Bool = false,
     _ignored...,  # absorb unknown keys from caller without error
 )
     validate_vms = validate_voltage_magnitudes
     i, converged = 1, false
     consecutive_reverts = 0
-    monitor = get_log_solver_diagnostics(J.data)
-    eig_sign = EigvalSign.UNSEEN  # sign of real(λ_min) last iter, for the fold bail-out
-    prev_F::Float64 = NaN  # previous ‖F‖∞, for the contraction ratio
+    monitor, diag_state = setup_solver_diagnostics(J, stop_at_fold)
     while i < maxIterations && !converged
         if iwamoto
             made_progress = _iwamoto_step(
@@ -698,22 +696,13 @@ function _run_power_flow_method(time_step::Int,
             vm_validation_range,
             i,
         )
-        if monitor || bail_on_eig_sign_switch
-            # Refresh the factor on the current J (reuses the cached symbolic;
-            # no second matrix) so κ̂/λ_min match the reported residual. Shared by
-            # the diagnostic log line and the fold bail-out below.
-            numeric_refactor!(linSolveCache, J.Jv)
-        end
-        if monitor
-            prev_F = _log_solver_diagnostics(
-                "NR iter $i", residual, J.data, time_step,
-                linSolveCache, size(J.Jv, 1), prev_F)
-        end
-        if bail_on_eig_sign_switch
-            switched, eig_sign = detect_eig_sign_switch(
-                eig_sign, "NR iter $i", J.data, time_step,
-                linSolveCache, size(J.Jv, 1))
-            switched && return false, i
+        if !isnothing(diag_state)
+            # After `_simple_step`, J.Jv and residual.Rv are at the same iterate, so
+            # one refactor feeds both the log line and the bail-out.
+            run_solver_diagnostics!(
+                diag_state, "NR iter $i", residual, J, time_step,
+                linSolveCache, monitor, stop_at_fold) &&
+                return false, i
         end
         converged = norm(residual.Rv, Inf) < tol
         if !converged
@@ -749,7 +738,7 @@ function _run_power_flow_method(time_step::Int,
     iwamoto_fallback::Bool = DEFAULT_IWAMOTO_FALLBACK,
     validate_voltage_magnitudes::Bool = DEFAULT_VALIDATE_VOLTAGES,
     vm_validation_range::MinMax = DEFAULT_VALIDATION_RANGE,
-    bail_on_eig_sign_switch::Bool = false,
+    stop_at_fold::Bool = false,
     _ignored...,  # absorb unknown keys from caller without error
 )
     validate_vms = validate_voltage_magnitudes
@@ -774,9 +763,7 @@ function _run_power_flow_method(time_step::Int,
     linf = norm(residual.Rv, Inf)
     @debug "initially: sum of squares $(siground(residualSize)), L ∞ norm $(siground(linf)), Δ $(siground(delta))"
 
-    monitor = get_log_solver_diagnostics(J.data)
-    eig_sign = EigvalSign.UNSEEN  # sign of real(λ_min) last iter, for the fold bail-out
-    prev_F::Float64 = NaN  # previous ‖F‖∞, for the contraction ratio
+    monitor, diag_state = setup_solver_diagnostics(J, stop_at_fold)
     while i < maxIterations && !converged
         delta = _trust_region_step(
             time_step,
@@ -796,22 +783,13 @@ function _run_power_flow_method(time_step::Int,
             vm_validation_range,
             i,
         )
-        if monitor || bail_on_eig_sign_switch
-            # Refresh the factor on the current J (reuses the cached symbolic;
-            # no second matrix) so κ̂/λ_min match the reported residual. Shared by
-            # the diagnostic log line and the fold bail-out below.
-            numeric_refactor!(linSolveCache, J.Jv)
-        end
-        if monitor
-            prev_F = _log_solver_diagnostics(
-                "TR iter $i", residual, J.data, time_step,
-                linSolveCache, size(J.Jv, 1), prev_F)
-        end
-        if bail_on_eig_sign_switch
-            switched, eig_sign = detect_eig_sign_switch(
-                eig_sign, "TR iter $i", J.data, time_step,
-                linSolveCache, size(J.Jv, 1))
-            switched && return false, i
+        if !isnothing(diag_state)
+            # After `_trust_region_step` (incl. reject and iwamoto-fallback), J.Jv and
+            # residual.Rv are at the same iterate, so one refactor feeds both.
+            run_solver_diagnostics!(
+                diag_state, "TR iter $i", residual, J, time_step,
+                linSolveCache, monitor, stop_at_fold) &&
+                return false, i
         end
         converged = norm(residual.Rv, Inf) < tol
         if !converged
@@ -902,7 +880,7 @@ function _newton_power_flow(
     autoscale::Bool = DEFAULT_AUTOSCALE,
     iwamoto_fallback::Bool = DEFAULT_IWAMOTO_FALLBACK,
     # NR and TR: fold / voltage-collapse bail-out (any backend; κ̂ is KLU-only)
-    bail_on_eig_sign_switch::Bool = false,
+    stop_at_fold::Bool = false,
     # initialize_power_flow_variables
     x0::Union{Vector{Float64}, Nothing} = nothing,
     # linear solver backend, resolved by `PNM.resolve_linear_solver`. Canonical names:
@@ -947,7 +925,7 @@ function _newton_power_flow(
             eta,
             autoscale,
             iwamoto_fallback,
-            bail_on_eig_sign_switch,
+            stop_at_fold,
         )
         x_final = stateVector.x
     end

--- a/src/power_flow_types.jl
+++ b/src/power_flow_types.jl
@@ -154,6 +154,7 @@ struct ACPolarPowerFlow{ACSolver <: ACPowerFlowSolverType} <: AbstractACPowerFlo
     exporter::Union{Nothing, PowerFlowEvaluationModel}
     calculate_loss_factors::Bool
     calculate_voltage_stability_factors::Bool
+    log_solver_diagnostics::Bool
     generator_slack_participation_factors::Union{
         Nothing,
         Dict{Tuple{DataType, String}, Float64},
@@ -208,6 +209,7 @@ function ACPolarPowerFlow{ACSolver}(;
     exporter::Union{Nothing, PowerFlowEvaluationModel} = nothing,
     calculate_loss_factors::Bool = false,
     calculate_voltage_stability_factors::Bool = false,
+    log_solver_diagnostics::Bool = false,
     generator_slack_participation_factors::Union{
         Nothing,
         Dict{Tuple{DataType, String}, Float64},
@@ -237,6 +239,7 @@ function ACPolarPowerFlow{ACSolver}(;
         exporter,
         calculate_loss_factors,
         calculate_voltage_stability_factors,
+        log_solver_diagnostics,
         generator_slack_participation_factors,
         enhanced_flat_start,
         robust_power_flow,
@@ -278,6 +281,11 @@ get_calculate_loss_factors(pf::ACPolarPowerFlow) = pf.calculate_loss_factors
 get_calculate_voltage_stability_factors(::AbstractACPowerFlow) = false
 get_calculate_voltage_stability_factors(pf::ACPolarPowerFlow) =
     pf.calculate_voltage_stability_factors
+# Available on every AC formulation: the per-iteration ‖F‖/κ̂(J)/λ_min diagnostic
+# needs only the Jacobian (1st derivatives), so it works for polar, rectangular-CI,
+# and mixed-CPB, with or without LCC.
+get_log_solver_diagnostics(::PowerFlowEvaluationModel) = false
+get_log_solver_diagnostics(pf::AbstractACPowerFlow) = pf.log_solver_diagnostics
 
 """
     ACRectangularPowerFlow{ACSolver}(; kwargs...) where {ACSolver <: ACPowerFlowSolverType}
@@ -325,6 +333,7 @@ struct ACRectangularPowerFlow{ACSolver <: ACPowerFlowSolverType} <:
         Vector{Dict{Tuple{DataType, String}, Float64}},
     }
     enhanced_flat_start::Bool
+    log_solver_diagnostics::Bool
     skip_redistribution::Bool
     distribute_slack_proportional_to_headroom::Bool
     network_reductions::Vector{PNM.NetworkReduction}
@@ -343,6 +352,7 @@ function ACRectangularPowerFlow{ACSolver}(;
         Vector{Dict{Tuple{DataType, String}, Float64}},
     } = nothing,
     enhanced_flat_start::Bool = true,
+    log_solver_diagnostics::Bool = false,
     skip_redistribution::Bool = false,
     distribute_slack_proportional_to_headroom::Bool = false,
     network_reductions::Vector{PNM.NetworkReduction} = PNM.NetworkReduction[],
@@ -375,6 +385,7 @@ function ACRectangularPowerFlow{ACSolver}(;
         exporter,
         generator_slack_participation_factors,
         enhanced_flat_start,
+        log_solver_diagnostics,
         skip_redistribution,
         distribute_slack_proportional_to_headroom,
         network_reductions,
@@ -434,6 +445,7 @@ struct ACMixedPowerFlow{ACSolver <: ACPowerFlowSolverType} <:
         Vector{Dict{Tuple{DataType, String}, Float64}},
     }
     enhanced_flat_start::Bool
+    log_solver_diagnostics::Bool
     skip_redistribution::Bool
     distribute_slack_proportional_to_headroom::Bool
     network_reductions::Vector{PNM.NetworkReduction}
@@ -452,6 +464,7 @@ function ACMixedPowerFlow{ACSolver}(;
         Vector{Dict{Tuple{DataType, String}, Float64}},
     } = nothing,
     enhanced_flat_start::Bool = true,
+    log_solver_diagnostics::Bool = false,
     skip_redistribution::Bool = false,
     distribute_slack_proportional_to_headroom::Bool = false,
     network_reductions::Vector{PNM.NetworkReduction} = PNM.NetworkReduction[],
@@ -485,6 +498,7 @@ function ACMixedPowerFlow{ACSolver}(;
         exporter,
         generator_slack_participation_factors,
         enhanced_flat_start,
+        log_solver_diagnostics,
         skip_redistribution,
         distribute_slack_proportional_to_headroom,
         network_reductions,

--- a/src/power_flow_types.jl
+++ b/src/power_flow_types.jl
@@ -281,9 +281,7 @@ get_calculate_loss_factors(pf::ACPolarPowerFlow) = pf.calculate_loss_factors
 get_calculate_voltage_stability_factors(::AbstractACPowerFlow) = false
 get_calculate_voltage_stability_factors(pf::ACPolarPowerFlow) =
     pf.calculate_voltage_stability_factors
-# Available on every AC formulation: the per-iteration ‖F‖/κ̂(J)/λ_min diagnostic
-# needs only the Jacobian (1st derivatives), so it works for polar, rectangular-CI,
-# and mixed-CPB, with or without LCC.
+# Works on every AC formulation: the diagnostic needs only J (1st derivatives).
 get_log_solver_diagnostics(::PowerFlowEvaluationModel) = false
 get_log_solver_diagnostics(pf::AbstractACPowerFlow) = pf.log_solver_diagnostics
 

--- a/src/residual_condition_diagnostics.jl
+++ b/src/residual_condition_diagnostics.jl
@@ -1,0 +1,227 @@
+#=
+Per-iteration solver diagnostics, enabled by the `log_solver_diagnostics` flag.
+Each line reports the residual infinity norm ‖F‖∞ (and the bus/equation where it
+is attained), a condition estimate κ̂(J), the Jacobian eigenvalue closest to the
+origin, and the observed residual contraction ratio ‖Fₖ‖/‖Fₖ₋₁‖.
+
+The eigenvalue is computed on the bus-voltage Schur complement S = A − B·D⁻¹·C,
+where the Jacobian is blocked as J = [A B; C D] with the LCC tail (4·n_lcc rows
+and columns) in the trailing block. The (1,1) block of J⁻¹ is exactly S⁻¹, so the
+matvec v ↦ (J⁻¹·[v; 0])[1:nb] applies S⁻¹ using the *existing* factorization of
+the full J — no second matrix, no second factorization. When there are no LCCs,
+S = J and the matvec is a plain J⁻¹ back-solve.
+=#
+
+"""Applies the bus-voltage Schur inverse `S⁻¹` to a vector by back-solving against
+an existing factorization of the full Jacobian `J`: it pads the input with zeros
+in the LCC-tail slots, applies `J⁻¹` in place via [`_apply_Jinv!`](@ref), and
+returns the leading `n_bus` block."""
+struct SchurInverseOperator{C}
+    cache::C                  # factorization of the full J; see _apply_Jinv!
+    n_bus::Int                # size of the leading bus-voltage block
+    buffer::Vector{Float64}   # length = full state; reused as the padded RHS
+end
+
+"""Apply `J⁻¹` to `b` in place by back-solving against the cached factorization."""
+_apply_Jinv!(cache::PFLinearSolverCache, b::Vector{Float64}) = solve!(cache, b)
+
+# PERF: LAPACK's dlacn2 would be the drop-in replacement, but Julia doesn't expose it.
+"""Condition estimate κ̂(J), or `NaN` when the backend doesn't expose one."""
+_diag_condest(cache::PNM.KLULinSolveCache) = condest!(cache)
+_diag_condest(::PFLinearSolverCache) = NaN
+
+function (op::SchurInverseOperator)(v::AbstractVector{Float64})
+    b = op.buffer
+    @inbounds begin
+        copyto!(view(b, 1:(op.n_bus)), v)
+        fill!(view(b, (op.n_bus + 1):length(b)), 0.0)
+    end
+    _apply_Jinv!(op.cache, b)
+    # KrylovKit stores each returned vector, so hand back a fresh copy of the
+    # bus block rather than the reused buffer.
+    return b[1:(op.n_bus)]
+end
+
+"""Smallest-magnitude eigenvalue of the bus-voltage Schur complement `S`, by
+inverse iteration: KrylovKit finds the largest-magnitude eigenvalue `μ` of `S⁻¹`
+(applied by `op`) and we return `1/μ`. `S` is non-symmetric, so the result may be
+complex."""
+function _schur_min_eigenvalue(
+    op::SchurInverseOperator;
+    tol::Float64 = 1e-6,
+    maxiter::Int = 200,
+    krylovdim::Int = 30,
+)
+    n = op.n_bus
+    v0 = fill(1.0 / sqrt(n), n)   # deterministic init for reproducible logs
+    vals, _, _ = KrylovKit.eigsolve(op, v0, 1, :LM; tol, maxiter, krylovdim)
+    return isempty(vals) ? complex(NaN, NaN) : inv(vals[1])
+end
+
+"""Format a (possibly complex) eigenvalue to 4 significant figures as `a` or
+`a ± b im`."""
+function _fmt_eig(z::Number, sf)
+    iz = imag(z)
+    return if iz == 0
+        "$(sf(real(z)))"
+    else
+        "$(sf(real(z))) $(iz < 0 ? "-" : "+") $(sf(abs(iz)))im"
+    end
+end
+
+"""The system bus number for the `bus_ix`-th bus (reduced ordering)."""
+_diag_bus_number(data::ACPowerFlowData, bus_ix::Int) =
+    axes(data.power_network_matrix, 1)[bus_ix]
+
+const _LCC_RESIDUAL_ROW_NAMES =
+    ("P-setpoint", "DC-line balance", "rectifier α-limit", "inverter α-limit")
+
+"""Describe a residual entry that falls in the LCC tail (4 rows per LCC)."""
+function _describe_lcc_residual_entry(data::ACPowerFlowData, tail_ix::Int)
+    i = div(tail_ix - 1, 4) + 1
+    row = mod1(tail_ix, 4)
+    from_no, to_no = data.lcc.arcs[i]
+    return "LCC $(from_no)→$(to_no) ($(_LCC_RESIDUAL_ROW_NAMES[row]))"
+end
+
+"""`(bus index, 1-based row within that bus's block)` for variable-block
+formulations, from the `bus_state_offset` table."""
+function _locate_variable_block(offsets::AbstractVector, ix::Int)
+    b = searchsortedlast(offsets, ix)
+    return b, ix - Int(offsets[b]) + 1
+end
+
+# Formulation-aware label for the entry where ‖F‖∞ is attained. The bus block is
+# laid out first, the LCC tail last, in every formulation.
+function _describe_residual_entry(
+    ::ACPowerFlowResidual,
+    data::ACPowerFlowData,
+    time_step::Int,
+    ix::Int,
+)
+    n_bus_eqs = 2 * size(data.bus_type, 1)
+    if ix <= n_bus_eqs
+        bus_ix = div(ix - 1, 2) + 1
+        return "bus $(_diag_bus_number(data, bus_ix)) ($(isodd(ix) ? "P" : "Q"))"
+    end
+    return _describe_lcc_residual_entry(data, ix - n_bus_eqs)
+end
+
+function _describe_residual_entry(
+    r::ACRectangularCIResidual,
+    data::ACPowerFlowData,
+    ::Int,
+    ix::Int,
+)
+    if ix <= r.total_bus_state
+        b, row = _locate_variable_block(r.bus_state_offset, ix)
+        labels = ("ΔI_re", "ΔI_im", "|V|²−V_set²")   # PV uses the 3rd row
+        return "bus $(_diag_bus_number(data, b)) ($(labels[row]))"
+    end
+    return _describe_lcc_residual_entry(data, ix - r.total_bus_state)
+end
+
+function _describe_residual_entry(
+    r::ACMixedCPBResidual,
+    data::ACPowerFlowData,
+    time_step::Int,
+    ix::Int,
+)
+    if ix <= r.total_bus_state
+        b, row = _locate_variable_block(r.bus_state_offset, ix)
+        bt = data.bus_type[b, time_step]
+        labels = if bt == PSY.ACBusTypes.PV
+            ("ΔP", "|V|²−V_set²")
+        elseif bt == PSY.ACBusTypes.PQ
+            ("ΔI_im", "ΔI_re")
+        else  # REF
+            ("ΔI_re", "ΔI_im")
+        end
+        return "bus $(_diag_bus_number(data, b)) ($(labels[row]))"
+    end
+    return _describe_lcc_residual_entry(data, ix - r.total_bus_state)
+end
+
+"""Compute and `@info`-log one per-iteration diagnostic line. `cache` must hold
+the current factorization of the Jacobian `J`. Reports ‖F‖∞ and where it is attained,
+κ̂(J) [or n/a], λ_min of the bus-voltage Schur complement, and the contraction ratio
+relative to `prev_F_inf`. Returns the current ‖F‖∞ so the caller can carry it forward.
+All numerics are rounded to 4 significant figures."""
+function _log_solver_diagnostics(
+    label::AbstractString,
+    residual,
+    data::ACPowerFlowData,
+    time_step::Int,
+    cache::PFLinearSolverCache,
+    n_state::Int,
+    prev_F_inf::Float64,
+)
+    n_lcc = size(data.lcc.p_set, 1)
+    n_bus = n_state - 4 * n_lcc
+    abs_max, ix = findmax(abs, residual.Rv)
+
+    κ = _diag_condest(cache)
+    op = SchurInverseOperator(cache, n_bus, Vector{Float64}(undef, n_state))
+    λ_min = _schur_min_eigenvalue(op)
+
+    sf(x) = round(x; sigdigits = 4)
+    parts = [
+        "‖F‖_∞ = $(sf(abs_max)) at " *
+        "$(_describe_residual_entry(residual, data, time_step, ix))",
+        "κ̂(J) = $(isnan(κ) ? "n/a (KLU-only)" : string(sf(κ)))",
+        "λ_min(S) = $(_fmt_eig(λ_min, sf)) (|λ_min| = $(sf(abs(λ_min))))",
+    ]
+    if !isnan(prev_F_inf) && prev_F_inf > 0
+        push!(parts, "contraction = $(sf(abs_max / prev_F_inf))")
+    end
+    @info "$label: " * join(parts, ", ")
+    return abs_max
+end
+
+# ---------------------------------------------------------------------------
+# Fold / voltage-collapse bail-out: stop the search when the Jacobian's
+# eigenvalue closest to the origin switches sign across an iteration.
+# ---------------------------------------------------------------------------
+
+# `UNSEEN` is the pre-first-observation state
+# zero real part (essentially never, in floating point) just keeps the prior sign.
+IS.@scoped_enum(EigvalSign, UNSEEN = 0, NEGATIVE = -1, POSITIVE = 1)
+
+"""
+    detect_eig_sign_switch(prev, label, data, time_step, cache, n_state)
+        -> (switched::Bool, current::EigvalSign)
+
+Given an up-to-date factorization `cache` of the Jacobian, compute `λ_min` of
+the bus-voltage Schur complement and decide whether the sign of its real part has
+flipped since the previous iteration's sign `prev`.
+
+On a switch this logs a warning so the caller can abort the search. Returns
+`(switched, current_sign))`. Assumes `cache` has been numerically factored already."""
+function detect_eig_sign_switch(
+    prev::EigvalSign,
+    label::AbstractString,
+    data::ACPowerFlowData,
+    ::Int,
+    cache::PFLinearSolverCache,
+    n_state::Int,
+)
+    n_lcc = size(data.lcc.p_set, 1)
+    n_bus = n_state - 4 * n_lcc
+    op = SchurInverseOperator(cache, n_bus, Vector{Float64}(undef, n_state))
+    λ_min = _schur_min_eigenvalue(op)
+    s = real(λ_min)
+    # exact 0: keep prior sign
+    current = s > 0 ? EigvalSign.POSITIVE : (s < 0 ? EigvalSign.NEGATIVE : prev)
+
+    # A switch needs a real, previously-seen sign that differs from the new one.
+    switched = prev != EigvalSign.UNSEEN && current != prev
+    switched || return false, current
+
+    sf(x) = round(x; sigdigits = 4)
+    @warn "$label: λ_min(S) real part switched sign " *
+          "($(prev == EigvalSign.POSITIVE ? "+" : "−") → " *
+          "$(current == EigvalSign.POSITIVE ? "+" : "−")), " *
+          "λ_min = $(_fmt_eig(λ_min, sf)). This is a fold / voltage-collapse " *
+          "signature; aborting the search."
+    return true, current
+end

--- a/src/residual_condition_diagnostics.jl
+++ b/src/residual_condition_diagnostics.jl
@@ -1,34 +1,31 @@
 #=
-Per-iteration solver diagnostics, enabled by the `log_solver_diagnostics` flag.
-Each line reports the residual infinity norm ‖F‖∞ (and the bus/equation where it
-is attained), a condition estimate κ̂(J), the Jacobian eigenvalue closest to the
-origin, and the observed residual contraction ratio ‖Fₖ‖/‖Fₖ₋₁‖.
+Per-iteration solver diagnostics (`log_solver_diagnostics`) and a fold /
+voltage-collapse bail-out (`stop_at_fold`).
 
-The eigenvalue is computed on the bus-voltage Schur complement S = A − B·D⁻¹·C,
-where the Jacobian is blocked as J = [A B; C D] with the LCC tail (4·n_lcc rows
-and columns) in the trailing block. The (1,1) block of J⁻¹ is exactly S⁻¹, so the
-matvec v ↦ (J⁻¹·[v; 0])[1:nb] applies S⁻¹ using the *existing* factorization of
-the full J — no second matrix, no second factorization. When there are no LCCs,
-S = J and the matvec is a plain J⁻¹ back-solve.
+λ_min is taken on the bus-voltage Schur complement S = A − B·D⁻¹·C of the blocked
+Jacobian J = [A B; C D], whose LCC tail (4·n_lcc rows/cols) is the trailing block.
+The (1,1) block of J⁻¹ is exactly S⁻¹, so v ↦ (J⁻¹·[v; 0])[1:nb] applies S⁻¹ from
+the *existing* factorization of J — no second matrix or factorization. With no
+LCCs, S = J. The monitor line and the bail-out share one refactor and one
+eigensolve via `run_solver_diagnostics!`.
 =#
 
-"""Applies the bus-voltage Schur inverse `S⁻¹` to a vector by back-solving against
-an existing factorization of the full Jacobian `J`: it pads the input with zeros
-in the LCC-tail slots, applies `J⁻¹` in place via [`_apply_Jinv!`](@ref), and
-returns the leading `n_bus` block."""
+"""Round to 4 significant figures (one more digit than `siground`'s 3)."""
+_sf4(x) = round(x; sigdigits = 4)
+
+"""Applies S⁻¹ via a back-solve of the full `J`: pads `v` with zeros in the
+LCC-tail slots, applies `J⁻¹`, returns the leading `n_bus` block."""
 struct SchurInverseOperator{C}
-    cache::C                  # factorization of the full J; see _apply_Jinv!
-    n_bus::Int                # size of the leading bus-voltage block
-    buffer::Vector{Float64}   # length = full state; reused as the padded RHS
+    cache::C
+    n_bus::Int
+    buffer::Vector{Float64}   # padded RHS, length = full state
 end
 
-"""Apply `J⁻¹` to `b` in place by back-solving against the cached factorization."""
-_apply_Jinv!(cache::PFLinearSolverCache, b::Vector{Float64}) = solve!(cache, b)
-
-# PERF: LAPACK's dlacn2 would be the drop-in replacement, but Julia doesn't expose it.
-"""Condition estimate κ̂(J), or `NaN` when the backend doesn't expose one."""
+"""Condition estimate κ̂(J), or `NaN` when the backend exposes none. The NaN
+fallback is restricted to the non-KLU `PFLinearSolverCache` members so the concrete
+`KLULinSolveCache` doesn't shadow the KLU method onto the NaN path."""
 _diag_condest(cache::PNM.KLULinSolveCache) = condest!(cache)
-_diag_condest(::PFLinearSolverCache) = NaN
+_diag_condest(::Union{PNM.AAFactorCache, PardisoLinSolveCache}) = NaN
 
 function (op::SchurInverseOperator)(v::AbstractVector{Float64})
     b = op.buffer
@@ -36,36 +33,45 @@ function (op::SchurInverseOperator)(v::AbstractVector{Float64})
         copyto!(view(b, 1:(op.n_bus)), v)
         fill!(view(b, (op.n_bus + 1):length(b)), 0.0)
     end
-    _apply_Jinv!(op.cache, b)
+    solve!(op.cache, b)
     # KrylovKit stores each returned vector, so hand back a fresh copy of the
     # bus block rather than the reused buffer.
     return b[1:(op.n_bus)]
 end
 
-"""Smallest-magnitude eigenvalue of the bus-voltage Schur complement `S`, by
-inverse iteration: KrylovKit finds the largest-magnitude eigenvalue `μ` of `S⁻¹`
-(applied by `op`) and we return `1/μ`. `S` is non-symmetric, so the result may be
-complex."""
+"""Smallest-magnitude eigenvalue of the Schur complement `S` by inverse iteration:
+KrylovKit finds the largest-magnitude eigenvalue `μ` of `S⁻¹` and returns `1/μ`.
+`S` is non-symmetric, so the result may be complex. Returns `(λ_min, converged)`,
+with `converged = false` (and `λ_min = NaN ± NaN im`) on any failure."""
 function _schur_min_eigenvalue(
     op::SchurInverseOperator;
     tol::Float64 = 1e-6,
     maxiter::Int = 200,
     krylovdim::Int = 30,
-)
+)::Tuple{ComplexF64, Bool}
     n = op.n_bus
     v0 = fill(1.0 / sqrt(n), n)   # deterministic init for reproducible logs
-    vals, _, _ = KrylovKit.eigsolve(op, v0, 1, :LM; tol, maxiter, krylovdim)
-    return isempty(vals) ? complex(NaN, NaN) : inv(vals[1])
+    vals, _, info = KrylovKit.eigsolve(op, v0, 1, :LM; tol, maxiter, krylovdim)
+    if info.converged < 1 || isempty(vals)
+        return complex(NaN, NaN), false
+    end
+    μ = vals[1]
+    # A (near-)zero dominant eigenvalue of S⁻¹ makes 1/μ overflow; treat it as
+    # not-converged rather than reporting an Inf eigenvalue of S.
+    if abs(μ) <= eps(Float64)
+        return complex(NaN, NaN), false
+    end
+    return inv(ComplexF64(μ)), true
 end
 
 """Format a (possibly complex) eigenvalue to 4 significant figures as `a` or
 `a ± b im`."""
-function _fmt_eig(z::Number, sf)
+function _fmt_eig(z::Number)
     iz = imag(z)
     return if iz == 0
-        "$(sf(real(z)))"
+        "$(_sf4(real(z)))"
     else
-        "$(sf(real(z))) $(iz < 0 ? "-" : "+") $(sf(abs(iz)))im"
+        "$(_sf4(real(z))) $(iz < 0 ? "-" : "+") $(_sf4(abs(iz)))im"
     end
 end
 
@@ -142,86 +148,142 @@ function _describe_residual_entry(
     return _describe_lcc_residual_entry(data, ix - r.total_bus_state)
 end
 
-"""Compute and `@info`-log one per-iteration diagnostic line. `cache` must hold
-the current factorization of the Jacobian `J`. Reports ‖F‖∞ and where it is attained,
-κ̂(J) [or n/a], λ_min of the bus-voltage Schur complement, and the contraction ratio
-relative to `prev_F_inf`. Returns the current ‖F‖∞ so the caller can carry it forward.
-All numerics are rounded to 4 significant figures."""
-function _log_solver_diagnostics(
-    label::AbstractString,
-    residual,
-    data::ACPowerFlowData,
-    time_step::Int,
-    cache::PFLinearSolverCache,
-    n_state::Int,
-    prev_F_inf::Float64,
-)
-    n_lcc = size(data.lcc.p_set, 1)
-    n_bus = n_state - 4 * n_lcc
-    abs_max, ix = findmax(abs, residual.Rv)
-
-    κ = _diag_condest(cache)
-    op = SchurInverseOperator(cache, n_bus, Vector{Float64}(undef, n_state))
-    λ_min = _schur_min_eigenvalue(op)
-
-    sf(x) = round(x; sigdigits = 4)
-    parts = [
-        "‖F‖_∞ = $(sf(abs_max)) at " *
-        "$(_describe_residual_entry(residual, data, time_step, ix))",
-        "κ̂(J) = $(isnan(κ) ? "n/a (KLU-only)" : string(sf(κ)))",
-        "λ_min(S) = $(_fmt_eig(λ_min, sf)) (|λ_min| = $(sf(abs(λ_min))))",
-    ]
-    if !isnan(prev_F_inf) && prev_F_inf > 0
-        push!(parts, "contraction = $(sf(abs_max / prev_F_inf))")
-    end
-    @info "$label: " * join(parts, ", ")
-    return abs_max
-end
-
 # ---------------------------------------------------------------------------
-# Fold / voltage-collapse bail-out: stop the search when the Jacobian's
-# eigenvalue closest to the origin switches sign across an iteration.
+# Fold / voltage-collapse bail-out state and the shared per-iteration hook.
 # ---------------------------------------------------------------------------
 
-# `UNSEEN` is the pre-first-observation state
-# zero real part (essentially never, in floating point) just keeps the prior sign.
+# UNSEEN = pre-first-observation. A non-finite/non-converged λ_min is deliberately
+# not a sign here; the bail decision treats it as a conservative abort.
 IS.@scoped_enum(EigvalSign, UNSEEN = 0, NEGATIVE = -1, POSITIVE = 1)
 
-"""
-    detect_eig_sign_switch(prev, label, data, time_step, cache, n_state)
-        -> (switched::Bool, current::EigvalSign)
+"""Per-solve scratch for [`run_solver_diagnostics!`](@ref): previous ‖F‖∞ (`prev_F`),
+last-seen sign of `real(λ_min)` (`eig_sign`), and a reusable padded RHS (`buffer`) so
+the Schur operator allocates nothing per iteration."""
+mutable struct SolverDiagnosticsState
+    prev_F::Float64
+    eig_sign::EigvalSign
+    buffer::Vector{Float64}
+end
 
-Given an up-to-date factorization `cache` of the Jacobian, compute `λ_min` of
-the bus-voltage Schur complement and decide whether the sign of its real part has
-flipped since the previous iteration's sign `prev`.
+SolverDiagnosticsState(n_state::Int) =
+    SolverDiagnosticsState(NaN, EigvalSign.UNSEEN, Vector{Float64}(undef, n_state))
 
-On a switch this logs a warning so the caller can abort the search. Returns
-`(switched, current_sign))`. Assumes `cache` has been numerically factored already."""
-function detect_eig_sign_switch(
-    prev::EigvalSign,
-    label::AbstractString,
-    data::ACPowerFlowData,
-    ::Int,
-    cache::PFLinearSolverCache,
-    n_state::Int,
+"""Set up a solver loop's diagnostics: returns `(monitor, diag_state)`, allocating
+the scratch only when a diagnostic or the bail-out is on so the default solve path
+allocates nothing. `diag_state` is `nothing` when neither is requested."""
+function setup_solver_diagnostics(
+    J::Union{ACPowerFlowJacobian, ACRectangularCIJacobian, ACMixedCPBJacobian},
+    bail::Bool,
 )
-    n_lcc = size(data.lcc.p_set, 1)
-    n_bus = n_state - 4 * n_lcc
-    op = SchurInverseOperator(cache, n_bus, Vector{Float64}(undef, n_state))
-    λ_min = _schur_min_eigenvalue(op)
+    monitor = get_log_solver_diagnostics(J.data)
+    diag_state = (monitor || bail) ? SolverDiagnosticsState(size(J.Jv, 1)) : nothing
+    return monitor, diag_state
+end
+
+"""Update `state.eig_sign` from `λ_min` and decide the fold bail-out. A non-converged
+or non-finite `real(λ_min)` is a conservative bail (warn + abort), never a silent
+no-op. An exact-zero real part keeps the prior sign. Returns `true` to abort."""
+function _decide_eig_sign_switch!(
+    state::SolverDiagnosticsState,
+    label::AbstractString,
+    λ_min::ComplexF64,
+    converged::Bool,
+)::Bool
     s = real(λ_min)
-    # exact 0: keep prior sign
+    if !converged || !isfinite(s)
+        @warn "$label: λ_min(S) is indeterminate " *
+              "(converged = $converged, λ_min = $(_fmt_eig(λ_min))); treating it as " *
+              "a fold / voltage-collapse signature and aborting the search."
+        return true
+    end
+    prev = state.eig_sign
     current = s > 0 ? EigvalSign.POSITIVE : (s < 0 ? EigvalSign.NEGATIVE : prev)
+    state.eig_sign = current
 
     # A switch needs a real, previously-seen sign that differs from the new one.
     switched = prev != EigvalSign.UNSEEN && current != prev
-    switched || return false, current
+    switched || return false
 
-    sf(x) = round(x; sigdigits = 4)
     @warn "$label: λ_min(S) real part switched sign " *
           "($(prev == EigvalSign.POSITIVE ? "+" : "−") → " *
           "$(current == EigvalSign.POSITIVE ? "+" : "−")), " *
-          "λ_min = $(_fmt_eig(λ_min, sf)). This is a fold / voltage-collapse " *
+          "λ_min = $(_fmt_eig(λ_min)). This is a fold / voltage-collapse " *
           "signature; aborting the search."
-    return true, current
+    return true
+end
+
+"""Run one iteration's diagnostics against the current `J`/residual. Does the
+*single* per-iteration refactor of `cache` on `J.Jv` (NR/TR pass `linSolveCache`, LM
+its own KLU `diag_cache`) and, on success, the *single* eigensolve shared by the
+monitor line (`monitor`) and the fold bail-out (`bail`). Returns `true` iff the
+caller should abort. A `SingularException` is itself a fold signature: under `bail`
+it aborts, under monitor-only it reports `singular` and continues; any other
+exception is rethrown."""
+function run_solver_diagnostics!(
+    state::SolverDiagnosticsState,
+    label::AbstractString,
+    residual::Union{ACPowerFlowResidual, ACRectangularCIResidual, ACMixedCPBResidual},
+    J::Union{ACPowerFlowJacobian, ACRectangularCIJacobian, ACMixedCPBJacobian},
+    time_step::Int,
+    cache::PFLinearSolverCache,
+    monitor::Bool,
+    bail::Bool,
+)::Bool
+    # KLU throws `SingularException` on a singular J; AppleAccelerate does not (it
+    # silently returns garbage but still factors), so only KLU reaches the catch.
+    singular = false
+    try
+        numeric_refactor!(cache, J.Jv)
+    catch e
+        e isa LinearAlgebra.SingularException || rethrow()
+        singular = true
+    end
+
+    data = J.data
+    if singular
+        if bail
+            @warn "$label: the Jacobian is singular; this is a fold / " *
+                  "voltage-collapse signature, aborting the search."
+            return true
+        end
+        # Monitor-only: report the singularity rather than crashing, and leave
+        # `state.prev_F` untouched so the next contraction ratio is meaningful.
+        abs_max, ix = findmax(abs, residual.Rv)
+        @info "$label: ‖F‖_∞ = $(_sf4(abs_max)) at " *
+              "$(_describe_residual_entry(residual, data, time_step, ix)), " *
+              "κ̂(J) = singular, λ_min(S) = singular"
+        return false
+    end
+
+    n_lcc = size(data.lcc.p_set, 1)
+    n_state = size(J.Jv, 1)
+    n_bus = n_state - 4 * n_lcc
+    op = SchurInverseOperator(cache, n_bus, state.buffer)
+    λ_min, converged = _schur_min_eigenvalue(op)
+
+    if monitor
+        abs_max, ix = findmax(abs, residual.Rv)
+        κ = _diag_condest(cache)
+        λ_str = if converged
+            "$(_fmt_eig(λ_min)) (|λ_min| = $(_sf4(abs(λ_min))))"
+        else
+            "not-converged"
+        end
+        parts = [
+            "‖F‖_∞ = $(_sf4(abs_max)) at " *
+            "$(_describe_residual_entry(residual, data, time_step, ix))",
+            "κ̂(J) = $(isnan(κ) ? "n/a (KLU-only)" : string(_sf4(κ)))",
+            "λ_min(S) = $λ_str",
+        ]
+        if !isnan(state.prev_F) && state.prev_F > 0
+            push!(parts, "contraction = $(_sf4(abs_max / state.prev_F))")
+        end
+        @info "$label: " * join(parts, ", ")
+        state.prev_F = abs_max
+    end
+
+    if bail
+        return _decide_eig_sign_switch!(state, label, λ_min, converged)
+    end
+    return false
 end

--- a/test/PowerFlowsTests.jl
+++ b/test/PowerFlowsTests.jl
@@ -1,6 +1,7 @@
 module PowerFlowsTests
 
 using ReTest
+import Test  # for Test.TestLogger (ReTest re-exports macros but not the module)
 using PowerFlows
 using Logging
 using Dates

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -28,3 +28,8 @@ TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 [compat]
 julia = "^1.10"
 PowerNetworkMatrices = "^0.23"
+
+# Mirror the root project: pull PNM from the branch carrying the condest!/rcond!
+# re-export until it lands in a tagged release, so the test env resolves on CI.
+[sources]
+PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl", rev = "lk/expose-klu-condest"}

--- a/test/test_residual_condition_diagnostics.jl
+++ b/test/test_residual_condition_diagnostics.jl
@@ -24,7 +24,8 @@ function _schur_eig_and_truth(pf, sys; time_step = 1, backend = PNM.KLUSolver())
     n_lcc = size(data.lcc.p_set, 1)
     n_bus = n_state - 4 * n_lcc
     op = PF.SchurInverseOperator(cache, n_bus, Vector{Float64}(undef, n_state))
-    λ = PF._schur_min_eigenvalue(op)
+    λ, converged = PF._schur_min_eigenvalue(op)
+    @test converged
 
     Jinv = inv(Matrix(jac.Jv))
     S = inv(Jinv[1:n_bus, 1:n_bus])
@@ -92,6 +93,10 @@ end
             @test occursin("κ̂(J) = ", line)
             @test occursin("λ_min(S) = ", line)
             @test occursin(r"at bus \d+", line)
+            # Under KLU, κ̂ must be a real number, never the n/a fallback — guards
+            # against the _diag_condest dispatch silently routing KLU to NaN.
+            @test occursin(r"κ̂\(J\) = [0-9]", line)
+            @test !occursin("κ̂(J) = n/a", line)
         end
         # The contraction ratio appears from the second logged iteration onward.
         @test any(l -> occursin("contraction = ", l), lines)
@@ -141,14 +146,14 @@ end
     end
 end
 
-@testset "bail_on_eig_sign_switch returns without erroring on a well-conditioned case" begin
+@testset "stop_at_fold returns without erroring on a well-conditioned case" begin
     # c_sys14 converges with a stable-sign Jacobian, so the bail-out never fires;
-    # this just exercises the plumbing (kwarg → loop → detect_eig_sign_switch).
+    # this just exercises the plumbing (kwarg → loop → run_solver_diagnostics!).
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
     for solver in (NewtonRaphsonACPowerFlow, TrustRegionACPowerFlow)
         pf = ACPowerFlow{solver}(; correct_bustypes = true,
             solver_settings = Dict{Symbol, Any}(
-                :linear_solver => "KLU", :bail_on_eig_sign_switch => true))
+                :linear_solver => "KLU", :stop_at_fold => true))
         data = PowerFlowData(pf, sys)
         @test solve_power_flow!(data)
     end

--- a/test/test_residual_condition_diagnostics.jl
+++ b/test/test_residual_condition_diagnostics.jl
@@ -1,0 +1,155 @@
+# The Schur-eigenvalue solve and the fold bail-out need only a back-solve, so they
+# work on any backend; only κ̂ is KLU-only (reported as `n/a` otherwise). Tests that
+# assert a numeric κ̂ pin `linear_solver = "KLU"` for determinism across platforms
+# (on Apple the default is AppleAccelerate); the AppleAccelerate path is covered
+# explicitly below.
+const _KLU_SETTINGS = Dict{Symbol, Any}(:linear_solver => "KLU")
+
+# Build a Schur operator at the flat start of `sys` under `backend` and return its
+# smallest eigenvalue alongside the dense ground truth (smallest-magnitude
+# eigenvalue of S = A − B·D⁻¹·C, recovered as inv(inv(J)[1:nb, 1:nb])).
+function _schur_eig_and_truth(pf, sys; time_step = 1, backend = PNM.KLUSolver())
+    data = PowerFlowData(pf, sys)
+    residual = PF.ACPowerFlowResidual(data, time_step)
+    jac = PF.ACPowerFlowJacobian(residual, time_step)
+    x0 = PF.calculate_x0(data, time_step)
+    residual(x0, time_step)
+    jac(time_step)
+
+    cache = PF.make_linear_solver_cache(backend, jac.Jv)
+    PF.symbolic_factor!(cache, jac.Jv)
+    PF.numeric_refactor!(cache, jac.Jv)
+
+    n_state = size(jac.Jv, 1)
+    n_lcc = size(data.lcc.p_set, 1)
+    n_bus = n_state - 4 * n_lcc
+    op = PF.SchurInverseOperator(cache, n_bus, Vector{Float64}(undef, n_state))
+    λ = PF._schur_min_eigenvalue(op)
+
+    Jinv = inv(Matrix(jac.Jv))
+    S = inv(Jinv[1:n_bus, 1:n_bus])
+    ev = eigvals(S)
+    return λ, ev[argmin(abs.(ev))], n_lcc
+end
+
+# Solve under `pf` and return the per-iteration diagnostic log lines.
+function _solver_diagnostic_lines(pf, sys)
+    data = PowerFlowData(pf, sys)
+    tl = Test.TestLogger(; min_level = Logging.Info)
+    Logging.with_logger(tl) do
+        solve_power_flow!(data)
+    end
+    return [r.message for r in tl.logs if occursin(r"iter \d+", r.message)]
+end
+
+@testset "Schur min-eigenvalue matches dense ground truth (no LCC)" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true)
+    λ, λ_true, n_lcc = _schur_eig_and_truth(pf, sys)
+    @test n_lcc == 0                       # with no LCC, S = J
+    @test abs(λ - λ_true) / abs(λ_true) < 1e-6
+end
+
+@testset "Schur min-eigenvalue matches dense ground truth (LCC)" begin
+    # On an LCC system the Schur complement projects out the converter states;
+    # the matvec must still match the dense inv(inv(J)[1:nb, 1:nb]) eigenvalue.
+    sys = System(joinpath(TEST_DATA_DIR, "case5_2_lcc.raw"))
+    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}()
+    λ, λ_true, n_lcc = _schur_eig_and_truth(pf, sys)
+    @test n_lcc == 2
+    @test abs(λ - λ_true) / abs(λ_true) < 1e-6
+end
+
+@testset "Schur min-eigenvalue is backend-agnostic (AppleAccelerate)" begin
+    # The Schur matvec is just a back-solve, so AppleAccelerate must give the same
+    # eigenvalue as KLU. Only meaningful where AppleAccelerate is available.
+    if Sys.isapple()
+        sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+        pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true)
+        λ, λ_true, _ = _schur_eig_and_truth(pf, sys;
+            backend = PNM.AppleAccelerateLUSolver())
+        @test abs(λ - λ_true) / abs(λ_true) < 1e-6
+    end
+end
+
+@testset "log_solver_diagnostics is off by default" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true,
+        solver_settings = _KLU_SETTINGS)
+    @test isempty(_solver_diagnostic_lines(pf, sys))
+end
+
+@testset "log_solver_diagnostics emits ‖F‖/κ̂/λ_min/contraction lines" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    for solver in (NewtonRaphsonACPowerFlow, TrustRegionACPowerFlow,
+        LevenbergMarquardtACPowerFlow)
+        pf = ACPowerFlow{solver}(; correct_bustypes = true,
+            log_solver_diagnostics = true, solver_settings = _KLU_SETTINGS)
+        lines = _solver_diagnostic_lines(pf, sys)
+        @test length(lines) >= 2
+        for line in lines
+            @test occursin("‖F‖_∞ = ", line)
+            @test occursin("κ̂(J) = ", line)
+            @test occursin("λ_min(S) = ", line)
+            @test occursin(r"at bus \d+", line)
+        end
+        # The contraction ratio appears from the second logged iteration onward.
+        @test any(l -> occursin("contraction = ", l), lines)
+    end
+end
+
+@testset "log_solver_diagnostics works for rectangular-CI and mixed-CPB" begin
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    for PFType in (PF.ACRectangularPowerFlow, PF.ACMixedPowerFlow)
+        pf = PFType{NewtonRaphsonACPowerFlow}(; correct_bustypes = true,
+            log_solver_diagnostics = true, solver_settings = _KLU_SETTINGS)
+        lines = _solver_diagnostic_lines(pf, sys)
+        @test length(lines) >= 2
+        for line in lines
+            @test occursin("λ_min(S) = ", line)
+            @test occursin("κ̂(J) = ", line)
+        end
+    end
+end
+
+@testset "log_solver_diagnostics works on LCC systems" begin
+    sys = System(joinpath(TEST_DATA_DIR, "case5_2_lcc.raw"))
+    pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; log_solver_diagnostics = true,
+        solver_settings = _KLU_SETTINGS)
+    lines = _solver_diagnostic_lines(pf, sys)
+    @test length(lines) >= 2
+    for line in lines
+        @test occursin("λ_min(S) = ", line)
+    end
+end
+
+@testset "diagnostics run on AppleAccelerate, reporting κ̂ as n/a" begin
+    # The Schur eigenvalue needs only a back-solve, so AppleAccelerate works; only
+    # κ̂ is unavailable and must be reported as `n/a` rather than erroring. Only
+    # meaningful where the AppleAccelerate backend is available (Apple platforms).
+    if Sys.isapple()
+        sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+        pf = ACPowerFlow{NewtonRaphsonACPowerFlow}(; correct_bustypes = true,
+            log_solver_diagnostics = true,
+            solver_settings = Dict{Symbol, Any}(:linear_solver => "AppleAccelerateLU"))
+        lines = _solver_diagnostic_lines(pf, sys)
+        @test length(lines) >= 2
+        for line in lines
+            @test occursin("λ_min(S) = ", line)          # back-solve path works
+            @test occursin("κ̂(J) = n/a", line)           # condest unavailable
+        end
+    end
+end
+
+@testset "bail_on_eig_sign_switch returns without erroring on a well-conditioned case" begin
+    # c_sys14 converges with a stable-sign Jacobian, so the bail-out never fires;
+    # this just exercises the plumbing (kwarg → loop → detect_eig_sign_switch).
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14")
+    for solver in (NewtonRaphsonACPowerFlow, TrustRegionACPowerFlow)
+        pf = ACPowerFlow{solver}(; correct_bustypes = true,
+            solver_settings = Dict{Symbol, Any}(
+                :linear_solver => "KLU", :bail_on_eig_sign_switch => true))
+        data = PowerFlowData(pf, sys)
+        @test solve_power_flow!(data)
+    end
+end


### PR DESCRIPTION
Adds an opt-in `log_solver_diagnostics` flag (available on every AC formulation) that logs `‖F‖_∞` and where it is attained, the condition estimate `κ̂(J)`, `λ_min` of the bus-voltage Schur complement, and the residual contraction ratio on each Newton-Raphson, Trust-Region, and Levenberg-Marquardt iteration. Adds a `bail_on_eig_sign_switch` solver setting (NR/TR only) that aborts the search when `real(λ_min)` crosses zero — the saddle-node fold / voltage-collapse signature.

`λ_min` is found by inverse iteration (KrylovKit) on the Schur complement `S = A − B·D⁻¹·C` of the LCC tail, applying S⁻¹ through the existing factorization of the full Jacobian — no second matrix, no second factorization. Since this needs only a back-solve, the diagnostics and the bail-out work on every linear-solver backend. The lone exception is κ̂, which uses libklu's `condest` and so is reported as `n/a` on the non-KLU backends rather than failing.

Remember to eliminate the `[sources]` pin on PNM before merging.