### PR TITLE
Candidate fix: switched-shunt control should target PSS/E band edge, not midpoint

### DIFF
--- a/src/discrete_control/control_continuation.jl
+++ b/src/discrete_control/control_continuation.jl
@@ -156,6 +156,27 @@ function _step_device!(
     return abs(reached - p_now)
 end
 
+# PSS/E's MODSW=1/2 switched-shunt control switches the minimum number of steps needed to
+# bring the controlled bus back inside [VSWLO, VSWHI] — it does not drive to the band's
+# midpoint. Call once per solve, right after the base-case converges and before any device
+# is probed/stepped: freeze a shunt already inside the band, otherwise point `vset` at the
+# nearest violated edge so the continuation below pushes it back to the edge, not the center.
+function _apply_shunt_deadband!(
+    shunts, offset::Int, frozen::Vector{Bool}, data, ts::Int,
+)
+    for (i, d) in enumerate(shunts)
+        y = measured_value(d, data, ts)
+        if y < d.vset_lo
+            d.vset = d.vset_lo
+        elseif y > d.vset_hi
+            d.vset = d.vset_hi
+        else
+            frozen[offset + i] = true
+        end
+    end
+    return nothing
+end
+
 # Probe each device in one concrete vector for its plant sign (dV/dp) and write the result into
 # the shared per-device state at `offset + i`. A function barrier: the body specializes on the
 # concrete element type, so there is no dynamic dispatch over a heterogeneous device collection.
@@ -165,6 +186,9 @@ function _probe_device_signs!(
     data, ts::Int, pf; kwargs...,
 )
     for (i, d) in enumerate(devices)
+        # Already frozen (e.g. a shunt `_apply_shunt_deadband!` held in-band): skip the
+        # 2-solve probe entirely, it will never be stepped.
+        frozen[offset + i] && continue
         s, reliable = _plant_sign(d, data, ts, pf; kwargs...)
         reliable ? (dVdp[offset + i] = s) : (frozen[offset + i] = true)
     end
@@ -210,30 +234,35 @@ function _control_continuation!(
     frozen = fill(false, n_dev)
     osc = zeros(Int, n_dev)
     prev_sign = zeros(Int, n_dev)
+    _apply_shunt_deadband!(set.shunts, n_taps, frozen, data, ts)
+    deadband_frozen = copy(frozen)   # in-band shunts: expected, not a fault; excluded below
     _probe_device_signs!(set.taps, 0, dVdp, frozen, data, ts, pf; kwargs...)
     _probe_device_signs!(set.shunts, n_taps, dVdp, frozen, data, ts, pf; kwargs...)
     _probe_device_signs!(
         set.facts, n_taps + n_shunts, dVdp, frozen, data, ts, pf; kwargs...)
     _probe_device_signs!(
         set.phase_shifters, n_volt, dVdp, frozen, data, ts, pf; kwargs...)
-    if any(frozen)
+    probe_frozen = frozen .& .!deadband_frozen
+    if any(probe_frozen)
         frozen_names = join(
             vcat(
-                [set.taps[i].name for i in 1:n_taps if frozen[i]],
-                [set.shunts[j].name
-                    for j in eachindex(set.shunts) if frozen[n_taps + j]],
+                [set.taps[i].name for i in 1:n_taps if probe_frozen[i]],
+                [
+                    set.shunts[j].name
+                    for j in eachindex(set.shunts) if probe_frozen[n_taps + j]
+                ],
                 [
                     set.facts[k].name
-                    for k in eachindex(set.facts) if frozen[n_taps + n_shunts + k]
+                    for k in eachindex(set.facts) if probe_frozen[n_taps + n_shunts + k]
                 ],
                 [
                     set.phase_shifters[m].name
-                    for m in eachindex(set.phase_shifters) if frozen[n_volt + m]
+                    for m in eachindex(set.phase_shifters) if probe_frozen[n_volt + m]
                 ],
             ),
             ", ",
         )
-        @warn "discrete control: $(count(frozen)) device(s) had an unreliable \
+        @warn "discrete control: $(count(probe_frozen)) device(s) had an unreliable \
             plant-sensitivity probe and were frozen at their current parameter \
             (time step $ts): $frozen_names"
     end

--- a/src/discrete_control/control_metadata.jl
+++ b/src/discrete_control/control_metadata.jl
@@ -190,6 +190,8 @@ function build_controlled_device_set(
                 bus_lookup[bus],
                 bus_lookup[cbus],
                 vset,
+                lims.min,
+                lims.max,
                 g0,
                 b0,
                 steps,

--- a/src/discrete_control/controlled_devices.jl
+++ b/src/discrete_control/controlled_devices.jl
@@ -26,7 +26,13 @@ mutable struct ControlledSwitchedShunt <: AbstractShuntControl
     name::String
     bus_ix::Int
     controlled_ix::Int
-    vset::Float64
+    vset::Float64                    # current point target; set to the nearest violated
+    # band edge (or held at the base voltage, frozen) once
+    # per solve by `_apply_shunt_deadband!` — see PSS/E's
+    # VSWLO/VSWHI semantics: switch the minimum number of
+    # steps to re-enter the band, not to a fixed setpoint.
+    vset_lo::Float64                 # PSS/E VSWLO
+    vset_hi::Float64                 # PSS/E VSWHI
     g0::Float64                      # real(get_Y)
     b0::Float64                      # imag(get_Y)
     block_steps::Vector{Int}         # number_of_steps per block

--- a/test/test_discrete_control.jl
+++ b/test/test_discrete_control.jl
@@ -139,6 +139,32 @@ end
     ) === nothing
 end
 
+@testset "discrete control: shunt deadband" begin
+    mk(ix) = PowerFlows.ControlledSwitchedShunt(
+        "sh", ix, ix, 1.0, 0.95, 1.05, 0.0, 0.0,
+        [4], [0.25], 0.0, 1.0, [1], zeros(Int, 1), false, 0.0,
+    )
+    data = (; bus_magnitude = reshape([0.90, 1.00, 1.10], 3, 1))
+
+    below = mk(1)
+    frozen = fill(false, 1)
+    PowerFlows._apply_shunt_deadband!([below], 0, frozen, data, 1)
+    @test below.vset == 0.95
+    @test frozen == [false]
+
+    inband = mk(2)
+    frozen = fill(false, 1)
+    PowerFlows._apply_shunt_deadband!([inband], 0, frozen, data, 1)
+    @test inband.vset == 1.0   # untouched: PSS/E would not switch this shunt
+    @test frozen == [true]
+
+    above = mk(3)
+    frozen = fill(false, 1)
+    PowerFlows._apply_shunt_deadband!([above], 0, frozen, data, 1)
+    @test above.vset == 1.05
+    @test frozen == [false]
+end
+
 @testset "discrete control: tap invariant validation" begin
     # p_min > p_max (malformed) triggers error.
     @test_throws ErrorException PowerFlows._validate_tap!("bad_tap", 1.1, 0.9, 33)
@@ -170,7 +196,7 @@ end
     @test PowerFlows.target_from_voltage(d2, 1.5, S) ≈ 1.1 atol = 1e-6
 
     block_dB_sh = [0.05]
-    sh = PowerFlows.ControlledSwitchedShunt("s", 3, 3, 1.0, 0.0, 0.0,
+    sh = PowerFlows.ControlledSwitchedShunt("s", 3, 3, 1.0, 0.9, 1.1, 0.0, 0.0,
         [4], block_dB_sh, 0.0, 0.2,
         [1], zeros(Int, length(block_dB_sh)), false, 0.0)
     @test PowerFlows.target_from_voltage(sh, 1.0, S) ≈ 0.1 atol = 1e-9
@@ -190,7 +216,7 @@ end
     secondary = PowerFlows.ControlledTap("ts", 1, 2, 1, false, 1.0,
         1.0 / (0.01 + 0.1im), 0.0 + 0.0im, 0.0, 0.9, 1.1,
         collect(range(0.9, 1.1; length = 33)), (1, 2, 3, 4), 1.0)
-    shunt = PowerFlows.ControlledSwitchedShunt("sh", 3, 3, 1.0, 0.0, 0.0,
+    shunt = PowerFlows.ControlledSwitchedShunt("sh", 3, 3, 1.0, 0.9, 1.1, 0.0, 0.0,
         [4], [0.05], 0.0, 0.2, [1], zeros(Int, 1), false, 0.0)
     for d in (primary, secondary, shunt)
         vset = PowerFlows.voltage_setpoint(d)
@@ -258,13 +284,13 @@ end
     @test PowerFlows.snap_to_discrete(d, 1.03) == 1.05
     @test PowerFlows.snap_to_discrete(d, 1.20) == 1.1   # clamp
     block_dB_sh_snap = [0.05]
-    sh = PowerFlows.ControlledSwitchedShunt("s", 3, 3, 1.0, 0.0, 0.0,
+    sh = PowerFlows.ControlledSwitchedShunt("s", 3, 3, 1.0, 0.9, 1.1, 0.0, 0.0,
         [4], block_dB_sh_snap, 0.0, 0.2,
         [1], zeros(Int, length(block_dB_sh_snap)),
         false, 0.0)  # reachable: 0,0.05,0.10,0.15,0.20
     @test PowerFlows.snap_to_discrete(sh, 0.12) == 0.10
     block_dB_sh2 = [0.1, 0.02]
-    sh2 = PowerFlows.ControlledSwitchedShunt("s2", 3, 3, 1.0, 0.0, 0.0,
+    sh2 = PowerFlows.ControlledSwitchedShunt("s2", 3, 3, 1.0, 0.9, 1.1, 0.0, 0.0,
         [2, 3], block_dB_sh2, 0.0, 0.26,
         [1, 2], zeros(Int, length(block_dB_sh2)),
         false, 0.0)  # block-greedy with ±1 refinement
@@ -278,7 +304,7 @@ end
     # continuous == true ⇒ snap_to_discrete returns the clamped continuous value,
     # NOT the nearest reachable block grid point.
     block_dB = [0.05]
-    cont = PowerFlows.ControlledSwitchedShunt("c", 3, 3, 1.0, 0.0, 0.0,
+    cont = PowerFlows.ControlledSwitchedShunt("c", 3, 3, 1.0, 0.9, 1.1, 0.0, 0.0,
         [4], block_dB, 0.0, 0.2, [1], zeros(Int, length(block_dB)), true, 0.0)
     # 0.12 is between grid points 0.10 and 0.15; continuous must return it unchanged.
     @test PowerFlows.snap_to_discrete(cont, 0.12) == 0.12
@@ -286,7 +312,7 @@ end
     @test PowerFlows.snap_to_discrete(cont, 0.30) == 0.2
     @test PowerFlows.snap_to_discrete(cont, -0.10) == 0.0
     # sanity: the discrete twin DOES snap 0.12 → 0.10.
-    disc = PowerFlows.ControlledSwitchedShunt("d", 3, 3, 1.0, 0.0, 0.0,
+    disc = PowerFlows.ControlledSwitchedShunt("d", 3, 3, 1.0, 0.9, 1.1, 0.0, 0.0,
         [4], block_dB, 0.0, 0.2, [1], zeros(Int, length(block_dB)), false, 0.0)
     @test PowerFlows.snap_to_discrete(disc, 0.12) == 0.10
 end


### PR DESCRIPTION
## Summary
- Stacked on `jd/discrete-control-homotopy`. Opening this as a separate PR for review rather than folding it into the parent branch, since it changes intentional, tested behavior from the original discrete-control algorithm design.
- **Observed discrepancy**: on a 3-bus repro (switched shunt starting off, `initial_status=[0]`), PSS/E converges to 2 engaged steps (50 Mvar) and bus voltage `0.96077`. `PowerFlows.jl` with `control_discrete_devices=true` converges to 3 steps and `1.0110` — a ~0.05 pu gap.
- **Root cause**: PSS/E's MODSW=1/2 switched-shunt control switches the *minimum number of steps* needed to bring the controlled bus back inside `[VSWLO, VSWHI]`. It does not drive to the band's midpoint. The current implementation sets `vset = (VSWLO+VSWHI)/2` once at construction and treats the shunt as a point-voltage regulator, which can engage more steps than PSS/E would.
- **Change**: `_apply_shunt_deadband!` (new, `control_continuation.jl`), called once per solve right after the base case converges: a shunt already inside `[VSWLO, VSWHI]` is frozen (reusing the existing `frozen` mechanism — PSS/E would not touch it); one outside the band gets its point target set to the nearest violated edge, so the existing sigmoid/relaxation continuation only pushes it back to the edge, not the center. `ControlledSwitchedShunt` gains two new fields (`vset_lo`, `vset_hi`) to carry the band through to solve time.
- Also skips the 2-solve plant-sign probe for shunts already frozen this way (cheap, and consistent with how unreliable-probe freezing already skips stepping).
- The pre-existing "unreliable probe" freeze warning now excludes deadband-held shunts (that's expected/routine, not a fault) so it isn't misleadingly triggered on ordinary in-band shunts.

## Test plan
- [x] New `discrete control: shunt deadband` unit test (band-below/in-band/band-above cases) — 6/6 pass.
- [x] Full existing `test_discrete_control.jl` suite (all shunt/tap/FACTS/PAR testsets, `ramp completes, tight regulation`, `tap+shunt converges (NR)`, etc.) — all green, no regressions (`Main.PowerFlowsTests | 182`, no fail/error column).
- [x] Have not re-validated against the original 3-bus PSS/E repro end-to-end in this session (parser-only + unit-level verification so far) — recommend doing so before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)