### PR TITLE
Clear bus_hvdc_net_power in clear_injection_data!

### DIFF
--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -445,6 +445,7 @@ function clear_injection_data!(pfd::PowerFlowData)
     for col in eachcol(pfd.bus_magnitude)
         any(isnan, col) && (col .= 1.0)
     end
+    pfd.bus_hvdc_net_power .= 0.0
     return
 end
 

--- a/test/test_power_flow_data.jl
+++ b/test/test_power_flow_data.jl
@@ -159,6 +159,17 @@ end
     @test data.bus_magnitude[:, 2] == orig_mag_2
 end
 
+@testset "clear_injection_data! zeroes bus_hvdc_net_power" begin
+    # bus_hvdc_net_power is seeded at construction from native HVDC setpoints and is also
+    # written by PowerSimulations each solve, so clear_injection_data! must reset it to avoid
+    # double-counting the construction-time seed and accumulating across solves.
+    sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
+    data = PowerFlowData(ACPowerFlow(; correct_bustypes = true, time_steps = 2), sys)
+    data.bus_hvdc_net_power .= 1.23
+    PF.clear_injection_data!(data)
+    @test all(iszero, data.bus_hvdc_net_power)
+end
+
 @testset "Wrong bus type" begin
     sys = PSB.build_system(PSB.PSITestSystems, "c_sys14"; add_forecasts = false)
     buses = collect(PSY.get_components(PSY.ACBus, sys))


### PR DESCRIPTION
Zero `bus_hvdc_net_power` each solve, alongside the other injection fields, so construction-time native HVDC setpoints don't double-count and per-solve writes don't accumulate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)