### PR TITLE
Port onto the infrastore line; identify the exported system by its UUID

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,19 +26,19 @@ Pardiso = "46dd5b70-b6fb-5a00-ae2d-e8fea33afaf2"
 [extensions]
 PowerFlowsPardisoExt = "Pardiso"
 
-# Pin the unreleased Sienna stack to the psy6/IS4 development branches so the package
+# Pin the unreleased Sienna stack to the feat/infrastore-integration development branches so the package
 # environment resolves against them instead of the registry/main versions. Mirrors the
 # pins in test/Project.toml; remove before registering a release.
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"}
-PowerSystems = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
-# Registry PNM v0.24 requires PSY ^5.11, which conflicts with the psy6 branch (5.10.0);
-# the psy6 branch carries the transformer-circuit API against the psy6/IS4 sources.
-PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git", rev = "psy6"}
+InfrastructureSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"}
+PowerSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
+# Pinned to the branch rather than the registry: registry PNM v0.24 requires PowerSystems
+# 5.11, which this line (5.10.0) does not satisfy.
+PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git", rev = "feat/infrastore-integration"}
 # PSY's own [sources] pins for these are ignored once PSY is a dependency rather than the
 # root project; PF needs its own pins so Pkg can resolve PSY's unregistered OpenAPI deps.
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerOperationsOpenAPIModels.jl"}
 
 [compat]
 DataFrames = "1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -16,13 +16,15 @@ PrettyTables = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
 
 # Mirrors the pins in the root and `test/` environments. Only the ACTIVE project's
 # `[sources]` are honored, so the docs env must repeat them — without these it resolves the
-# registry PowerSystems against the IS4 InfrastructureSystems and fails to precompile.
+# registry PowerSystems against the infrastore InfrastructureSystems and fails to precompile.
 # Remove before registering a release.
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"}
-PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git", rev = "psy6"}
-PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl.git", rev = "psy6"}
-PowerSystems = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
+InfrastructureSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"}
+# Pinned to the branch rather than the registry: registry PNM v0.24 requires PowerSystems
+# 5.11, which this line (5.10.0) does not satisfy.
+PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git", rev = "feat/infrastore-integration"}
+PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl.git", rev = "feat/infrastore-integration"}
+PowerSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
 
 [compat]
 Documenter = "^1.0"

--- a/src/psse_export.jl
+++ b/src/psse_export.jl
@@ -210,6 +210,10 @@ PowerSystems.jl to perform a round trip with the names restored.
 """
 mutable struct PSSEExporter <: SystemPowerFlowContainer
     system::PSY.System
+    # Identity of the system passed at construction. `system` is a `fast_deepcopy_system`,
+    # which mints a fresh metadata UUID, so its own UUID cannot serve as the identity to
+    # validate later `update_exporter!` calls against.
+    base_system_uuid::Base.UUID
     psse_version::Symbol
     export_dir::String
     name::String
@@ -241,6 +245,7 @@ mutable struct PSSEExporter <: SystemPowerFlowContainer
         mkpath(export_dir)
         new(
             system,
+            PSY.get_system_uuid(base_system),
             psse_version,
             String(export_dir),
             String(name),
@@ -282,8 +287,8 @@ function update_version_group(psse_version::Symbol)
     return groups
 end
 
-function _validate_same_system(sys1::PSY.System, sys2::PSY.System)
-    return IS.get_uuid(PSY.get_internal(sys1)) == IS.get_uuid(PSY.get_internal(sys2))
+function _validate_same_system(exporter::PSSEExporter, sys::PSY.System)
+    return exporter.base_system_uuid == PSY.get_system_uuid(sys)
 end
 
 """
@@ -323,7 +328,7 @@ Update the `PSSEExporter` with new `data`.
     exhaustively verify it.
 """
 function update_exporter!(exporter::PSSEExporter, data::PSY.System)
-    _validate_same_system(exporter.system, data) || throw(
+    _validate_same_system(exporter, data) || throw(
         ArgumentError(
             "System passed to update_exporter must be the same system as the one with which the exporter was constructed, just with different values",
         ),

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -30,21 +30,21 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimeSeries = "9e3dc215-6440-5c97-bce1-76c03772f85e"
 
 [sources]
-InfrastructureSystems = {rev = "IS4", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"}
-# PSCB/parser psy6 branches carry the PSS/E import-contract fixes the round-trip tests need
-PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl.git", rev = "psy6"}
-PowerSystems = {rev = "psy6", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
-PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl.git", rev = "psy6"}
-# Registry PNM v0.24 requires PSY ^5.11, which conflicts with the psy6 branch (5.10.0);
-# the psy6 branch carries the transformer-circuit API against the psy6/IS4 sources.
-PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git", rev = "psy6"}
+InfrastructureSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/InfrastructureSystems.jl.git"}
+# PSCB/parser branches carry the PSS/E import-contract fixes the round-trip tests need
+PowerSystemCaseBuilder = {url = "https://github.com/Sienna-Platform/PowerSystemCaseBuilder.jl.git", rev = "feat/infrastore-integration"}
+PowerSystems = {rev = "feat/infrastore-integration", url = "https://github.com/Sienna-Platform/PowerSystems.jl.git"}
+PowerFlowFileParser = {url = "https://github.com/Sienna-Platform/PowerFlowFileParser.jl.git", rev = "feat/infrastore-integration"}
+# Pinned to the branch rather than the registry: registry PNM v0.24 requires PowerSystems
+# 5.11, which this line (5.10.0) does not satisfy.
+PowerNetworkMatrices = {url = "https://github.com/Sienna-Platform/PowerNetworkMatrices.jl.git", rev = "feat/infrastore-integration"}
 # PSY's own [sources] pins for these are ignored once PSY is a dependency rather than the
 # root project; the test env needs its own pins so Pkg can resolve PSY's unregistered OpenAPI deps.
-PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerCoreOpenAPIModels.jl"}
-PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerOperationsOpenAPIModels.jl"}
+PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerCoreOpenAPIModels.jl"}
+PowerOperationsOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "feat/infrastore-integration", subdir = "PowerOperationsOpenAPIModels.jl"}
 # PSCB's own [sources] pin for this is ignored once PSCB is a dependency rather than the root
 # project; the test env needs its own pin so Pkg can resolve PSCB's unregistered parser dep.
-PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl.git", rev = "psy6"}
+PowerTableDataParser = {url = "https://github.com/NLR-Sienna/PowerTableDataParser.jl.git", rev = "feat/infrastore-integration"}
 
 [compat]
 julia = "^1.10"


### PR DESCRIPTION
`IS.get_uuid` no longer exists. The one use was `_validate_same_system`, comparing the two Systems' internals — and neither obvious replacement works, each failing silently in the opposite direction. `IS.get_id` on a System's internal always returns 0, because Systems are never attached to a SystemData and the id defaults to UNASSIGNED_ID, so the guard would accept any two unrelated systems. `PSY.get_system_uuid(exporter.system)` always differs, because `fast_deepcopy_system` forwards name and description but not the uuid, so the exporter's copy carries a fresh one — the old code worked precisely because the internal uuid survives a deepcopy.

So `PSSEExporter` captures the base system's UUID at construction and compares against that. It is never reassigned: validation already guarantees equality, so a fixed value cannot go stale.

Pins move to the infrastore-line branches across all three environments. PowerNetworkMatrices stays pinned to its branch rather than the registry because registry v0.24 requires PowerSystems 5.11, which this line does not satisfy.