### PR TITLE
Make update_state!/update_data! respect ZIP withdrawals

### DIFF
--- a/src/state_indexing_helpers.jl
+++ b/src/state_indexing_helpers.jl
@@ -44,7 +44,13 @@ function area_tail_offset(data::ACPowerFlowData, dcn::DCNetwork)
     return 2 * n_buses + 4 * size(data.lcc.p_set, 1) + vsc_tail_length(dcn)
 end
 
-"""Update state vector based on values of fields of data."""
+"""Update state vector based on values of fields of data.
+
+The REF/PV power slots hold the *net* injection `P_gen - P_load_total`, where
+`P_load_total` includes the constant-current and constant-impedance ZIP terms evaluated at
+the bus's current voltage magnitude (see [`get_bus_active_power_total_withdrawals`](@ref)) —
+matching how `ACPowerFlowResidual` forms `P_net`/`Q_net`. Inverse of [`update_data!`](@ref).
+"""
 function update_state!(x::Vector{Float64},
     data::ACPowerFlowData,
     time_step::Int64,
@@ -59,15 +65,15 @@ function update_state!(x::Vector{Float64},
         if b == PSY.ACBusTypes.REF
             x[state_variable_count] =
                 data.bus_active_power_injections[ix, time_step] -
-                data.bus_active_power_withdrawals[ix, time_step]
+                get_bus_active_power_total_withdrawals(data, ix, time_step)
             x[state_variable_count + 1] =
                 data.bus_reactive_power_injections[ix, time_step] -
-                data.bus_reactive_power_withdrawals[ix, time_step]
+                get_bus_reactive_power_total_withdrawals(data, ix, time_step)
             state_variable_count += 2
         elseif b == PSY.ACBusTypes.PV
             x[state_variable_count] =
                 data.bus_reactive_power_injections[ix, time_step] -
-                data.bus_reactive_power_withdrawals[ix, time_step]
+                get_bus_reactive_power_total_withdrawals(data, ix, time_step)
             x[state_variable_count + 1] = data.bus_angles[ix, time_step]
             state_variable_count += 2
         elseif b == PSY.ACBusTypes.PQ
@@ -107,7 +113,14 @@ function update_state!(x::Vector{Float64},
     @assert state_variable_count - 1 == length(x)
 end
 
-"""Update the fields of data based on the values of the state vector."""
+"""Update the fields of data based on the values of the state vector.
+
+At REF/PV buses the bus injections are recovered by adding back the total withdrawals,
+including the constant-current and constant-impedance ZIP terms at the bus's voltage
+magnitude. PQ magnitudes are written before they are read for any ZIP term, because a bus's
+ZIP withdrawal depends only on its own magnitude and REF/PV magnitudes are fixed setpoints.
+Inverse of [`update_state!`](@ref).
+"""
 function update_data!(data::ACPowerFlowData,
     x::Vector{Float64},
     time_step::Int64,
@@ -138,9 +151,11 @@ function _set_state_variables_at_bus(
     ::Val{PSY.ACBusTypes.REF})
     # When bustype == REFERENCE PSY.Bus, state variables are Active and Reactive Power Generated
     data.bus_active_power_injections[ix, time_step] =
-        StateVector[2 * ix - 1] + data.bus_active_power_withdrawals[ix, time_step]
+        StateVector[2 * ix - 1] +
+        get_bus_active_power_total_withdrawals(data, ix, time_step)
     data.bus_reactive_power_injections[ix, time_step] =
-        StateVector[2 * ix] + data.bus_reactive_power_withdrawals[ix, time_step]
+        StateVector[2 * ix] +
+        get_bus_reactive_power_total_withdrawals(data, ix, time_step)
 end
 
 function _set_state_variables_at_bus(
@@ -151,7 +166,8 @@ function _set_state_variables_at_bus(
     ::Val{PSY.ACBusTypes.PV})
     # When bustype == PV PSY.Bus, state variables are Reactive Power Generated and Voltage Angle
     data.bus_reactive_power_injections[ix, time_step] =
-        StateVector[2 * ix - 1] + data.bus_reactive_power_withdrawals[ix, time_step]
+        StateVector[2 * ix - 1] +
+        get_bus_reactive_power_total_withdrawals(data, ix, time_step)
     data.bus_angles[ix, time_step] = StateVector[2 * ix]
 end
 

--- a/test/test_state_indexing_helpers.jl
+++ b/test/test_state_indexing_helpers.jl
@@ -37,3 +37,160 @@
     @test isequal(tp[:Vm], Vms_1)
     @test isequal(tp[:Va], Vas_1)
 end
+
+"""Three-bus system (REF / PV / PQ) carrying a ZIP load at every bus, with
+off-nominal REF and PV voltage setpoints so the constant-current (`∝ |V|`) and
+constant-impedance (`∝ |V|²`) terms are distinguishable from the constant-power
+term. Used to pin `update_state!` / `update_data!` against issue #431."""
+function _zip_state_indexing_system()
+    sys = System(100.0)
+    b1 = _add_simple_bus!(sys, 1, ACBusTypes.REF, 230.0, 1.02, 0.0)
+    b2 = _add_simple_bus!(sys, 2, ACBusTypes.PV, 230.0, 1.03, 0.0)
+    b3 = _add_simple_bus!(sys, 3, ACBusTypes.PQ, 230.0, 1.0, 0.0)
+    _add_simple_line!(sys, b1, b2, 0.01, 0.08, 0.0)
+    _add_simple_line!(sys, b2, b3, 0.01, 0.08, 0.0)
+    _add_simple_source!(sys, b1, 0.0, 0.0)
+    _add_simple_thermal_standard!(sys, b2, 0.5, 0.0)
+    # ZIP loads on the REF and PV buses too: those are the buses whose power slots
+    # `update_state!`/`update_data!` build from the withdrawal fields.
+    for b in (b1, b2, b3)
+        _add_simple_zip_load!(
+            sys,
+            b;
+            constant_power_active_power = 1.0,
+            constant_power_reactive_power = 0.5,
+            constant_current_active_power = 2.0,
+            constant_current_reactive_power = 1.0,
+            constant_impedance_active_power = 3.0,
+            constant_impedance_reactive_power = 1.5,
+        )
+    end
+    return sys
+end
+
+"""Independent restatement of the ZIP withdrawal at bus `ix`: constant power,
+plus constant current scaled by `|V|`, plus constant impedance scaled by `|V|²`."""
+function _expected_total_withdrawals(data, ix, time_step)
+    vm = data.bus_magnitude[ix, time_step]
+    p =
+        data.bus_active_power_withdrawals[ix, time_step] +
+        data.bus_active_power_constant_current_withdrawals[ix, time_step] * vm +
+        data.bus_active_power_constant_impedance_withdrawals[ix, time_step] * vm^2
+    q =
+        data.bus_reactive_power_withdrawals[ix, time_step] +
+        data.bus_reactive_power_constant_current_withdrawals[ix, time_step] * vm +
+        data.bus_reactive_power_constant_impedance_withdrawals[ix, time_step] * vm^2
+    return (p, q)
+end
+
+@testset "update_state! includes ZIP withdrawals" begin
+    sys = _zip_state_indexing_system()
+    data = PowerFlowData(ACPowerFlow(), sys)
+    time_step = 1
+    n_buses = size(data.bus_type, 1)
+    bus_types = data.bus_type[:, time_step]
+
+    # Guard the fixture: without nonzero const-I/const-Z at REF and PV, and
+    # off-nominal setpoints there, this testset cannot detect the bug.
+    for ix in 1:n_buses
+        @test data.bus_active_power_constant_current_withdrawals[ix, time_step] != 0.0
+        @test data.bus_active_power_constant_impedance_withdrawals[ix, time_step] != 0.0
+        @test data.bus_reactive_power_constant_current_withdrawals[ix, time_step] != 0.0
+        @test data.bus_reactive_power_constant_impedance_withdrawals[ix, time_step] != 0.0
+    end
+    for ix in 1:n_buses
+        if bus_types[ix] != PSY.ACBusTypes.PQ
+            @test data.bus_magnitude[ix, time_step] != 1.0
+        end
+    end
+
+    x = PF.calculate_x0(data, time_step)
+    for ix in 1:n_buses
+        (p_w, q_w) = _expected_total_withdrawals(data, ix, time_step)
+        if bus_types[ix] == PSY.ACBusTypes.REF
+            @test x[2 * ix - 1] ≈
+                  data.bus_active_power_injections[ix, time_step] - p_w
+            @test x[2 * ix] ≈
+                  data.bus_reactive_power_injections[ix, time_step] - q_w
+        elseif bus_types[ix] == PSY.ACBusTypes.PV
+            @test x[2 * ix - 1] ≈
+                  data.bus_reactive_power_injections[ix, time_step] - q_w
+            @test x[2 * ix] == data.bus_angles[ix, time_step]
+        else
+            @test x[2 * ix - 1] == data.bus_magnitude[ix, time_step]
+            @test x[2 * ix] == data.bus_angles[ix, time_step]
+        end
+    end
+end
+
+@testset "update_data! includes ZIP withdrawals" begin
+    sys = _zip_state_indexing_system()
+    data = PowerFlowData(ACPowerFlow(), sys)
+    time_step = 1
+    n_buses = size(data.bus_type, 1)
+    bus_types = data.bus_type[:, time_step]
+
+    # Write chosen NET injections into the power slots, then check `update_data!`
+    # recovers gross injections by adding back the full ZIP withdrawal.
+    x = PF.calculate_x0(data, time_step)
+    net_p = Dict{Int, Float64}()
+    net_q = Dict{Int, Float64}()
+    for ix in 1:n_buses
+        if bus_types[ix] == PSY.ACBusTypes.REF
+            net_p[ix] = 0.25 * ix
+            net_q[ix] = -0.15 * ix
+            x[2 * ix - 1] = net_p[ix]
+            x[2 * ix] = net_q[ix]
+        elseif bus_types[ix] == PSY.ACBusTypes.PV
+            net_q[ix] = -0.15 * ix
+            x[2 * ix - 1] = net_q[ix]
+        end
+    end
+
+    PF.update_data!(data, x, time_step)
+
+    for ix in 1:n_buses
+        (p_w, q_w) = _expected_total_withdrawals(data, ix, time_step)
+        if bus_types[ix] == PSY.ACBusTypes.REF
+            @test data.bus_active_power_injections[ix, time_step] ≈ net_p[ix] + p_w
+            @test data.bus_reactive_power_injections[ix, time_step] ≈ net_q[ix] + q_w
+        elseif bus_types[ix] == PSY.ACBusTypes.PV
+            @test data.bus_reactive_power_injections[ix, time_step] ≈ net_q[ix] + q_w
+        end
+    end
+end
+
+@testset "update_state!/update_data! round trip with ZIP loads" begin
+    sys = _zip_state_indexing_system()
+    data = PowerFlowData(ACPowerFlow(), sys)
+    time_step = 1
+    solve_power_flow!(data)
+
+    x = PF.calculate_x0(data, time_step)
+    p_inj = copy(data.bus_active_power_injections)
+    q_inj = copy(data.bus_reactive_power_injections)
+    vm = copy(data.bus_magnitude)
+    va = copy(data.bus_angles)
+
+    PF.update_data!(data, x, time_step)
+
+    @test data.bus_active_power_injections ≈ p_inj
+    @test data.bus_reactive_power_injections ≈ q_inj
+    @test data.bus_magnitude ≈ vm
+    @test data.bus_angles ≈ va
+end
+
+@testset "update_state! at the solution is a residual zero with ZIP loads" begin
+    sys = _zip_state_indexing_system()
+    data = PowerFlowData(ACPowerFlow(), sys)
+    time_step = 1
+    solve_power_flow!(data)
+
+    # The converged `data` must map back to a state vector at which the residual
+    # vanishes. Dropping the const-I/const-Z terms from the REF/PV power slots
+    # leaves an error of exactly those withdrawals, so this fails on unfixed code.
+    x = PF.calculate_x0(data, time_step)
+    residual = PF.ACPowerFlowResidual(data, time_step)
+    residual(x, time_step)
+    @test norm(residual.Rv, Inf) < 1e-8
+end


### PR DESCRIPTION
Closes #431 for the polar formulation.

## Problem

`update_state!` and `update_data!` built the REF/PV power slots from the bare constant-power field `bus_*_power_withdrawals`, ignoring the constant-current (`∝ |V|`) and constant-impedance (`∝ |V|²`) ZIP terms. Anything reconstructing a residual from `data` in a system with ZIP loads or `SwitchedAdmittance` components got the wrong net injection at REF and PV buses.

This is not confined to diagnostics: `calculate_x0` calls `update_state!`, so it perturbs the starting point of every polar solve on a ZIP system, and `_previous_solution_start` inherits it for the time-step warm start.

## Fix

Route both through `get_bus_active_power_total_withdrawals` / `get_bus_reactive_power_total_withdrawals`, matching how `ACPowerFlowResidual` already forms `P_net`/`Q_net`. Docstrings now state the net-injection convention and that the two functions are inverses.

No ordering hazard in `update_data!`: a bus's ZIP withdrawal depends only on its own magnitude, and REF/PV magnitudes are fixed setpoints, so PQ magnitude writes never race a ZIP read.

## Tests

A 3-bus REF/PV/PQ fixture carrying a full ZIP load at every bus, with off-nominal REF/PV setpoints (1.02, 1.03) so the `|V|` and `|V|²` terms are separable from constant power. Four testsets, including guards that assert the fixture actually has nonzero const-I/const-Z and off-nominal setpoints — without those the tests could not detect the bug.

Verified they discriminate, by stashing the source fix and re-running:

| testset | against unfixed code |
|---|---|
| `update_state!` includes ZIP withdrawals | **3 fail** — REF P `-0.1` vs `-0.616`, REF Q `-0.05` vs `-0.308`, PV Q `-0.05` vs `-0.312` |
| `update_data!` includes ZIP withdrawals | **3 fail** — `0.35` vs `0.866`, etc. |
| `update_state!` at the solution is a residual zero | **1 fail** — `‖Rv‖∞ = 0.516`, exactly the dropped withdrawal |
| round trip | passes either way |

The round-trip testset is deliberately non-discriminating — the bug is symmetric, so it cannot catch it. Kept as an inverse invariant guarding against a future one-sided edit; the other three are what pin the issue.

Full suite green: 46033 passing, 0 failures.

## Scope

Polar only. The rectangular and mixed formulations have a related constant-current gap, plus a separate results-layer bug in `rect_finalize_bus_injections!` that I found while scoping this — both written up in a comment on #431 rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)