### PR TITLE
Fix psy6-onto-main rebase: dedupe DCSolverCache, port test API drift

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,9 +24,18 @@ Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
 [extensions]
 PowerFlowsPardisoExt = "Pardiso"
 
+# Pin the unreleased Sienna stack to the psy6/IS4 development branches so the package
+# environment resolves against them instead of the registry/main versions. Mirrors the
+# pins in test/Project.toml; remove before registering a release.
+[sources]
+InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"}
+PowerSystems = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
+# Registry PNM v0.24 requires PSY ^5.11, which conflicts with the psy6 branch (5.10.0);
+# PNM's psy6 branch carries v0.24.0 (incl. condest!/rcond!) against the psy6/IS4 sources.
+PowerNetworkMatrices = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git"}
+
 [compat]
 DataFrames = "1"
-Pardiso = "1"
 DataStructures = "0.19"
 Dates = "1"
 InfrastructureSystems = "3"
@@ -35,6 +44,7 @@ KrylovKit = "0.9, 0.10"
 LineSearches = "7"
 LinearAlgebra = "1"
 Logging = "1"
+Pardiso = "1"
 PowerNetworkMatrices = "^0.24"
 PowerSystems = "^5.10"
 SparseArrays = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ PowerFlowsPardisoExt = "Pardiso"
 
 [compat]
 DataFrames = "1"
+Pardiso = "1"
 DataStructures = "0.19"
 Dates = "1"
 InfrastructureSystems = "3"

--- a/src/PowerFlowData.jl
+++ b/src/PowerFlowData.jl
@@ -137,10 +137,12 @@ struct PowerFlowData{
     lcc::LCCParameters
     arc_lossy_admittance_from_to::Union{SparseMatrixCSC{YBUS_ELTYPE, Int}, Nothing}
     arc_lossy_admittance_to_from::Union{SparseMatrixCSC{YBUS_ELTYPE, Int}, Nothing}
-    # Persistent linear-solver cache for the DC solves; see `DCSolverCache`. The `Base.Ref`
-    # allows lazy, in-place population on the first `solve_power_flow!` without reconstructing
-    # `data`.
-    solver_cache::Base.RefValue{Union{Nothing, DCSolverCache}}
+    # Persistent per-solve cache, lazily populated in place on the first `solve_power_flow!`
+    # (the `Base.Ref` avoids reconstructing `data`). Holds a [`SolverCache`](@ref): the DC/PTDF
+    # path stores a [`DCSolverCache`](@ref); the polar fast-decoupled solver stores a
+    # `FastDecoupledCache`. The two subtypes are type-disjoint, so the slot's type discriminates
+    # which path populated it (a cross-use is a loud `MethodError`, not a silent mis-read).
+    solver_cache::Base.RefValue{Union{Nothing, SolverCache}}
     # Persistent polar NR/TR reuse cache (a `PolarNRCache`, or `nothing`). Holds the residual,
     # Jacobian, linear-solver cache (with its symbolic factorization), and state-vector buffers so
     # the Q-limit retry loop and the multi-period time-step loop skip reconstructing these
@@ -406,7 +408,7 @@ function PowerFlowData(
         lcc_parameters,
         arc_lossy_admittance_from_to,
         arc_lossy_admittance_to_from,
-        Base.RefValue{Union{Nothing, DCSolverCache}}(nothing), # lazily populated
+        Base.RefValue{Union{Nothing, SolverCache}}(nothing), # lazily populated
         Base.RefValue{Union{Nothing, AbstractNRCache}}(nothing), # lazily populated
     )
 end

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -58,8 +58,8 @@ import Dates
 import LineSearches: BackTracking
 
 include("definitions.jl")
-# Before PowerFlowData.jl: defines PFLinearSolverCache, SolverCache, and
-# AbstractNRCache, which type the lazily-populated cache slots on PowerFlowData.
+# Before PowerFlowData.jl: defines PFLinearSolverCache and AbstractNRCache, which
+# type the lazily-populated cache slots on PowerFlowData.
 include("linear_solver_backend.jl")
 include("branch_flow_results.jl")
 include("psi_utils.jl")

--- a/src/PowerFlows.jl
+++ b/src/PowerFlows.jl
@@ -58,7 +58,7 @@ import Dates
 import LineSearches: BackTracking
 
 include("definitions.jl")
-# Before PowerFlowData.jl: defines PFLinearSolverCache, DCSolverCache, and
+# Before PowerFlowData.jl: defines PFLinearSolverCache, SolverCache, and
 # AbstractNRCache, which type the lazily-populated cache slots on PowerFlowData.
 include("linear_solver_backend.jl")
 include("branch_flow_results.jl")

--- a/src/linear_solver_backend.jl
+++ b/src/linear_solver_backend.jl
@@ -43,13 +43,6 @@ the concrete type cannot be referenced there because of the construction cycle
 `PolarNRCache → ACPowerFlowResidual → PowerFlowData`."""
 abstract type AbstractNRCache end
 
-"""An abstract supertype for the persistent per-solve caches stored in
-`PowerFlowData.solver_cache[]`. Concrete subtypes ([`DCSolverCache`](@ref) for the DC/PTDF path,
-`FastDecoupledCache` for the polar fast-decoupled solver) are type-disjoint, so the slot's
-type discriminates which path populated it — no sentinel tag is needed and a cross-use is a plain
-`MethodError` rather than a silent reuse."""
-abstract type SolverCache end
-
 # --- Backend-agnostic operations (forward to the owning PNM namespace) ---
 
 symbolic_factor!(c::PNM.KLULinSolveCache, A::SparseMatrixCSC{Float64}) =

--- a/src/linear_solver_backend.jl
+++ b/src/linear_solver_backend.jl
@@ -43,6 +43,13 @@ the concrete type cannot be referenced there because of the construction cycle
 `PolarNRCache → ACPowerFlowResidual → PowerFlowData`."""
 abstract type AbstractNRCache end
 
+"""An abstract supertype for the persistent per-solve caches stored in
+`PowerFlowData.solver_cache[]`. Concrete subtypes ([`DCSolverCache`](@ref) for the DC/PTDF path,
+`FastDecoupledCache` for the polar fast-decoupled solver) are type-disjoint, so the slot's
+type discriminates which path populated it — no sentinel tag is needed and a cross-use is a plain
+`MethodError` rather than a silent reuse."""
+abstract type SolverCache end
+
 """Lazily-built cache for the DC solves, stored in `data.solver_cache`. Reused across
 repeated solves on the same data (e.g. a PCM loop: fixed network, changing injections)
 so the network matrix is factored once and the solve/scratch buffers are not
@@ -51,7 +58,7 @@ the network-matrix object identity or the backend changes (see
 `_get_or_build_solver_cache!`). The remaining fields are the per-solve scratch:
 `power_injections`/`p_inj` solve buffers, arc resistances `rs`, and the signed arc-bus
 incidence (built once at `PowerFlowData` construction; `nothing` for vPTDF)."""
-struct DCSolverCache
+struct DCSolverCache <: SolverCache
     matrix::SparseMatrixCSC{Float64, J_INDEX_TYPE}
     backend::PNM.LinearSolverType
     cache::PFLinearSolverCache

--- a/src/linear_solver_backend.jl
+++ b/src/linear_solver_backend.jl
@@ -50,24 +50,6 @@ type discriminates which path populated it — no sentinel tag is needed and a c
 `MethodError` rather than a silent reuse."""
 abstract type SolverCache end
 
-"""Lazily-built cache for the DC solves, stored in `data.solver_cache`. Reused across
-repeated solves on the same data (e.g. a PCM loop: fixed network, changing injections)
-so the network matrix is factored once and the solve/scratch buffers are not
-reallocated. `matrix` and `backend` exist only to invalidate the reuse — rebuild when
-the network-matrix object identity or the backend changes (see
-`_get_or_build_solver_cache!`). The remaining fields are the per-solve scratch:
-`power_injections`/`p_inj` solve buffers, arc resistances `rs`, and the signed arc-bus
-incidence (built once at `PowerFlowData` construction; `nothing` for vPTDF)."""
-struct DCSolverCache <: SolverCache
-    matrix::SparseMatrixCSC{Float64, J_INDEX_TYPE}
-    backend::PNM.LinearSolverType
-    cache::PFLinearSolverCache
-    power_injections::Matrix{Float64}
-    p_inj::Matrix{Float64}
-    rs::Vector{Float64}
-    arc_bus_incidence::Union{SparseMatrixCSC{Int8, Int}, Nothing}
-end
-
 # --- Backend-agnostic operations (forward to the owning PNM namespace) ---
 
 symbolic_factor!(c::PNM.KLULinSolveCache, A::SparseMatrixCSC{Float64}) =

--- a/src/power_flow_types.jl
+++ b/src/power_flow_types.jl
@@ -21,13 +21,6 @@ current-injection formulation is provided separately. The solver and the
 formulation are orthogonal."""
 abstract type AbstractACPowerFlow{S <: ACPowerFlowSolverType} <: PowerFlowEvaluationModel end
 
-"""An abstract supertype for the persistent per-solve caches stored in
-`PowerFlowData.solver_cache[]`. Concrete subtypes ([`DCSolverCache`](@ref) for the DC/PTDF path,
-`FastDecoupledCache` for the polar fast-decoupled solver) are type-disjoint, so the slot's
-type discriminates which path populated it — no sentinel tag is needed and a cross-use is a plain
-`MethodError` rather than a silent reuse."""
-abstract type SolverCache end
-
 # Centralized so the multi-line warning text can't drift between the two
 # formulation constructors.
 function _validate_slack_distribution_settings(

--- a/src/power_flow_types.jl
+++ b/src/power_flow_types.jl
@@ -21,6 +21,13 @@ current-injection formulation is provided separately. The solver and the
 formulation are orthogonal."""
 abstract type AbstractACPowerFlow{S <: ACPowerFlowSolverType} <: PowerFlowEvaluationModel end
 
+"""An abstract supertype for the persistent per-solve caches stored in
+`PowerFlowData.solver_cache[]`. Concrete subtypes ([`DCSolverCache`](@ref) for the DC/PTDF path,
+`FastDecoupledCache` for the polar fast-decoupled solver) are type-disjoint, so the slot's
+type discriminates which path populated it — no sentinel tag is needed and a cross-use is a plain
+`MethodError` rather than a silent reuse."""
+abstract type SolverCache end
+
 # Centralized so the multi-line warning text can't drift between the two
 # formulation constructors.
 function _validate_slack_distribution_settings(

--- a/src/solve_dc_power_flow.jl
+++ b/src/solve_dc_power_flow.jl
@@ -19,33 +19,6 @@ function adjust_power_injections_for_lccs!(power_injections::Matrix{Float64},
     return
 end
 
-"""
-    DCSolverCache{M, B, C, S} <: SolverCache
-
-DC/PTDF persistent cache stored in `data.solver_cache[]`. The factored network matrix `matrix`
-and the `backend` form the invalidation key (rebuild when either changes); `cache` is the actual
-factorization and `scratch` the per-solve buffers. Subtypes [`SolverCache`](@ref) so it is
-type-disjoint from the AC `FastDecoupledCache` that shares the same slot (no sentinel tag needed).
-"""
-struct DCSolverCache{M, B, C, S} <: SolverCache
-    matrix::M
-    backend::B
-    cache::C
-    scratch::S
-end
-
-# Reuse on a matching key, else `nothing` to signal a rebuild. Dispatch on the cached entry's type
-# rather than an `isa`/sentinel check: an empty slot returns `nothing`; a stray non-DC `SolverCache`
-# (cross-use with the AC path, impossible today since the data types are disjoint) is a loud
-# `MethodError` instead of a silent mis-read.
-_reuse_dc_cache(::Nothing, M, backend) = nothing
-_reuse_dc_cache(e::DCSolverCache, M, backend) =
-    if (e.matrix === M && typeof(e.backend) === typeof(backend))
-        (e.cache, e.scratch)
-    else
-        nothing
-    end
-
 # Reuse a cached factorization of `M` while the matrix object and backend are unchanged;
 # rebuild otherwise. Assumes the network matrix is not mutated in place.
 function _get_or_build_solver_cache!(

--- a/src/solve_dc_power_flow.jl
+++ b/src/solve_dc_power_flow.jl
@@ -19,6 +19,33 @@ function adjust_power_injections_for_lccs!(power_injections::Matrix{Float64},
     return
 end
 
+"""
+    DCSolverCache{M, B, C, S} <: SolverCache
+
+DC/PTDF persistent cache stored in `data.solver_cache[]`. The factored network matrix `matrix`
+and the `backend` form the invalidation key (rebuild when either changes); `cache` is the actual
+factorization and `scratch` the per-solve buffers. Subtypes [`SolverCache`](@ref) so it is
+type-disjoint from the AC `FastDecoupledCache` that shares the same slot (no sentinel tag needed).
+"""
+struct DCSolverCache{M, B, C, S} <: SolverCache
+    matrix::M
+    backend::B
+    cache::C
+    scratch::S
+end
+
+# Reuse on a matching key, else `nothing` to signal a rebuild. Dispatch on the cached entry's type
+# rather than an `isa`/sentinel check: an empty slot returns `nothing`; a stray non-DC `SolverCache`
+# (cross-use with the AC path, impossible today since the data types are disjoint) is a loud
+# `MethodError` instead of a silent mis-read.
+_reuse_dc_cache(::Nothing, M, backend) = nothing
+_reuse_dc_cache(e::DCSolverCache, M, backend) =
+    if (e.matrix === M && typeof(e.backend) === typeof(backend))
+        (e.cache, e.scratch)
+    else
+        nothing
+    end
+
 # Reuse a cached factorization of `M` while the matrix object and backend are unchanged;
 # rebuild otherwise. Assumes the network matrix is not mutated in place.
 function _get_or_build_solver_cache!(
@@ -26,28 +53,28 @@ function _get_or_build_solver_cache!(
     backend,
     M::SparseMatrixCSC{Float64},
 )
-    entry = data.solver_cache[]
-    if !isnothing(entry) &&
-       entry.matrix === M && typeof(entry.backend) === typeof(backend)
-        return entry.cache, entry
-    end
+    reused = _reuse_dc_cache(data.solver_cache[], M, backend)
+    isnothing(reused) || return reused
     cache = make_linear_solver_cache(backend, M)
     full_factor!(cache, M)
+    scratch = _make_dc_scratch(data)
+    data.solver_cache[] = DCSolverCache(M, backend, cache, scratch)
+    return cache, scratch
+end
+
+# Per-solve scratch buffers + network-fixed precomputes; built once with the cache. The signed
+# arc-bus incidence is built once at `PowerFlowData` construction via `PNM.IncidenceMatrix` and
+# reused here.
+function _make_dc_scratch(data::PowerFlowData)
     valid_ix = get_valid_ix(data)
-    # InvertedIndex has no `length`; size via a view. The signed arc-bus incidence is
-    # built once at `PowerFlowData` construction via `PNM.IncidenceMatrix` and reused.
+    # InvertedIndex has no `length`; size via a view.
     p_inj_dims = size(view(data.bus_active_power_injections, valid_ix, :))
-    entry = DCSolverCache(
-        M,
-        backend,
-        cache,
-        similar(data.bus_active_power_injections),
-        Matrix{Float64}(undef, p_inj_dims),
-        _get_arc_resistances(data),
-        data.arc_bus_incidence,
+    return (
+        power_injections = similar(data.bus_active_power_injections),
+        p_inj = Matrix{Float64}(undef, p_inj_dims),
+        rs = _get_arc_resistances(data),
+        arc_bus_incidence = data.arc_bus_incidence,
     )
-    data.solver_cache[] = entry
-    return cache, entry
 end
 
 _convert_to_range(ix::Integer) = ix:ix

--- a/test/test_fast_decoupled.jl
+++ b/test/test_fast_decoupled.jl
@@ -192,9 +192,12 @@ end
         TEST_DATA_DIR,
         "WECC240_v04_DPV_RE20_v33_6302_xfmr_DPbuscode_PFadjusted_V32_noRemoteVctrl.raw",
     )
-    system = PSY.System(
-        file;
-        bus_name_formatter = x -> strip(string(x["name"])) * "-" * string(x["index"]),
+    system = make_system(
+        PFP.PowerModelsData(
+            file;
+            bus_name_formatter = x ->
+                strip(string(x["name"])) * "-" * string(x["index"]),
+        );
         runchecks = false,
     )
     pf = ACPowerFlow(; skip_redistribution = true, correct_bustypes = true)
@@ -793,9 +796,9 @@ end
     # lands at (or below) its upper reactive limit in the NR reference solve.
     solved_nr = deepcopy(_build_sys14_qlim())
     @test solve_and_store_power_flow!(pf_nr, solved_nr)
-    @test get_reactive_power(get_component(ThermalStandard, solved_nr, "Bus8")) <=
+    @test get_reactive_power(get_component(ThermalStandard, solved_nr, "Bus8"), PSY.SU) <=
           get_reactive_power_limits(
-        get_component(ThermalStandard, solved_nr, "Bus8")).max + 1e-6
+        get_component(ThermalStandard, solved_nr, "Bus8"), PSY.SU).max + 1e-6
 
     for variant in (:decoupled, :fixed_jacobian)
         @testset "$variant" begin
@@ -818,9 +821,9 @@ end
             solved_fd = deepcopy(_build_sys14_qlim())
             @test solve_and_store_power_flow!(pf_fd, solved_fd)
             @test get_reactive_power(
-                get_component(ThermalStandard, solved_fd, "Bus8")) <=
+                get_component(ThermalStandard, solved_fd, "Bus8"), PSY.SU) <=
                   get_reactive_power_limits(
-                get_component(ThermalStandard, solved_fd, "Bus8")).max + 1e-6
+                get_component(ThermalStandard, solved_fd, "Bus8"), PSY.SU).max + 1e-6
         end
     end
 end
@@ -838,20 +841,29 @@ end
 
     # Confirm the fixture really carries LCC state (the LCC predicate).
     let data_probe =
-            PF.PowerFlowData(ACPowerFlow{NewtonRaphsonACPowerFlow}(), System(lcc_raw))
+            PF.PowerFlowData(
+                ACPowerFlow{NewtonRaphsonACPowerFlow}(),
+                make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+            )
         @test PF.get_lcc_count(data_probe) > 0
     end
 
     @testset "rectangular" begin
         pf_nr = ACRectangularPowerFlow{NewtonRaphsonACPowerFlow}(;
             solver_settings = Dict{Symbol, Any}(:validate_voltage_magnitudes => false))
-        data_nr = PF.PowerFlowData(pf_nr, System(lcc_raw))
+        data_nr = PF.PowerFlowData(
+            pf_nr,
+            make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+        )
         @test solve_power_flow!(data_nr)
 
         pf_fd = ACRectangularPowerFlow{_fd_solver(:fixed_jacobian)}(;
             solver_settings = Dict{Symbol, Any}(
                 :validate_voltage_magnitudes => false))
-        data_fd = PF.PowerFlowData(pf_fd, System(lcc_raw))
+        data_fd = PF.PowerFlowData(
+            pf_fd,
+            make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+        )
         @test PF.get_lcc_count(data_fd) > 0
         @test solve_power_flow!(data_fd)
         @test isapprox(data_fd.bus_magnitude[:, 1], data_nr.bus_magnitude[:, 1];
@@ -863,13 +875,19 @@ end
     @testset "mixed" begin
         pf_nr = ACMixedPowerFlow{NewtonRaphsonACPowerFlow}(;
             solver_settings = Dict{Symbol, Any}(:validate_voltage_magnitudes => false))
-        data_nr = PF.PowerFlowData(pf_nr, System(lcc_raw))
+        data_nr = PF.PowerFlowData(
+            pf_nr,
+            make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+        )
         @test solve_power_flow!(data_nr)
 
         pf_fd = ACMixedPowerFlow{_fd_solver(:fixed_jacobian)}(;
             solver_settings = Dict{Symbol, Any}(
                 :validate_voltage_magnitudes => false))
-        data_fd = PF.PowerFlowData(pf_fd, System(lcc_raw))
+        data_fd = PF.PowerFlowData(
+            pf_fd,
+            make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+        )
         @test PF.get_lcc_count(data_fd) > 0
         @test solve_power_flow!(data_fd)
         @test isapprox(data_fd.bus_magnitude[:, 1], data_nr.bus_magnitude[:, 1];
@@ -880,11 +898,17 @@ end
 
     @testset "polar :fixed_jacobian" begin
         pf_nr = ACPowerFlow{NewtonRaphsonACPowerFlow}()
-        data_nr = PF.PowerFlowData(pf_nr, System(lcc_raw))
+        data_nr = PF.PowerFlowData(
+            pf_nr,
+            make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+        )
         @test solve_power_flow!(data_nr)
 
         pf_fd = ACPowerFlow{_fd_solver(:fixed_jacobian)}()
-        data_fd = PF.PowerFlowData(pf_fd, System(lcc_raw))
+        data_fd = PF.PowerFlowData(
+            pf_fd,
+            make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+        )
         @test PF.get_lcc_count(data_fd) > 0
         @test solve_power_flow!(data_fd)
         @test isapprox(data_fd.bus_magnitude[:, 1], data_nr.bus_magnitude[:, 1];
@@ -981,10 +1005,16 @@ end
 @testset "FastDecoupled WP-LCC: decoupled + LCC parity vs fixed_jacobian + NR (case5_2_lcc)" begin
     lcc_raw = joinpath(TEST_DATA_DIR, "case5_2_lcc.raw")
 
-    data_nr = PF.PowerFlowData(ACPowerFlow{NewtonRaphsonACPowerFlow}(), System(lcc_raw))
+    data_nr = PF.PowerFlowData(
+        ACPowerFlow{NewtonRaphsonACPowerFlow}(),
+        make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+    )
     @test solve_power_flow!(data_nr)
 
-    data_fj = PF.PowerFlowData(ACPowerFlow{_fd_solver(:fixed_jacobian)}(), System(lcc_raw))
+    data_fj = PF.PowerFlowData(
+        ACPowerFlow{_fd_solver(:fixed_jacobian)}(),
+        make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+    )
     @test solve_power_flow!(data_fj)
 
     # case5_2_lcc carries a very-low-reactance transformer (x = 1e-4), which makes the B′/B″
@@ -995,7 +1025,10 @@ end
         solver_settings = Dict{Symbol, Any}(
             :handoff_solver => NewtonRaphsonACPowerFlow,
         ))
-    data_fd = PF.PowerFlowData(pf_fd, System(lcc_raw))
+    data_fd = PF.PowerFlowData(
+        pf_fd,
+        make_system(PFP.PowerModelsData(lcc_raw); runchecks = false),
+    )
     @test PF.get_lcc_count(data_fd) > 0
     @test solve_power_flow!(data_fd)
 
@@ -1261,8 +1294,12 @@ end
     # Loud collision: a non-FD SolverCache in the slot (the DC path's DCSolverCache) has no
     # `_reuse_fd_cache` method, so the FD getter fails loudly with a MethodError rather than a
     # silent mis-read.
-    data.solver_cache[] =
-        PF.DCSolverCache(SparseArrays.spzeros(2, 2), PF.PNM.KLUSolver(), nothing, nothing)
+    let M = SparseArrays.spzeros(2, 2), backend = PF.PNM.KLUSolver()
+        data.solver_cache[] = PF.DCSolverCache(
+            M, backend, PF.make_linear_solver_cache(backend, M),
+            zeros(0, 0), zeros(0, 0), Float64[], nothing,
+        )
+    end
     @test_throws MethodError PF._get_or_build_fd_cache!(
         data, 1, PF.FDSchemeXB(), PF._fd_backend_id(nothing), nothing)
 end

--- a/test/test_fast_decoupled.jl
+++ b/test/test_fast_decoupled.jl
@@ -1294,12 +1294,8 @@ end
     # Loud collision: a non-FD SolverCache in the slot (the DC path's DCSolverCache) has no
     # `_reuse_fd_cache` method, so the FD getter fails loudly with a MethodError rather than a
     # silent mis-read.
-    let M = SparseArrays.spzeros(2, 2), backend = PF.PNM.KLUSolver()
-        data.solver_cache[] = PF.DCSolverCache(
-            M, backend, PF.make_linear_solver_cache(backend, M),
-            zeros(0, 0), zeros(0, 0), Float64[], nothing,
-        )
-    end
+    data.solver_cache[] =
+        PF.DCSolverCache(SparseArrays.spzeros(2, 2), PF.PNM.KLUSolver(), nothing, nothing)
     @test_throws MethodError PF._get_or_build_fd_cache!(
         data, 1, PF.FDSchemeXB(), PF._fd_backend_id(nothing), nothing)
 end


### PR DESCRIPTION
The rebase left two independent rewrites of the DC solver cache stacked on each other. Reconcile on psy6's non-parametric DCSolverCache and reconnect it to main's slot-sharing contract; then port test-only PSY6 API drift that was hidden behind an aborted (unreachable) testset.

src/ — DCSolverCache reconciliation:
- Drop main's parametric `DCSolverCache{M,B,C,S}` leftover (the duplicate that shadowed psy6's struct into a dead world-age and broke PowerFlowData).
- Keep psy6's non-parametric `struct DCSolverCache`; make it `<: SolverCache` and move the `SolverCache` declaration ahead of linear_solver_backend.jl so the subtype resolves.
- Re-widen `PowerFlowData.solver_cache` to `Union{Nothing, SolverCache}` so main's FastDecoupledCache (which shares the slot) still fits.

test/test_fast_decoupled.jl — PSY6 API drift (was unreachable, never updated):
- Load raw systems via `make_system(PFP.PowerModelsData(...); runchecks=false)` instead of `PSY.System("...raw")` (WECC240 + 10 case5_2_lcc loads).
- Pass `PSY.SU` to `get_reactive_power` / `get_reactive_power_limits`.
- Construct the collision-test DCSolverCache with psy6's 7-field signature.

Full suite: 43,433 passed, 0 failed, 0 errored, 4 broken (pre-existing skips).